### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -243,11 +243,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1706893048,
-        "narHash": "sha256-y7tlAk6253w6twBA8JUueq+5yBQDQxWEjpEz9osQJm8=",
+        "lastModified": 1707419286,
+        "narHash": "sha256-Y3Zd0zWKiTQfA1P+a31uPPayTSYm/W37APtHGRsejWc=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "e7bf502a6ae492f42a91d231864e25630286319b",
+        "rev": "fab00f7c0f3a08e860e39c7adeb8fbe849921a98",
         "type": "github"
       },
       "original": {
@@ -333,11 +333,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706798041,
-        "narHash": "sha256-BbvuF4CsVRBGRP8P+R+JUilojk0M60D7hzqE0bEvJBQ=",
+        "lastModified": 1707467182,
+        "narHash": "sha256-/Bw/xgCXfj4nXDd8Xq+r1kaorfsYkkomMf5w5MpsDyA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4d53427bce7bf3d17e699252fd84dc7468afc46e",
+        "rev": "5b9156fa9a8b8beba917b8f9adbfd27bf63e16af",
         "type": "github"
       },
       "original": {
@@ -557,11 +557,11 @@
     "neodev-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1706767532,
-        "narHash": "sha256-p0rMleK1A3chd35jzlpAqEEja6PD8YlastX8d2YPJ4I=",
+        "lastModified": 1707473123,
+        "narHash": "sha256-lrPy5viMR9FTEgCzyWQXzea9496JR8gziSh8beQVChA=",
         "owner": "folke",
         "repo": "neodev.nvim",
-        "rev": "2793ba3127c2c93ee486b9072a3ef129eeb950cc",
+        "rev": "b49b976cf2c28cd8283e9d74cb10885f6dd9e3d0",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1706683685,
-        "narHash": "sha256-FtPPshEpxH/ewBOsdKBNhlsL2MLEFv1hEnQ19f/bFsQ=",
+        "lastModified": 1707451808,
+        "narHash": "sha256-UwDBUNHNRsYKFJzyTMVMTF5qS4xeJlWoeyJf+6vvamU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5ad9903c16126a7d949101687af0aa589b1d7d3d",
+        "rev": "442d407992384ed9c0e6d352de75b69079904e4e",
         "type": "github"
       },
       "original": {
@@ -747,11 +747,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1706873780,
-        "narHash": "sha256-nEEHd2S32kP6f2NU9JnIkX6hIwI/qNzX2GgPLMgp5k4=",
+        "lastModified": 1707445495,
+        "narHash": "sha256-co0XAqy2NIT+eqAvbndGeev+3gqlpe5OPXJC5wxjYi4=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "9a6279953c82d01b58825a46ede032ab246a5983",
+        "rev": "f12f1b9e877b1e6e2ef7eae1a524d8253af4243d",
         "type": "github"
       },
       "original": {
@@ -977,11 +977,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1706759690,
-        "narHash": "sha256-kaSb1OmTItIbxlASP0omyleQyXjSdi/P+rwVHBXeynk=",
+        "lastModified": 1707446310,
+        "narHash": "sha256-t58sRzxwU7NUkZ2X8fVCaMWRbCqT0ywvm71eiFfMo3Q=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "7b5c5f56a21e82fdcfe5b250278b8dfc4b1cbab4",
+        "rev": "0f865f17af4f9bc1587a0132414cdfd32d91852e",
         "type": "github"
       },
       "original": {
@@ -993,11 +993,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1706564564,
-        "narHash": "sha256-bIAZWkgvD8G/GWDcI3CoufatmFm4x27WjE0MIAmL1JE=",
+        "lastModified": 1707089826,
+        "narHash": "sha256-xcfy2sqsk8VUBxU7TgWo1Jzw3UdysIBsNr9sn47WZx4=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "aaec87dbdaa776bfa0a13c8694bec9bcb7454719",
+        "rev": "313d9e7193354c5de7cdb1724f9e2d3f442780b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/e7bf502a6ae492f42a91d231864e25630286319b' (2024-02-02)
  → 'github:tpope/vim-fugitive/fab00f7c0f3a08e860e39c7adeb8fbe849921a98' (2024-02-08)
• Updated input 'home-manager':
    'github:nix-community/home-manager/4d53427bce7bf3d17e699252fd84dc7468afc46e' (2024-02-01)
  → 'github:nix-community/home-manager/5b9156fa9a8b8beba917b8f9adbfd27bf63e16af' (2024-02-09)
• Updated input 'neodev-nvim':
    'github:folke/neodev.nvim/2793ba3127c2c93ee486b9072a3ef129eeb950cc' (2024-02-01)
  → 'github:folke/neodev.nvim/b49b976cf2c28cd8283e9d74cb10885f6dd9e3d0' (2024-02-09)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5ad9903c16126a7d949101687af0aa589b1d7d3d' (2024-01-31)
  → 'github:nixos/nixpkgs/442d407992384ed9c0e6d352de75b69079904e4e' (2024-02-09)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/9a6279953c82d01b58825a46ede032ab246a5983' (2024-02-02)
  → 'github:neovim/nvim-lspconfig/f12f1b9e877b1e6e2ef7eae1a524d8253af4243d' (2024-02-09)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/7b5c5f56a21e82fdcfe5b250278b8dfc4b1cbab4' (2024-02-01)
  → 'github:nvim-telescope/telescope.nvim/0f865f17af4f9bc1587a0132414cdfd32d91852e' (2024-02-09)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/aaec87dbdaa776bfa0a13c8694bec9bcb7454719' (2024-01-29)
  → 'github:nvim-tree/nvim-web-devicons/313d9e7193354c5de7cdb1724f9e2d3f442780b0' (2024-02-04)

```

</p></details>

 - Updated input [`neodev-nvim`](https://github.com/folke/neodev.nvim): [`2793ba31` ➡️ `b49b976c`](https://github.com/folke/neodev.nvim/compare/2793ba3127c2c93ee486b9072a3ef129eeb950cc...b49b976cf2c28cd8283e9d74cb10885f6dd9e3d0) <sub>(2024-02-01 to 2024-02-09)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`e7bf502a` ➡️ `fab00f7c`](https://github.com/tpope/vim-fugitive/compare/e7bf502a6ae492f42a91d231864e25630286319b...fab00f7c0f3a08e860e39c7adeb8fbe849921a98) <sub>(2024-02-02 to 2024-02-08)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`9a627995` ➡️ `f12f1b9e`](https://github.com/neovim/nvim-lspconfig/compare/9a6279953c82d01b58825a46ede032ab246a5983...f12f1b9e877b1e6e2ef7eae1a524d8253af4243d) <sub>(2024-02-02 to 2024-02-09)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`5ad9903c` ➡️ `442d4079`](https://github.com/nixos/nixpkgs/compare/5ad9903c16126a7d949101687af0aa589b1d7d3d...442d407992384ed9c0e6d352de75b69079904e4e) <sub>(2024-01-31 to 2024-02-09)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`7b5c5f56` ➡️ `0f865f17`](https://github.com/nvim-telescope/telescope.nvim/compare/7b5c5f56a21e82fdcfe5b250278b8dfc4b1cbab4...0f865f17af4f9bc1587a0132414cdfd32d91852e) <sub>(2024-02-01 to 2024-02-09)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`aaec87db` ➡️ `313d9e71`](https://github.com/nvim-tree/nvim-web-devicons/compare/aaec87dbdaa776bfa0a13c8694bec9bcb7454719...313d9e7193354c5de7cdb1724f9e2d3f442780b0) <sub>(2024-01-29 to 2024-02-04)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`4d53427b` ➡️ `5b9156fa`](https://github.com/nix-community/home-manager/compare/4d53427bce7bf3d17e699252fd84dc7468afc46e...5b9156fa9a8b8beba917b8f9adbfd27bf63e16af) <sub>(2024-02-01 to 2024-02-09)</sub>