### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -291,11 +291,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1705767798,
-        "narHash": "sha256-dFI2F7/eDCUTk+mAzBJa3rvOQDyYCvSgWePJ5gaOl78=",
+        "lastModified": 1706282483,
+        "narHash": "sha256-jVzZPD9RdM0Ie3nWuZgv+XVhwWzLJ2QODrIGRCENWjo=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "c5ff7628e19a47ec14d3657294cc074ecae27b99",
+        "rev": "fb9fd5312476b51a42a98122616e1c448d823d5c",
         "type": "github"
       },
       "original": {
@@ -333,11 +333,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705823474,
-        "narHash": "sha256-2C4uRe9/U3QwSPC4dYKM1/njgCQk0Mltezy4VcjAqa4=",
+        "lastModified": 1706221476,
+        "narHash": "sha256-T4b8YafVjHXvtDY8ARec1WrXO8uyyNZOpNgv9yoQy2M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "928f2528f9ee952ba0a47bbb1ece8d93ed66e784",
+        "rev": "c7ce343d9bf1a329056a4dd5b32ea8cc43b55e15",
         "type": "github"
       },
       "original": {
@@ -367,11 +367,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1705671586,
-        "narHash": "sha256-JOwVlSgwo2nqQRcArelrx/lK9OUoUxaXUQThQw1q8oA=",
+        "lastModified": 1706198673,
+        "narHash": "sha256-bHlxFd+3QHy6eXtTzzhwVNcyxBSOxTvBuJGNUzI4C4M=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "72a67d0f58d0ed44a20341fddb2bdfa33c2a2558",
+        "rev": "16884001b26e6955ff4b88b4dfe4c8986e20f153",
         "type": "github"
       },
       "original": {
@@ -469,11 +469,11 @@
     "lualine-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1703568994,
-        "narHash": "sha256-do28EEtiu14NAroVblx8FJLCk8CVNmpm8RaTbcDHtvk=",
+        "lastModified": 1706181415,
+        "narHash": "sha256-LMMcRY4qnGywdK6Bl4YeAEKLhnRuOZ2txn4oYoso2gI=",
         "owner": "nvim-lualine",
         "repo": "lualine.nvim",
-        "rev": "566b7036f717f3d676362742630518a47f132fff",
+        "rev": "7d131a8d3ba5016229e8a1d08bf8782acea98852",
         "type": "github"
       },
       "original": {
@@ -541,11 +541,11 @@
     "neodev-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1705730714,
-        "narHash": "sha256-QzSKq2euwmpNxvo2CxPVZynRxC2CB36Xq2EImHQwrjo=",
+        "lastModified": 1706249139,
+        "narHash": "sha256-BRsZdc1TO88pCoehDv7ervBjaeOpcmSGm/RZAInhI9Q=",
         "owner": "folke",
         "repo": "neodev.nvim",
-        "rev": "aaeb44589cab39c2545a328661af355622d68479",
+        "rev": "64b2a51b02c6f2ae177c745e4d8bc801a339fe09",
         "type": "github"
       },
       "original": {
@@ -564,11 +564,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1705697470,
-        "narHash": "sha256-Htn7xl9hjkDB+A8x0Y6/okwEUgCwKaKJFk4QNcXHN5k=",
+        "lastModified": 1706140641,
+        "narHash": "sha256-H1qHhkf7sF7yrG2rb9Ks1Y4EtLY3cXGp16KCGveJWY4=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "d3a8e9217f39c59dd7762bd22a76b8bd03ca85ff",
+        "rev": "4e59422e1d4950a3042bad41a7b81c8db4f8b648",
         "type": "github"
       },
       "original": {
@@ -589,11 +589,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705709061,
-        "narHash": "sha256-Ai6ZAztEf310lxq93JWDzBKQfBlBZnGoHqAJYMV8W+M=",
+        "lastModified": 1706141075,
+        "narHash": "sha256-o66/XFTXmcJSpEcO508V5r765HtgT8qtr+H4LRIB9BY=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "664ff2a12e3f733dc1db467bd8b905438440f924",
+        "rev": "1da2e054a16309d7d7f7669438c8b9a5ef1b4642",
         "type": "github"
       },
       "original": {
@@ -605,11 +605,11 @@
     "nightfox-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1704982694,
-        "narHash": "sha256-H9S0r2evXGMRDOmoFU98+sbEmXkozinMQyiRqFy0oLg=",
+        "lastModified": 1706281390,
+        "narHash": "sha256-Nkobz9wA2wgWFHqRu5RdEcA5YldjGO1/pR675bZyTUQ=",
         "owner": "EdenEast",
         "repo": "nightfox.nvim",
-        "rev": "a4bc2bd3d7ff1770ae104068458d3b0b8f8ec00d",
+        "rev": "57b8154aba0de8ced36722ea2674a7b97e4f468f",
         "type": "github"
       },
       "original": {
@@ -667,11 +667,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1705883077,
-        "narHash": "sha256-ByzHHX3KxpU1+V0erFy8jpujTufimh6KaS/Iv3AciHk=",
+        "lastModified": 1706173671,
+        "narHash": "sha256-lciR7kQUK2FCAYuszyd7zyRRmTaXVeoZsCyK6QFpGdk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5f5210aa20e343b7e35f40c033000db0ef80d7b9",
+        "rev": "4fddc9be4eaf195d631333908f2a454b03628ee5",
         "type": "github"
       },
       "original": {
@@ -785,11 +785,11 @@
     "plenary-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1701343040,
-        "narHash": "sha256-f8YVaXMG0ZyW6iotAgnftaYULnL69UPolRad6RTG27g=",
+        "lastModified": 1705841956,
+        "narHash": "sha256-awRAI1ov9OBt6VuNxk/qjPTSPBYsMJzURKVV+IA7kok=",
         "owner": "nvim-lua",
         "repo": "plenary.nvim",
-        "rev": "55d9fe89e33efd26f532ef20223e5f9430c8b0c0",
+        "rev": "663246936325062427597964d81d30eaa42ab1e4",
         "type": "github"
       },
       "original": {
@@ -960,11 +960,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1705801821,
-        "narHash": "sha256-iHJjDQx8jaz2EeXWIIwjw77z/xWbShyDh925MQhpQXQ=",
+        "lastModified": 1706154992,
+        "narHash": "sha256-uagWtwd/L07RRUpSu+kVv0qD+neySSmSrIeFBJ0gZiM=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "0902bb39ebaf76e655addc65130eb79b29abe6d2",
+        "rev": "1bfbb1fb5c56d2dbe33216fcb2ebe82e499aa06c",
         "type": "github"
       },
       "original": {
@@ -976,11 +976,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1705292513,
-        "narHash": "sha256-xuHIdvezGH04X+B+x4MjaUFOAZkR2Qc19ErZaeUJ7W0=",
+        "lastModified": 1706072160,
+        "narHash": "sha256-w038PU9i1onEBo3x4bo1kDz9Fo46Whd8ZJhyIqxz3I8=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "140edfcf25093e8b321d13e154cbce89ee868ca0",
+        "rev": "b427ac5f9dff494f839e81441fb3f04a58cbcfbc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/c5ff7628e19a47ec14d3657294cc074ecae27b99' (2024-01-20)
  → 'github:lewis6991/gitsigns.nvim/fb9fd5312476b51a42a98122616e1c448d823d5c' (2024-01-26)
• Updated input 'home-manager':
    'github:nix-community/home-manager/928f2528f9ee952ba0a47bbb1ece8d93ed66e784' (2024-01-21)
  → 'github:nix-community/home-manager/c7ce343d9bf1a329056a4dd5b32ea8cc43b55e15' (2024-01-25)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/72a67d0f58d0ed44a20341fddb2bdfa33c2a2558' (2024-01-19)
  → 'github:hyprwm/contrib/16884001b26e6955ff4b88b4dfe4c8986e20f153' (2024-01-25)
• Updated input 'lualine-nvim':
    'github:nvim-lualine/lualine.nvim/566b7036f717f3d676362742630518a47f132fff' (2023-12-26)
  → 'github:nvim-lualine/lualine.nvim/7d131a8d3ba5016229e8a1d08bf8782acea98852' (2024-01-25)
• Updated input 'neodev-nvim':
    'github:folke/neodev.nvim/aaeb44589cab39c2545a328661af355622d68479' (2024-01-20)
  → 'github:folke/neodev.nvim/64b2a51b02c6f2ae177c745e4d8bc801a339fe09' (2024-01-26)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/664ff2a12e3f733dc1db467bd8b905438440f924' (2024-01-20)
  → 'github:nix-community/neovim-nightly-overlay/1da2e054a16309d7d7f7669438c8b9a5ef1b4642' (2024-01-25)
• Updated input 'neovim-nightly-overlay/neovim-flake':
    'github:neovim/neovim/d3a8e9217f39c59dd7762bd22a76b8bd03ca85ff?dir=contrib' (2024-01-19)
  → 'github:neovim/neovim/4e59422e1d4950a3042bad41a7b81c8db4f8b648?dir=contrib' (2024-01-24)
• Updated input 'nightfox-nvim':
    'github:EdenEast/nightfox.nvim/a4bc2bd3d7ff1770ae104068458d3b0b8f8ec00d' (2024-01-11)
  → 'github:EdenEast/nightfox.nvim/57b8154aba0de8ced36722ea2674a7b97e4f468f' (2024-01-26)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5f5210aa20e343b7e35f40c033000db0ef80d7b9' (2024-01-22)
  → 'github:nixos/nixpkgs/4fddc9be4eaf195d631333908f2a454b03628ee5' (2024-01-25)
• Updated input 'plenary-nvim':
    'github:nvim-lua/plenary.nvim/55d9fe89e33efd26f532ef20223e5f9430c8b0c0' (2023-11-30)
  → 'github:nvim-lua/plenary.nvim/663246936325062427597964d81d30eaa42ab1e4' (2024-01-21)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/0902bb39ebaf76e655addc65130eb79b29abe6d2' (2024-01-21)
  → 'github:nvim-telescope/telescope.nvim/1bfbb1fb5c56d2dbe33216fcb2ebe82e499aa06c' (2024-01-25)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/140edfcf25093e8b321d13e154cbce89ee868ca0' (2024-01-15)
  → 'github:nvim-tree/nvim-web-devicons/b427ac5f9dff494f839e81441fb3f04a58cbcfbc' (2024-01-24)

```

</p></details>

 - Updated input [`neodev-nvim`](https://github.com/folke/neodev.nvim): [`aaeb4458` ➡️ `64b2a51b`](https://github.com/folke/neodev.nvim/compare/aaeb44589cab39c2545a328661af355622d68479...64b2a51b02c6f2ae177c745e4d8bc801a339fe09) <sub>(2024-01-20 to 2024-01-26)</sub>
 - Updated input [`nightfox-nvim`](https://github.com/EdenEast/nightfox.nvim): [`a4bc2bd3` ➡️ `57b8154a`](https://github.com/EdenEast/nightfox.nvim/compare/a4bc2bd3d7ff1770ae104068458d3b0b8f8ec00d...57b8154aba0de8ced36722ea2674a7b97e4f468f) <sub>(2024-01-11 to 2024-01-26)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`664ff2a1` ➡️ `1da2e054`](https://github.com/nix-community/neovim-nightly-overlay/compare/664ff2a12e3f733dc1db467bd8b905438440f924...1da2e054a16309d7d7f7669438c8b9a5ef1b4642) <sub>(2024-01-20 to 2024-01-25)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`72a67d0f` ➡️ `16884001`](https://github.com/hyprwm/contrib/compare/72a67d0f58d0ed44a20341fddb2bdfa33c2a2558...16884001b26e6955ff4b88b4dfe4c8986e20f153) <sub>(2024-01-19 to 2024-01-25)</sub>
 - Updated input [`plenary-nvim`](https://github.com/nvim-lua/plenary.nvim): [`55d9fe89` ➡️ `66324693`](https://github.com/nvim-lua/plenary.nvim/compare/55d9fe89e33efd26f532ef20223e5f9430c8b0c0...663246936325062427597964d81d30eaa42ab1e4) <sub>(2023-11-30 to 2024-01-21)</sub>
 - Updated input [`lualine-nvim`](https://github.com/nvim-lualine/lualine.nvim): [`566b7036` ➡️ `7d131a8d`](https://github.com/nvim-lualine/lualine.nvim/compare/566b7036f717f3d676362742630518a47f132fff...7d131a8d3ba5016229e8a1d08bf8782acea98852) <sub>(2023-12-26 to 2024-01-25)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`c5ff7628` ➡️ `fb9fd531`](https://github.com/lewis6991/gitsigns.nvim/compare/c5ff7628e19a47ec14d3657294cc074ecae27b99...fb9fd5312476b51a42a98122616e1c448d823d5c) <sub>(2024-01-20 to 2024-01-26)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`5f5210aa` ➡️ `4fddc9be`](https://github.com/nixos/nixpkgs/compare/5f5210aa20e343b7e35f40c033000db0ef80d7b9...4fddc9be4eaf195d631333908f2a454b03628ee5) <sub>(2024-01-22 to 2024-01-25)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`0902bb39` ➡️ `1bfbb1fb`](https://github.com/nvim-telescope/telescope.nvim/compare/0902bb39ebaf76e655addc65130eb79b29abe6d2...1bfbb1fb5c56d2dbe33216fcb2ebe82e499aa06c) <sub>(2024-01-21 to 2024-01-25)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-flake`](https://github.com/neovim/neovim): [`d3a8e921` ➡️ `4e59422e`](https://github.com/neovim/neovim/compare/d3a8e9217f39c59dd7762bd22a76b8bd03ca85ff...4e59422e1d4950a3042bad41a7b81c8db4f8b648) <sub>(2024-01-19 to 2024-01-24)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`140edfcf` ➡️ `b427ac5f`](https://github.com/nvim-tree/nvim-web-devicons/compare/140edfcf25093e8b321d13e154cbce89ee868ca0...b427ac5f9dff494f839e81441fb3f04a58cbcfbc) <sub>(2024-01-15 to 2024-01-24)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`928f2528` ➡️ `c7ce343d`](https://github.com/nix-community/home-manager/compare/928f2528f9ee952ba0a47bbb1ece8d93ed66e784...c7ce343d9bf1a329056a4dd5b32ea8cc43b55e15) <sub>(2024-01-21 to 2024-01-25)</sub>