### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704982712,
-        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
         "type": "github"
       },
       "original": {
@@ -381,11 +381,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1707419286,
-        "narHash": "sha256-Y3Zd0zWKiTQfA1P+a31uPPayTSYm/W37APtHGRsejWc=",
+        "lastModified": 1707706623,
+        "narHash": "sha256-dI28XbFYUWuGQ89oGR51WK6M3kWhBwqqC0Bs99vxrjY=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "fab00f7c0f3a08e860e39c7adeb8fbe849921a98",
+        "rev": "011cf4fcb93a9649ffc6dcdff56ef948f5d0f7cc",
         "type": "github"
       },
       "original": {
@@ -516,11 +516,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707467182,
-        "narHash": "sha256-/Bw/xgCXfj4nXDd8Xq+r1kaorfsYkkomMf5w5MpsDyA=",
+        "lastModified": 1708031129,
+        "narHash": "sha256-EH20hJfNnc1/ODdDVat9B7aKm0B95L3YtkIRwKLvQG8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5b9156fa9a8b8beba917b8f9adbfd27bf63e16af",
+        "rev": "3d6791b3897b526c82920a2ab5f61d71985b3cf8",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1705505979,
-        "narHash": "sha256-TlzIaDERoWt5yOyuCVtqJq3lHEtDsEd0lHKnFcvVqo8=",
+        "lastModified": 1708014104,
+        "narHash": "sha256-J20Zrdw8EmiA0ATgmoSYbej6mkoXD/b5eOy+IvprMHQ=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "2dbef19461198630b3d7c39f414d09fb07d1fdd2",
+        "rev": "f3b3d3446bcbfa62d638b1903ff00a78b2b730a1",
         "type": "github"
       },
       "original": {
@@ -740,11 +740,11 @@
     "neodev-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1707473123,
-        "narHash": "sha256-lrPy5viMR9FTEgCzyWQXzea9496JR8gziSh8beQVChA=",
+        "lastModified": 1708063534,
+        "narHash": "sha256-jn86mwnDbYytscJwPrmUFfgtEKtpJ4XXn81mtvoPm6A=",
         "owner": "folke",
         "repo": "neodev.nvim",
-        "rev": "b49b976cf2c28cd8283e9d74cb10885f6dd9e3d0",
+        "rev": "de3685b8c1cd439dd96b7958793f6f381f98652d",
         "type": "github"
       },
       "original": {
@@ -756,11 +756,11 @@
     "neodev-nvim_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1706767532,
-        "narHash": "sha256-p0rMleK1A3chd35jzlpAqEEja6PD8YlastX8d2YPJ4I=",
+        "lastModified": 1707473123,
+        "narHash": "sha256-lrPy5viMR9FTEgCzyWQXzea9496JR8gziSh8beQVChA=",
         "owner": "folke",
         "repo": "neodev.nvim",
-        "rev": "2793ba3127c2c93ee486b9072a3ef129eeb950cc",
+        "rev": "b49b976cf2c28cd8283e9d74cb10885f6dd9e3d0",
         "type": "github"
       },
       "original": {
@@ -778,11 +778,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1706160224,
-        "narHash": "sha256-vsth9dGLkfXjDRjCoJAIJ/pNQQvcOznjnVsoUkvIJPA=",
+        "lastModified": 1707418974,
+        "narHash": "sha256-wntNMNmcxaS+1Nq2NvrMkermWtwyoNrwK8efXl8aQM8=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "34e9174cf09fee5b4675ce13c9efbca436874d0a",
+        "rev": "296547b1e97314d507675e61b873542842e88786",
         "type": "github"
       },
       "original": {
@@ -801,11 +801,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1706140641,
-        "narHash": "sha256-H1qHhkf7sF7yrG2rb9Ks1Y4EtLY3cXGp16KCGveJWY4=",
+        "lastModified": 1708040042,
+        "narHash": "sha256-8iloeE/jALIKcOcYKgTlI9i7iDW7n52Epqps27jGklU=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "4e59422e1d4950a3042bad41a7b81c8db4f8b648",
+        "rev": "04dfa2eea914086a9f42a5a00a33e9524f9fded4",
         "type": "github"
       },
       "original": {
@@ -851,11 +851,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706141075,
-        "narHash": "sha256-o66/XFTXmcJSpEcO508V5r765HtgT8qtr+H4LRIB9BY=",
+        "lastModified": 1708041826,
+        "narHash": "sha256-zW7F31gW4HCBYcImcXxold4ntZdlEr/NTlMVhEMA5dw=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "1da2e054a16309d7d7f7669438c8b9a5ef1b4642",
+        "rev": "1afaeebc41dab1029b855b17d78f2348e8dd49e3",
         "type": "github"
       },
       "original": {
@@ -979,11 +979,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1707451808,
-        "narHash": "sha256-UwDBUNHNRsYKFJzyTMVMTF5qS4xeJlWoeyJf+6vvamU=",
+        "lastModified": 1708057191,
+        "narHash": "sha256-O3M5EGAeKZdEzfFIjqah0d8M44A4QCSVwvkbz4cbC2s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "442d407992384ed9c0e6d352de75b69079904e4e",
+        "rev": "5e55f0bb65124b05d0a52e164514c03596023634",
         "type": "github"
       },
       "original": {
@@ -1026,11 +1026,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1706006310,
-        "narHash": "sha256-nDPz0fj0IFcDhSTlXBU2aixcnGs2Jm4Zcuoj0QtmiXQ=",
+        "lastModified": 1707393347,
+        "narHash": "sha256-xmHgBMyF+Glxs3f8r+AMxJDTNUS01Q5kMjQdgAyw+B8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b43bb235efeab5324c5e486882ef46749188eee2",
+        "rev": "c0b7a892fb042ede583bdaecbbdc804acb85eabe",
         "type": "github"
       },
       "original": {
@@ -1042,11 +1042,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1706925685,
-        "narHash": "sha256-hVInjWMmgH4yZgA4ZtbgJM1qEAel72SYhP5nOWX4UIM=",
+        "lastModified": 1707451808,
+        "narHash": "sha256-UwDBUNHNRsYKFJzyTMVMTF5qS4xeJlWoeyJf+6vvamU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "79a13f1437e149dc7be2d1290c74d378dad60814",
+        "rev": "442d407992384ed9c0e6d352de75b69079904e4e",
         "type": "github"
       },
       "original": {
@@ -1091,11 +1091,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1707445495,
-        "narHash": "sha256-co0XAqy2NIT+eqAvbndGeev+3gqlpe5OPXJC5wxjYi4=",
+        "lastModified": 1708063340,
+        "narHash": "sha256-1k3BRjNy853WjuTMUT8EjGZd9v4phuUMTZmJfZLDToM=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "f12f1b9e877b1e6e2ef7eae1a524d8253af4243d",
+        "rev": "d1bab4cf4b69e49d6058028fd933d8ef5e74e680",
         "type": "github"
       },
       "original": {
@@ -1193,11 +1193,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1706424699,
-        "narHash": "sha256-Q3RBuOpZNH2eFA1e+IHgZLAOqDD9SKhJ/sszrL8bQD4=",
+        "lastModified": 1707297608,
+        "narHash": "sha256-ADjo/5VySGlvtCW3qR+vdFF4xM9kJFlRDqcC9ZGI8EA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "7c54e08a689b53c8a1e5d70169f2ec9e2a68ffaf",
+        "rev": "0db2e67ee49910adfa13010e7f012149660af7f0",
         "type": "github"
       },
       "original": {
@@ -1283,11 +1283,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1707005578,
-        "narHash": "sha256-CUelqScI8XEd04bJrtLqUihy8xBy9GEOKu8tKMcSwpc=",
+        "lastModified": 1708035011,
+        "narHash": "sha256-WkTMFo36+WMMEah5MFWqyrw+i+E2z/sc+VmbQH73rds=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "18b5442a418e38b8527d2c43892e266963a8778e",
+        "rev": "ec3288d52ed581ee63a10e41a226297801fa6ee8",
         "type": "github"
       },
       "original": {
@@ -1435,11 +1435,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1707446310,
-        "narHash": "sha256-t58sRzxwU7NUkZ2X8fVCaMWRbCqT0ywvm71eiFfMo3Q=",
+        "lastModified": 1708005261,
+        "narHash": "sha256-9M98CmquV9ZOkPDSW7545JBjoxXkx6PghivdysSVhhM=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "0f865f17af4f9bc1587a0132414cdfd32d91852e",
+        "rev": "45d61cc8da213e4052cf698653692b6a4c961760",
         "type": "github"
       },
       "original": {
@@ -1451,11 +1451,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1707089826,
-        "narHash": "sha256-xcfy2sqsk8VUBxU7TgWo1Jzw3UdysIBsNr9sn47WZx4=",
+        "lastModified": 1707525123,
+        "narHash": "sha256-Z2uIDeXKInS6qQZxZrpmCuwpT5h0LEOt/Tc+h0LXOus=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "313d9e7193354c5de7cdb1724f9e2d3f442780b0",
+        "rev": "7f30f2da3c3641841ceb0e2c150281f624445e8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/fab00f7c0f3a08e860e39c7adeb8fbe849921a98' (2024-02-08)
  → 'github:tpope/vim-fugitive/011cf4fcb93a9649ffc6dcdff56ef948f5d0f7cc' (2024-02-12)
• Updated input 'home-manager':
    'github:nix-community/home-manager/5b9156fa9a8b8beba917b8f9adbfd27bf63e16af' (2024-02-09)
  → 'github:nix-community/home-manager/3d6791b3897b526c82920a2ab5f61d71985b3cf8' (2024-02-15)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/2dbef19461198630b3d7c39f414d09fb07d1fdd2' (2024-01-17)
  → 'github:L3MON4D3/LuaSnip/f3b3d3446bcbfa62d638b1903ff00a78b2b730a1' (2024-02-15)
• Updated input 'neodev-nvim':
    'github:folke/neodev.nvim/b49b976cf2c28cd8283e9d74cb10885f6dd9e3d0' (2024-02-09)
  → 'github:folke/neodev.nvim/de3685b8c1cd439dd96b7958793f6f381f98652d' (2024-02-16)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/1da2e054a16309d7d7f7669438c8b9a5ef1b4642' (2024-01-25)
  → 'github:nix-community/neovim-nightly-overlay/1afaeebc41dab1029b855b17d78f2348e8dd49e3' (2024-02-16)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/07f6395285469419cf9d078f59b5b49993198c00' (2024-01-11)
  → 'github:hercules-ci/flake-parts/b253292d9c0a5ead9bc98c4e9a26c6312e27d69f' (2024-02-01)
• Updated input 'neovim-nightly-overlay/neovim-flake':
    'github:neovim/neovim/4e59422e1d4950a3042bad41a7b81c8db4f8b648?dir=contrib' (2024-01-24)
  → 'github:neovim/neovim/04dfa2eea914086a9f42a5a00a33e9524f9fded4?dir=contrib' (2024-02-15)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/442d407992384ed9c0e6d352de75b69079904e4e' (2024-02-09)
  → 'github:nixos/nixpkgs/5e55f0bb65124b05d0a52e164514c03596023634' (2024-02-16)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/f12f1b9e877b1e6e2ef7eae1a524d8253af4243d' (2024-02-09)
  → 'github:neovim/nvim-lspconfig/d1bab4cf4b69e49d6058028fd933d8ef5e74e680' (2024-02-16)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/18b5442a418e38b8527d2c43892e266963a8778e' (2024-02-04)
  → 'github:mrcjkb/rustaceanvim/ec3288d52ed581ee63a10e41a226297801fa6ee8' (2024-02-15)
• Updated input 'rustacean-nvim/neodev-nvim':
    'github:folke/neodev.nvim/2793ba3127c2c93ee486b9072a3ef129eeb950cc' (2024-02-01)
  → 'github:folke/neodev.nvim/b49b976cf2c28cd8283e9d74cb10885f6dd9e3d0' (2024-02-09)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/34e9174cf09fee5b4675ce13c9efbca436874d0a' (2024-01-25)
  → 'github:nvim-neorocks/neorocks/296547b1e97314d507675e61b873542842e88786' (2024-02-08)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/b43bb235efeab5324c5e486882ef46749188eee2' (2024-01-23)
  → 'github:nixos/nixpkgs/c0b7a892fb042ede583bdaecbbdc804acb85eabe' (2024-02-08)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/79a13f1437e149dc7be2d1290c74d378dad60814' (2024-02-03)
  → 'github:nixos/nixpkgs/442d407992384ed9c0e6d352de75b69079904e4e' (2024-02-09)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/7c54e08a689b53c8a1e5d70169f2ec9e2a68ffaf' (2024-01-28)
  → 'github:cachix/pre-commit-hooks.nix/0db2e67ee49910adfa13010e7f012149660af7f0' (2024-02-07)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/0f865f17af4f9bc1587a0132414cdfd32d91852e' (2024-02-09)
  → 'github:nvim-telescope/telescope.nvim/45d61cc8da213e4052cf698653692b6a4c961760' (2024-02-15)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/313d9e7193354c5de7cdb1724f9e2d3f442780b0' (2024-02-04)
  → 'github:nvim-tree/nvim-web-devicons/7f30f2da3c3641841ceb0e2c150281f624445e8f' (2024-02-10)

```

</p></details>

 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`18b5442a` ➡️ `ec3288d5`](https://github.com/mrcjkb/rustaceanvim/compare/18b5442a418e38b8527d2c43892e266963a8778e...ec3288d52ed581ee63a10e41a226297801fa6ee8) <sub>(2024-02-04 to 2024-02-15)</sub>
 - Updated input [`neodev-nvim`](https://github.com/folke/neodev.nvim): [`b49b976c` ➡️ `de3685b8`](https://github.com/folke/neodev.nvim/compare/b49b976cf2c28cd8283e9d74cb10885f6dd9e3d0...de3685b8c1cd439dd96b7958793f6f381f98652d) <sub>(2024-02-09 to 2024-02-16)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`b43bb235` ➡️ `c0b7a892`](https://github.com/nixos/nixpkgs/compare/b43bb235efeab5324c5e486882ef46749188eee2...c0b7a892fb042ede583bdaecbbdc804acb85eabe) <sub>(2024-01-23 to 2024-02-08)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`34e9174c` ➡️ `296547b1`](https://github.com/nvim-neorocks/neorocks/compare/34e9174cf09fee5b4675ce13c9efbca436874d0a...296547b1e97314d507675e61b873542842e88786) <sub>(2024-01-25 to 2024-02-08)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`fab00f7c` ➡️ `011cf4fc`](https://github.com/tpope/vim-fugitive/compare/fab00f7c0f3a08e860e39c7adeb8fbe849921a98...011cf4fcb93a9649ffc6dcdff56ef948f5d0f7cc) <sub>(2024-02-08 to 2024-02-12)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`1da2e054` ➡️ `1afaeebc`](https://github.com/nix-community/neovim-nightly-overlay/compare/1da2e054a16309d7d7f7669438c8b9a5ef1b4642...1afaeebc41dab1029b855b17d78f2348e8dd49e3) <sub>(2024-01-25 to 2024-02-16)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`2dbef194` ➡️ `f3b3d344`](https://github.com/L3MON4D3/LuaSnip/compare/2dbef19461198630b3d7c39f414d09fb07d1fdd2...f3b3d3446bcbfa62d638b1903ff00a78b2b730a1) <sub>(2024-01-17 to 2024-02-15)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`f12f1b9e` ➡️ `d1bab4cf`](https://github.com/neovim/nvim-lspconfig/compare/f12f1b9e877b1e6e2ef7eae1a524d8253af4243d...d1bab4cf4b69e49d6058028fd933d8ef5e74e680) <sub>(2024-02-09 to 2024-02-16)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`7c54e08a` ➡️ `0db2e67e`](https://github.com/cachix/pre-commit-hooks.nix/compare/7c54e08a689b53c8a1e5d70169f2ec9e2a68ffaf...0db2e67ee49910adfa13010e7f012149660af7f0) <sub>(2024-01-28 to 2024-02-07)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`79a13f14` ➡️ `442d4079`](https://github.com/nixos/nixpkgs/compare/79a13f1437e149dc7be2d1290c74d378dad60814...442d407992384ed9c0e6d352de75b69079904e4e) <sub>(2024-02-03 to 2024-02-09)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`442d4079` ➡️ `5e55f0bb`](https://github.com/nixos/nixpkgs/compare/442d407992384ed9c0e6d352de75b69079904e4e...5e55f0bb65124b05d0a52e164514c03596023634) <sub>(2024-02-09 to 2024-02-16)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`0f865f17` ➡️ `45d61cc8`](https://github.com/nvim-telescope/telescope.nvim/compare/0f865f17af4f9bc1587a0132414cdfd32d91852e...45d61cc8da213e4052cf698653692b6a4c961760) <sub>(2024-02-09 to 2024-02-15)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-flake`](https://github.com/neovim/neovim): [`4e59422e` ➡️ `04dfa2ee`](https://github.com/neovim/neovim/compare/4e59422e1d4950a3042bad41a7b81c8db4f8b648...04dfa2eea914086a9f42a5a00a33e9524f9fded4) <sub>(2024-01-24 to 2024-02-15)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`313d9e71` ➡️ `7f30f2da`](https://github.com/nvim-tree/nvim-web-devicons/compare/313d9e7193354c5de7cdb1724f9e2d3f442780b0...7f30f2da3c3641841ceb0e2c150281f624445e8f) <sub>(2024-02-04 to 2024-02-10)</sub>
 - Updated input [`rustacean-nvim/neodev-nvim`](https://github.com/folke/neodev.nvim): [`2793ba31` ➡️ `b49b976c`](https://github.com/folke/neodev.nvim/compare/2793ba3127c2c93ee486b9072a3ef129eeb950cc...b49b976cf2c28cd8283e9d74cb10885f6dd9e3d0) <sub>(2024-02-01 to 2024-02-09)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`5b9156fa` ➡️ `3d6791b3`](https://github.com/nix-community/home-manager/compare/5b9156fa9a8b8beba917b8f9adbfd27bf63e16af...3d6791b3897b526c82920a2ab5f61d71985b3cf8) <sub>(2024-02-09 to 2024-02-15)</sub>
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`07f63952` ➡️ `b253292d`](https://github.com/hercules-ci/flake-parts/compare/07f6395285469419cf9d078f59b5b49993198c00...b253292d9c0a5ead9bc98c4e9a26c6312e27d69f) <sub>(2024-01-11 to 2024-02-01)</sub>