### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -259,11 +259,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1705535370,
-        "narHash": "sha256-CdPz9neQM83dDi9mXLILYJeiwqoqOrB4KmXSMvBg6QM=",
+        "lastModified": 1705705285,
+        "narHash": "sha256-uM7p/Vpb0FwqqKok5AmIQEXYPCz9SR5dl76vRQqp+i8=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "ec8f7eed103c6d5b75eac69196bb87db0825629a",
+        "rev": "854a8df0d06b8d3fcb30fa7f2b08c62b553eee3b",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1705063762,
-        "narHash": "sha256-y8aoZa5UJGP0rgvYPL6NMD3IjbZnnGweZcTBIR5bAxU=",
+        "lastModified": 1705767798,
+        "narHash": "sha256-dFI2F7/eDCUTk+mAzBJa3rvOQDyYCvSgWePJ5gaOl78=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "4aaacbf5e5e2218fd05eb75703fe9e0f85335803",
+        "rev": "c5ff7628e19a47ec14d3657294cc074ecae27b99",
         "type": "github"
       },
       "original": {
@@ -349,11 +349,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705660020,
-        "narHash": "sha256-1tOuNh+UbiZlaC8RrpQzzypgnLBC67eRlBunfkE4sbQ=",
+        "lastModified": 1705823474,
+        "narHash": "sha256-2C4uRe9/U3QwSPC4dYKM1/njgCQk0Mltezy4VcjAqa4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2064348e555b6aa963da6372a8f14e6acb80a176",
+        "rev": "928f2528f9ee952ba0a47bbb1ece8d93ed66e784",
         "type": "github"
       },
       "original": {
@@ -432,11 +432,11 @@
     "lspconfig-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1705645524,
-        "narHash": "sha256-tPmMVp10f21oRfi9k7VN1OfqfSm3sfndnimPgjhN4z0=",
+        "lastModified": 1705757419,
+        "narHash": "sha256-StYsN9C2rV471JkncUR1PFeXs0S15ZGTF1DigSbwOHI=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "042aa6b27b8b8d4f4e1bd42de2037c83d676a8a0",
+        "rev": "8917d2c830e04bf944a699b8c41f097621283828",
         "type": "github"
       },
       "original": {
@@ -573,11 +573,11 @@
     "neodev-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1705557947,
-        "narHash": "sha256-4ct1xrR4M+MoCGk3aVHYJo1g5lfqLgbbemeyaj5qD6A=",
+        "lastModified": 1705730714,
+        "narHash": "sha256-QzSKq2euwmpNxvo2CxPVZynRxC2CB36Xq2EImHQwrjo=",
         "owner": "folke",
         "repo": "neodev.nvim",
-        "rev": "482abc6688a028ce183719b0350d0235ae2c2e83",
+        "rev": "aaeb44589cab39c2545a328661af355622d68479",
         "type": "github"
       },
       "original": {
@@ -596,11 +596,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1705595580,
-        "narHash": "sha256-nk57t1MPmwhQbPh1HPDv5P9+hmg/phVdNIFlR+yt5IE=",
+        "lastModified": 1705697470,
+        "narHash": "sha256-Htn7xl9hjkDB+A8x0Y6/okwEUgCwKaKJFk4QNcXHN5k=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "78b000c74d631fb097bc2ada0c929153f96d9769",
+        "rev": "d3a8e9217f39c59dd7762bd22a76b8bd03ca85ff",
         "type": "github"
       },
       "original": {
@@ -621,11 +621,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705622661,
-        "narHash": "sha256-x1ojDA4uEVUXhWcDgWdz9gG4CTX9+VNMW0c3mHUdpPM=",
+        "lastModified": 1705709061,
+        "narHash": "sha256-Ai6ZAztEf310lxq93JWDzBKQfBlBZnGoHqAJYMV8W+M=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "e53738305c3ee233abd025cc4947a282eeb2e8c0",
+        "rev": "664ff2a12e3f733dc1db467bd8b905438440f924",
         "type": "github"
       },
       "original": {
@@ -960,11 +960,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1705574702,
-        "narHash": "sha256-n1UQiHvVPEt6qrYL2Iv1OeNqoQm4ogRKkzDWZNQKmV4=",
+        "lastModified": 1705801821,
+        "narHash": "sha256-iHJjDQx8jaz2EeXWIIwjw77z/xWbShyDh925MQhpQXQ=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "9cf58f438f95f04cf1709b734bbcb9243c262d70",
+        "rev": "0902bb39ebaf76e655addc65130eb79b29abe6d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/ec8f7eed103c6d5b75eac69196bb87db0825629a' (2024-01-17)
  → 'github:tpope/vim-fugitive/854a8df0d06b8d3fcb30fa7f2b08c62b553eee3b' (2024-01-19)
• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/4aaacbf5e5e2218fd05eb75703fe9e0f85335803' (2024-01-12)
  → 'github:lewis6991/gitsigns.nvim/c5ff7628e19a47ec14d3657294cc074ecae27b99' (2024-01-20)
• Updated input 'home-manager':
    'github:nix-community/home-manager/2064348e555b6aa963da6372a8f14e6acb80a176' (2024-01-19)
  → 'github:nix-community/home-manager/928f2528f9ee952ba0a47bbb1ece8d93ed66e784' (2024-01-21)
• Updated input 'lspconfig-nvim':
    'github:neovim/nvim-lspconfig/042aa6b27b8b8d4f4e1bd42de2037c83d676a8a0' (2024-01-19)
  → 'github:neovim/nvim-lspconfig/8917d2c830e04bf944a699b8c41f097621283828' (2024-01-20)
• Updated input 'neodev-nvim':
    'github:folke/neodev.nvim/482abc6688a028ce183719b0350d0235ae2c2e83' (2024-01-18)
  → 'github:folke/neodev.nvim/aaeb44589cab39c2545a328661af355622d68479' (2024-01-20)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/e53738305c3ee233abd025cc4947a282eeb2e8c0' (2024-01-19)
  → 'github:nix-community/neovim-nightly-overlay/664ff2a12e3f733dc1db467bd8b905438440f924' (2024-01-20)
• Updated input 'neovim-nightly-overlay/neovim-flake':
    'github:neovim/neovim/78b000c74d631fb097bc2ada0c929153f96d9769?dir=contrib' (2024-01-18)
  → 'github:neovim/neovim/d3a8e9217f39c59dd7762bd22a76b8bd03ca85ff?dir=contrib' (2024-01-19)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/9cf58f438f95f04cf1709b734bbcb9243c262d70' (2024-01-18)
  → 'github:nvim-telescope/telescope.nvim/0902bb39ebaf76e655addc65130eb79b29abe6d2' (2024-01-21)

```

</p></details>

 - Updated input [`neodev-nvim`](https://github.com/folke/neodev.nvim): [`482abc66` ➡️ `aaeb4458`](https://github.com/folke/neodev.nvim/compare/482abc6688a028ce183719b0350d0235ae2c2e83...aaeb44589cab39c2545a328661af355622d68479) <sub>(2024-01-18 to 2024-01-20)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`ec8f7eed` ➡️ `854a8df0`](https://github.com/tpope/vim-fugitive/compare/ec8f7eed103c6d5b75eac69196bb87db0825629a...854a8df0d06b8d3fcb30fa7f2b08c62b553eee3b) <sub>(2024-01-17 to 2024-01-19)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`e5373830` ➡️ `664ff2a1`](https://github.com/nix-community/neovim-nightly-overlay/compare/e53738305c3ee233abd025cc4947a282eeb2e8c0...664ff2a12e3f733dc1db467bd8b905438440f924) <sub>(2024-01-19 to 2024-01-20)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`4aaacbf5` ➡️ `c5ff7628`](https://github.com/lewis6991/gitsigns.nvim/compare/4aaacbf5e5e2218fd05eb75703fe9e0f85335803...c5ff7628e19a47ec14d3657294cc074ecae27b99) <sub>(2024-01-12 to 2024-01-20)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`9cf58f43` ➡️ `0902bb39`](https://github.com/nvim-telescope/telescope.nvim/compare/9cf58f438f95f04cf1709b734bbcb9243c262d70...0902bb39ebaf76e655addc65130eb79b29abe6d2) <sub>(2024-01-18 to 2024-01-21)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-flake`](https://github.com/neovim/neovim): [`78b000c7` ➡️ `d3a8e921`](https://github.com/neovim/neovim/compare/78b000c74d631fb097bc2ada0c929153f96d9769...d3a8e9217f39c59dd7762bd22a76b8bd03ca85ff) <sub>(2024-01-18 to 2024-01-19)</sub>
 - Updated input [`lspconfig-nvim`](https://github.com/neovim/nvim-lspconfig): [`042aa6b2` ➡️ `8917d2c8`](https://github.com/neovim/nvim-lspconfig/compare/042aa6b27b8b8d4f4e1bd42de2037c83d676a8a0...8917d2c830e04bf944a699b8c41f097621283828) <sub>(2024-01-19 to 2024-01-20)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`2064348e` ➡️ `928f2528`](https://github.com/nix-community/home-manager/compare/2064348e555b6aa963da6372a8f14e6acb80a176...928f2528f9ee952ba0a47bbb1ece8d93ed66e784) <sub>(2024-01-19 to 2024-01-21)</sub>