### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -243,11 +243,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1705705285,
-        "narHash": "sha256-uM7p/Vpb0FwqqKok5AmIQEXYPCz9SR5dl76vRQqp+i8=",
+        "lastModified": 1706893048,
+        "narHash": "sha256-y7tlAk6253w6twBA8JUueq+5yBQDQxWEjpEz9osQJm8=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "854a8df0d06b8d3fcb30fa7f2b08c62b553eee3b",
+        "rev": "e7bf502a6ae492f42a91d231864e25630286319b",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1706282483,
-        "narHash": "sha256-jVzZPD9RdM0Ie3nWuZgv+XVhwWzLJ2QODrIGRCENWjo=",
+        "lastModified": 1706372432,
+        "narHash": "sha256-SLDaqzbvBTTuJEP9H2WOADuxsguMntR+upsGPW8aOEk=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "fb9fd5312476b51a42a98122616e1c448d823d5c",
+        "rev": "2c2463dbd82eddd7dbab881c3a62cfbfbe3c67ae",
         "type": "github"
       },
       "original": {
@@ -333,11 +333,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706221476,
-        "narHash": "sha256-T4b8YafVjHXvtDY8ARec1WrXO8uyyNZOpNgv9yoQy2M=",
+        "lastModified": 1706798041,
+        "narHash": "sha256-BbvuF4CsVRBGRP8P+R+JUilojk0M60D7hzqE0bEvJBQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c7ce343d9bf1a329056a4dd5b32ea8cc43b55e15",
+        "rev": "4d53427bce7bf3d17e699252fd84dc7468afc46e",
         "type": "github"
       },
       "original": {
@@ -557,11 +557,11 @@
     "neodev-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1706249139,
-        "narHash": "sha256-BRsZdc1TO88pCoehDv7ervBjaeOpcmSGm/RZAInhI9Q=",
+        "lastModified": 1706767532,
+        "narHash": "sha256-p0rMleK1A3chd35jzlpAqEEja6PD8YlastX8d2YPJ4I=",
         "owner": "folke",
         "repo": "neodev.nvim",
-        "rev": "64b2a51b02c6f2ae177c745e4d8bc801a339fe09",
+        "rev": "2793ba3127c2c93ee486b9072a3ef129eeb950cc",
         "type": "github"
       },
       "original": {
@@ -621,11 +621,11 @@
     "nightfox-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1706281390,
-        "narHash": "sha256-Nkobz9wA2wgWFHqRu5RdEcA5YldjGO1/pR675bZyTUQ=",
+        "lastModified": 1706673890,
+        "narHash": "sha256-QdIAP5IAfxrpOVfpzEucnmF2U9EoeXS4zF8SQCBnLUE=",
         "owner": "EdenEast",
         "repo": "nightfox.nvim",
-        "rev": "57b8154aba0de8ced36722ea2674a7b97e4f468f",
+        "rev": "a408e6bb101066952b81de9c11be367114bd561f",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1706173671,
-        "narHash": "sha256-lciR7kQUK2FCAYuszyd7zyRRmTaXVeoZsCyK6QFpGdk=",
+        "lastModified": 1706683685,
+        "narHash": "sha256-FtPPshEpxH/ewBOsdKBNhlsL2MLEFv1hEnQ19f/bFsQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4fddc9be4eaf195d631333908f2a454b03628ee5",
+        "rev": "5ad9903c16126a7d949101687af0aa589b1d7d3d",
         "type": "github"
       },
       "original": {
@@ -731,11 +731,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1702541213,
-        "narHash": "sha256-BtAYRYn6m788zAq/mNnbAzAxp1TGf9QkRE0hSOp9sdc=",
+        "lastModified": 1706857187,
+        "narHash": "sha256-FF7OHYUC4VFwFvqWKI/R5BSAC0JL6qFKUS6/XRSd9H8=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "538e37ba87284942c1d76ed38dd497e54e65b891",
+        "rev": "04e0ca376d6abdbfc8b52180f8ea236cbfddf782",
         "type": "github"
       },
       "original": {
@@ -747,11 +747,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1705757419,
-        "narHash": "sha256-StYsN9C2rV471JkncUR1PFeXs0S15ZGTF1DigSbwOHI=",
+        "lastModified": 1706873780,
+        "narHash": "sha256-nEEHd2S32kP6f2NU9JnIkX6hIwI/qNzX2GgPLMgp5k4=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "8917d2c830e04bf944a699b8c41f097621283828",
+        "rev": "9a6279953c82d01b58825a46ede032ab246a5983",
         "type": "github"
       },
       "original": {
@@ -801,11 +801,11 @@
     "plenary-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1705841956,
-        "narHash": "sha256-awRAI1ov9OBt6VuNxk/qjPTSPBYsMJzURKVV+IA7kok=",
+        "lastModified": 1706563407,
+        "narHash": "sha256-AWJHxehKUkEV6N+n78urqHjMVUsMfDK3lvHs/VxhKE8=",
         "owner": "nvim-lua",
         "repo": "plenary.nvim",
-        "rev": "663246936325062427597964d81d30eaa42ab1e4",
+        "rev": "4f71c0c4a196ceb656c824a70792f3df3ce6bb6d",
         "type": "github"
       },
       "original": {
@@ -977,11 +977,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1706154992,
-        "narHash": "sha256-uagWtwd/L07RRUpSu+kVv0qD+neySSmSrIeFBJ0gZiM=",
+        "lastModified": 1706759690,
+        "narHash": "sha256-kaSb1OmTItIbxlASP0omyleQyXjSdi/P+rwVHBXeynk=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "1bfbb1fb5c56d2dbe33216fcb2ebe82e499aa06c",
+        "rev": "7b5c5f56a21e82fdcfe5b250278b8dfc4b1cbab4",
         "type": "github"
       },
       "original": {
@@ -993,11 +993,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1706072160,
-        "narHash": "sha256-w038PU9i1onEBo3x4bo1kDz9Fo46Whd8ZJhyIqxz3I8=",
+        "lastModified": 1706564564,
+        "narHash": "sha256-bIAZWkgvD8G/GWDcI3CoufatmFm4x27WjE0MIAmL1JE=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "b427ac5f9dff494f839e81441fb3f04a58cbcfbc",
+        "rev": "aaec87dbdaa776bfa0a13c8694bec9bcb7454719",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/854a8df0d06b8d3fcb30fa7f2b08c62b553eee3b' (2024-01-19)
  → 'github:tpope/vim-fugitive/e7bf502a6ae492f42a91d231864e25630286319b' (2024-02-02)
• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/fb9fd5312476b51a42a98122616e1c448d823d5c' (2024-01-26)
  → 'github:lewis6991/gitsigns.nvim/2c2463dbd82eddd7dbab881c3a62cfbfbe3c67ae' (2024-01-27)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c7ce343d9bf1a329056a4dd5b32ea8cc43b55e15' (2024-01-25)
  → 'github:nix-community/home-manager/4d53427bce7bf3d17e699252fd84dc7468afc46e' (2024-02-01)
• Updated input 'neodev-nvim':
    'github:folke/neodev.nvim/64b2a51b02c6f2ae177c745e4d8bc801a339fe09' (2024-01-26)
  → 'github:folke/neodev.nvim/2793ba3127c2c93ee486b9072a3ef129eeb950cc' (2024-02-01)
• Updated input 'nightfox-nvim':
    'github:EdenEast/nightfox.nvim/57b8154aba0de8ced36722ea2674a7b97e4f468f' (2024-01-26)
  → 'github:EdenEast/nightfox.nvim/a408e6bb101066952b81de9c11be367114bd561f' (2024-01-31)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/4fddc9be4eaf195d631333908f2a454b03628ee5' (2024-01-25)
  → 'github:nixos/nixpkgs/5ad9903c16126a7d949101687af0aa589b1d7d3d' (2024-01-31)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/538e37ba87284942c1d76ed38dd497e54e65b891' (2023-12-14)
  → 'github:hrsh7th/nvim-cmp/04e0ca376d6abdbfc8b52180f8ea236cbfddf782' (2024-02-02)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/8917d2c830e04bf944a699b8c41f097621283828' (2024-01-20)
  → 'github:neovim/nvim-lspconfig/9a6279953c82d01b58825a46ede032ab246a5983' (2024-02-02)
• Updated input 'plenary-nvim':
    'github:nvim-lua/plenary.nvim/663246936325062427597964d81d30eaa42ab1e4' (2024-01-21)
  → 'github:nvim-lua/plenary.nvim/4f71c0c4a196ceb656c824a70792f3df3ce6bb6d' (2024-01-29)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/1bfbb1fb5c56d2dbe33216fcb2ebe82e499aa06c' (2024-01-25)
  → 'github:nvim-telescope/telescope.nvim/7b5c5f56a21e82fdcfe5b250278b8dfc4b1cbab4' (2024-02-01)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/b427ac5f9dff494f839e81441fb3f04a58cbcfbc' (2024-01-24)
  → 'github:nvim-tree/nvim-web-devicons/aaec87dbdaa776bfa0a13c8694bec9bcb7454719' (2024-01-29)

```

</p></details>

 - Updated input [`neodev-nvim`](https://github.com/folke/neodev.nvim): [`64b2a51b` ➡️ `2793ba31`](https://github.com/folke/neodev.nvim/compare/64b2a51b02c6f2ae177c745e4d8bc801a339fe09...2793ba3127c2c93ee486b9072a3ef129eeb950cc) <sub>(2024-01-26 to 2024-02-01)</sub>
 - Updated input [`nightfox-nvim`](https://github.com/EdenEast/nightfox.nvim): [`57b8154a` ➡️ `a408e6bb`](https://github.com/EdenEast/nightfox.nvim/compare/57b8154aba0de8ced36722ea2674a7b97e4f468f...a408e6bb101066952b81de9c11be367114bd561f) <sub>(2024-01-26 to 2024-01-31)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`854a8df0` ➡️ `e7bf502a`](https://github.com/tpope/vim-fugitive/compare/854a8df0d06b8d3fcb30fa7f2b08c62b553eee3b...e7bf502a6ae492f42a91d231864e25630286319b) <sub>(2024-01-19 to 2024-02-02)</sub>
 - Updated input [`plenary-nvim`](https://github.com/nvim-lua/plenary.nvim): [`66324693` ➡️ `4f71c0c4`](https://github.com/nvim-lua/plenary.nvim/compare/663246936325062427597964d81d30eaa42ab1e4...4f71c0c4a196ceb656c824a70792f3df3ce6bb6d) <sub>(2024-01-21 to 2024-01-29)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`8917d2c8` ➡️ `9a627995`](https://github.com/neovim/nvim-lspconfig/compare/8917d2c830e04bf944a699b8c41f097621283828...9a6279953c82d01b58825a46ede032ab246a5983) <sub>(2024-01-20 to 2024-02-02)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`538e37ba` ➡️ `04e0ca37`](https://github.com/hrsh7th/nvim-cmp/compare/538e37ba87284942c1d76ed38dd497e54e65b891...04e0ca376d6abdbfc8b52180f8ea236cbfddf782) <sub>(2023-12-14 to 2024-02-02)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`fb9fd531` ➡️ `2c2463db`](https://github.com/lewis6991/gitsigns.nvim/compare/fb9fd5312476b51a42a98122616e1c448d823d5c...2c2463dbd82eddd7dbab881c3a62cfbfbe3c67ae) <sub>(2024-01-26 to 2024-01-27)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`4fddc9be` ➡️ `5ad9903c`](https://github.com/nixos/nixpkgs/compare/4fddc9be4eaf195d631333908f2a454b03628ee5...5ad9903c16126a7d949101687af0aa589b1d7d3d) <sub>(2024-01-25 to 2024-01-31)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`1bfbb1fb` ➡️ `7b5c5f56`](https://github.com/nvim-telescope/telescope.nvim/compare/1bfbb1fb5c56d2dbe33216fcb2ebe82e499aa06c...7b5c5f56a21e82fdcfe5b250278b8dfc4b1cbab4) <sub>(2024-01-25 to 2024-02-01)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`b427ac5f` ➡️ `aaec87db`](https://github.com/nvim-tree/nvim-web-devicons/compare/b427ac5f9dff494f839e81441fb3f04a58cbcfbc...aaec87dbdaa776bfa0a13c8694bec9bcb7454719) <sub>(2024-01-24 to 2024-01-29)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`c7ce343d` ➡️ `4d53427b`](https://github.com/nix-community/home-manager/compare/c7ce343d9bf1a329056a4dd5b32ea8cc43b55e15...4d53427bce7bf3d17e699252fd84dc7468afc46e) <sub>(2024-01-25 to 2024-02-01)</sub>