### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -204,16 +204,34 @@
         "type": "github"
       }
     },
+    "flake-parts_4": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
         "type": "github"
       },
       "original": {
@@ -381,11 +399,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1707706623,
-        "narHash": "sha256-dI28XbFYUWuGQ89oGR51WK6M3kWhBwqqC0Bs99vxrjY=",
+        "lastModified": 1708801287,
+        "narHash": "sha256-1fnKrjX3eq05K9Flw5peGtD8zBTbuIEGoz+pb3DCKIg=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "011cf4fcb93a9649ffc6dcdff56ef948f5d0f7cc",
+        "rev": "2e88f14a585c014691904ba8fe39e6ea851c9422",
         "type": "github"
       },
       "original": {
@@ -423,6 +441,25 @@
       "original": {
         "owner": "dkuettel",
         "repo": "funky-formatter.nvim",
+        "type": "github"
+      }
+    },
+    "gen-luarc": {
+      "inputs": {
+        "flake-parts": "flake-parts_4",
+        "nixpkgs": "nixpkgs_7"
+      },
+      "locked": {
+        "lastModified": 1708688915,
+        "narHash": "sha256-Vcfbdo2IOEiimRnehGLUM5l2VEIjZYZdKS0sjYWwfb4=",
+        "owner": "mrcjkb",
+        "repo": "nix-gen-luarc-json",
+        "rev": "6eb62734dae84e5f79368dfc545b3fff305df754",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mrcjkb",
+        "repo": "nix-gen-luarc-json",
         "type": "github"
       }
     },
@@ -516,11 +553,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708591310,
-        "narHash": "sha256-8mQGVs8JccWTnORgoLOTh9zvf6Np+x2JzhIc+LDcJ9s=",
+        "lastModified": 1709204054,
+        "narHash": "sha256-U1idK0JHs1XOfSI1APYuXi4AEADf+B+ZU4Wifc0pBHk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0e0e9669547e45ea6cca2de4044c1a384fd0fe55",
+        "rev": "2f3367769a93b226c467551315e9e270c3f78b15",
         "type": "github"
       },
       "original": {
@@ -740,27 +777,11 @@
     "neodev-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1708668387,
-        "narHash": "sha256-JqrPVGzJFvJpJmAGoy535hNsF4zCkzSJ/bUgCZlRXqo=",
+        "lastModified": 1709144748,
+        "narHash": "sha256-VyJTGbWBzGmuEkotKwTxAVpznfrrQ26aaBc31n6ZjlE=",
         "owner": "folke",
         "repo": "neodev.nvim",
-        "rev": "f7f249b361e9fb245eea24cbcd9f5502e796c6ea",
-        "type": "github"
-      },
-      "original": {
-        "owner": "folke",
-        "repo": "neodev.nvim",
-        "type": "github"
-      }
-    },
-    "neodev-nvim_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1708322750,
-        "narHash": "sha256-Oy4j+5CYmYIM3ENiZNlGDrcbhMOs5qmDpLYxjJduSfM=",
-        "owner": "folke",
-        "repo": "neodev.nvim",
-        "rev": "bbe17de89345ce40725e721d347c596dc4a02b32",
+        "rev": "84e0290f5600e8b89c0dfcafc864f45496a53400",
         "type": "github"
       },
       "original": {
@@ -774,15 +795,15 @@
         "flake-compat": "flake-compat_2",
         "flake-utils": "flake-utils_7",
         "neovim-nightly": "neovim-nightly",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_8",
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1708406630,
-        "narHash": "sha256-5vy4yUf1vnOR6yO0rq+Qrl5RjhhhJZPinXpMLqK4DUE=",
+        "lastModified": 1709011371,
+        "narHash": "sha256-JUfnTaZZ0nuPK0lGzxz3dVXJG6Vg/DnA0VHBQQ5uFPs=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "897b505c49776a1d6baf7c9efa79e6ffc37645cd",
+        "rev": "b19f1764dc04fd97d5f592d74a9df72846ae454c",
         "type": "github"
       },
       "original": {
@@ -801,11 +822,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1708643613,
-        "narHash": "sha256-voR4Bhc33nm9ap6f7fwwxp0z/7lro3nKKNSN7RDO/vQ=",
+        "lastModified": 1709244818,
+        "narHash": "sha256-dCwN7Z4t+pmGuH90Dff5h1qIm2Rh917cZX3GF/W5GYk=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "df1795cd6bdf7e1db31c87d4a33d89a2c8269560",
+        "rev": "5d4e1693cb415e8b76749e833e28f00f14630b87",
         "type": "github"
       },
       "original": {
@@ -826,11 +847,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1708374065,
-        "narHash": "sha256-1g4X7Iztb3a6ILAGIZmfoNTpHc1FjTLrO+sFYrNllEI=",
+        "lastModified": 1708986177,
+        "narHash": "sha256-DgSR8cL6c+rqOwvCFFz9lKBLa6XweNBTMrMhL4X1THI=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "8952a89db588db10a9dba16356f9bbd35ca5fabb",
+        "rev": "a4b4442524b0fc7d4b79383786391427e200c194",
         "type": "github"
       },
       "original": {
@@ -851,11 +872,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708646639,
-        "narHash": "sha256-WxAbuR0ZtCiW1PDaO9SEv99xKM5uMWuGG0n/OuZBk1g=",
+        "lastModified": 1709251411,
+        "narHash": "sha256-gqdsGpxOYeVKL20NkzXhO34j+/acwf6cPP3WyNawO2A=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "c0e693f96608883cb9f2fca171c84ef2f04e52ad",
+        "rev": "cc9a9e3382376958422b12170c7edd78087c7a98",
         "type": "github"
       },
       "original": {
@@ -914,6 +935,24 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1704874635,
@@ -942,6 +981,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_10": {
+      "locked": {
+        "lastModified": 1704842529,
+        "narHash": "sha256-OTeQA+F8d/Evad33JMfuXC89VMetQbsU4qcaePchGr4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabe8d3eface69f5bb16c18f8662a702f50c20d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -979,11 +1034,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1708564076,
-        "narHash": "sha256-KKkqoxlgx9n3nwST7O2kM8tliDOijiSSNaWuSkiozdQ=",
+        "lastModified": 1709294055,
+        "narHash": "sha256-7EECkQYoNKJZOf2+miJdrMpxpvsn/qZFwIhUI3fQpLs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "98b00b6947a9214381112bdb6f89c25498db4959",
+        "rev": "ec869190b56a1b4677d24a8bdbcfe80ccea2ece6",
         "type": "github"
       },
       "original": {
@@ -1026,27 +1081,27 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1708373374,
-        "narHash": "sha256-yEyDvDj/YQc4GOZa/cXx6YUzexD8uv1rUvD6SJVr6UI=",
+        "lastModified": 1708475490,
+        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "93e1c2d08467d1117ebac45689469613a9fe8453",
+        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1708373374,
-        "narHash": "sha256-yEyDvDj/YQc4GOZa/cXx6YUzexD8uv1rUvD6SJVr6UI=",
+        "lastModified": 1708943256,
+        "narHash": "sha256-K9VeHrhXsigdhNMZ8hqAk7jtRy4ollqhkYYNZqbfssg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "93e1c2d08467d1117ebac45689469613a9fe8453",
+        "rev": "fcea2b6260dd566c28c894b4207a5f2b56c2cba3",
         "type": "github"
       },
       "original": {
@@ -1058,15 +1113,15 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1704842529,
-        "narHash": "sha256-OTeQA+F8d/Evad33JMfuXC89VMetQbsU4qcaePchGr4=",
-        "owner": "NixOS",
+        "lastModified": 1709038661,
+        "narHash": "sha256-Ys611iT6pChGv954aa4f8oKoDKJG3IXjJjPhnj6uaLY=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eabe8d3eface69f5bb16c18f8662a702f50c20d5",
+        "rev": "8520c158aee718c6e87b56881105fc4223c3c723",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
+        "owner": "nixos",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -1091,11 +1146,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1708666470,
-        "narHash": "sha256-b4Z/3uC29MpxrDuVGfAvUkyRX+w1CcOGCscKrpZy8tk=",
+        "lastModified": 1709187572,
+        "narHash": "sha256-adi0xaaBzrDnN9TzG0WsLb+i5xBdguZbQ8hrwe0Z3r4=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "d5b6d4366dfd7a1071b930defd365e6d0be258de",
+        "rev": "9553725789be682ecd945a527ec552e489ea8534",
         "type": "github"
       },
       "original": {
@@ -1189,7 +1244,7 @@
         "flake-compat": "flake-compat_4",
         "flake-utils": "flake-utils_10",
         "gitignore": "gitignore_2",
-        "nixpkgs": "nixpkgs_9",
+        "nixpkgs": "nixpkgs_10",
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
@@ -1277,17 +1332,17 @@
     "rustacean-nvim": {
       "inputs": {
         "flake-parts": "flake-parts_3",
-        "neodev-nvim": "neodev-nvim_2",
+        "gen-luarc": "gen-luarc",
         "neorocks": "neorocks",
-        "nixpkgs": "nixpkgs_8",
+        "nixpkgs": "nixpkgs_9",
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1708715230,
-        "narHash": "sha256-M4ddYUponnHO56mCbDC8UxhEhPVioPZDdUG4u7aILG4=",
+        "lastModified": 1709308484,
+        "narHash": "sha256-JyvaDySQp8qhC8u0sswjfPq5HlnK0CN9O7NbqacBgEI=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "b44e1db9056d74cc491aa4a3f625f8bdca0d6743",
+        "rev": "001dd498894e4c554e92af507fb27739146c177d",
         "type": "github"
       },
       "original": {
@@ -1435,11 +1490,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1708658155,
-        "narHash": "sha256-VJIqfJLkjhQYvYpkpeAkb/wXe0aD0yxp2yG6F3aWm+M=",
+        "lastModified": 1709316544,
+        "narHash": "sha256-nn5GvqS7BH2FuTnx2jMkGtBKfFIpn1J2FTXLJYyyIsQ=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "a5b69afa484038f1c4793e979d023edb478ebc0c",
+        "rev": "aa83606299c5beeaf80e656efbf07bde258db7be",
         "type": "github"
       },
       "original": {
@@ -1451,11 +1506,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1708217976,
-        "narHash": "sha256-hMBzqBSHrn4cqV1HBbFJSPR47INNs+jgm54w1f/lAtA=",
+        "lastModified": 1708837217,
+        "narHash": "sha256-66BJaZJdxtfcXPU4pDVvG2RrTg+1E4YA4SGE7e9X02c=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "14ac5887110b06b89a96881d534230dac3ed134d",
+        "rev": "0bb67ef952ea3eb7b1bac9c011281471d99a27bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'flake-utils':
    'github:numtide/flake-utils/1ef2e671c3b0c19053962c07dbda38332dcebf26' (2024-01-15)
  → 'github:numtide/flake-utils/d465f4819400de7c8d874d50b982301f28a84605' (2024-02-28)
• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/011cf4fcb93a9649ffc6dcdff56ef948f5d0f7cc' (2024-02-12)
  → 'github:tpope/vim-fugitive/2e88f14a585c014691904ba8fe39e6ea851c9422' (2024-02-24)
• Updated input 'home-manager':
    'github:nix-community/home-manager/0e0e9669547e45ea6cca2de4044c1a384fd0fe55' (2024-02-22)
  → 'github:nix-community/home-manager/2f3367769a93b226c467551315e9e270c3f78b15' (2024-02-29)
• Updated input 'neodev-nvim':
    'github:folke/neodev.nvim/f7f249b361e9fb245eea24cbcd9f5502e796c6ea' (2024-02-23)
  → 'github:folke/neodev.nvim/84e0290f5600e8b89c0dfcafc864f45496a53400' (2024-02-28)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/c0e693f96608883cb9f2fca171c84ef2f04e52ad' (2024-02-23)
  → 'github:nix-community/neovim-nightly-overlay/cc9a9e3382376958422b12170c7edd78087c7a98' (2024-03-01)
• Updated input 'neovim-nightly-overlay/neovim-flake':
    'github:neovim/neovim/df1795cd6bdf7e1db31c87d4a33d89a2c8269560?dir=contrib' (2024-02-22)
  → 'github:neovim/neovim/5d4e1693cb415e8b76749e833e28f00f14630b87?dir=contrib' (2024-02-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/98b00b6947a9214381112bdb6f89c25498db4959' (2024-02-22)
  → 'github:nixos/nixpkgs/ec869190b56a1b4677d24a8bdbcfe80ccea2ece6' (2024-03-01)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/d5b6d4366dfd7a1071b930defd365e6d0be258de' (2024-02-23)
  → 'github:neovim/nvim-lspconfig/9553725789be682ecd945a527ec552e489ea8534' (2024-02-29)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/b44e1db9056d74cc491aa4a3f625f8bdca0d6743' (2024-02-23)
  → 'github:mrcjkb/rustaceanvim/001dd498894e4c554e92af507fb27739146c177d' (2024-03-01)
• Added input 'rustacean-nvim/gen-luarc':
    'github:mrcjkb/nix-gen-luarc-json/6eb62734dae84e5f79368dfc545b3fff305df754' (2024-02-23)
• Added input 'rustacean-nvim/gen-luarc/flake-parts':
    'github:hercules-ci/flake-parts/b253292d9c0a5ead9bc98c4e9a26c6312e27d69f' (2024-02-01)
• Added input 'rustacean-nvim/gen-luarc/flake-parts/nixpkgs-lib':
    'github:NixOS/nixpkgs/97b17f32362e475016f942bbdfda4a4a72a8a652?dir=lib' (2024-01-29)
• Added input 'rustacean-nvim/gen-luarc/nixpkgs':
    'github:nixos/nixpkgs/0e74ca98a74bc7270d28838369593635a5db3260' (2024-02-21)
• Removed input 'rustacean-nvim/neodev-nvim'
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/897b505c49776a1d6baf7c9efa79e6ffc37645cd' (2024-02-20)
  → 'github:nvim-neorocks/neorocks/b19f1764dc04fd97d5f592d74a9df72846ae454c' (2024-02-27)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:neovim/neovim/8952a89db588db10a9dba16356f9bbd35ca5fabb?dir=contrib' (2024-02-19)
  → 'github:neovim/neovim/a4b4442524b0fc7d4b79383786391427e200c194?dir=contrib' (2024-02-26)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/93e1c2d08467d1117ebac45689469613a9fe8453' (2024-02-19)
  → 'github:nixos/nixpkgs/fcea2b6260dd566c28c894b4207a5f2b56c2cba3' (2024-02-26)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/93e1c2d08467d1117ebac45689469613a9fe8453' (2024-02-19)
  → 'github:nixos/nixpkgs/8520c158aee718c6e87b56881105fc4223c3c723' (2024-02-27)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/a5b69afa484038f1c4793e979d023edb478ebc0c' (2024-02-23)
  → 'github:nvim-telescope/telescope.nvim/aa83606299c5beeaf80e656efbf07bde258db7be' (2024-03-01)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/14ac5887110b06b89a96881d534230dac3ed134d' (2024-02-18)
  → 'github:nvim-tree/nvim-web-devicons/0bb67ef952ea3eb7b1bac9c011281471d99a27bc' (2024-02-25)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/neovim/neovim): [`8952a89d` ➡️ `a4b44425`](https://github.com/neovim/neovim/compare/8952a89db588db10a9dba16356f9bbd35ca5fabb...a4b4442524b0fc7d4b79383786391427e200c194) <sub>(2024-02-19 to 2024-02-26)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`b44e1db9` ➡️ `001dd498`](https://github.com/mrcjkb/rustaceanvim/compare/b44e1db9056d74cc491aa4a3f625f8bdca0d6743...001dd498894e4c554e92af507fb27739146c177d) <sub>(2024-02-23 to 2024-03-01)</sub>
 - Updated input [`neodev-nvim`](https://github.com/folke/neodev.nvim): [`f7f249b3` ➡️ `84e0290f`](https://github.com/folke/neodev.nvim/compare/f7f249b361e9fb245eea24cbcd9f5502e796c6ea...84e0290f5600e8b89c0dfcafc864f45496a53400) <sub>(2024-02-23 to 2024-02-28)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`93e1c2d0` ➡️ `fcea2b62`](https://github.com/nixos/nixpkgs/compare/93e1c2d08467d1117ebac45689469613a9fe8453...fcea2b6260dd566c28c894b4207a5f2b56c2cba3) <sub>(2024-02-19 to 2024-02-26)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`897b505c` ➡️ `b19f1764`](https://github.com/nvim-neorocks/neorocks/compare/897b505c49776a1d6baf7c9efa79e6ffc37645cd...b19f1764dc04fd97d5f592d74a9df72846ae454c) <sub>(2024-02-20 to 2024-02-27)</sub>
 - Added input [`rustacean-nvim/gen-luarc/flake-parts/nixpkgs-lib`](https://github.com/NixOS/nixpkgs): [github.com/NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/tree/97b17f32362e475016f942bbdfda4a4a72a8a652/)
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`011cf4fc` ➡️ `2e88f14a`](https://github.com/tpope/vim-fugitive/compare/011cf4fcb93a9649ffc6dcdff56ef948f5d0f7cc...2e88f14a585c014691904ba8fe39e6ea851c9422) <sub>(2024-02-12 to 2024-02-24)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`c0e693f9` ➡️ `cc9a9e33`](https://github.com/nix-community/neovim-nightly-overlay/compare/c0e693f96608883cb9f2fca171c84ef2f04e52ad...cc9a9e3382376958422b12170c7edd78087c7a98) <sub>(2024-02-23 to 2024-03-01)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`d5b6d436` ➡️ `95537257`](https://github.com/neovim/nvim-lspconfig/compare/d5b6d4366dfd7a1071b930defd365e6d0be258de...9553725789be682ecd945a527ec552e489ea8534) <sub>(2024-02-23 to 2024-02-29)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`93e1c2d0` ➡️ `8520c158`](https://github.com/nixos/nixpkgs/compare/93e1c2d08467d1117ebac45689469613a9fe8453...8520c158aee718c6e87b56881105fc4223c3c723) <sub>(2024-02-19 to 2024-02-27)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`98b00b69` ➡️ `ec869190`](https://github.com/nixos/nixpkgs/compare/98b00b6947a9214381112bdb6f89c25498db4959...ec869190b56a1b4677d24a8bdbcfe80ccea2ece6) <sub>(2024-02-22 to 2024-03-01)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`a5b69afa` ➡️ `aa836062`](https://github.com/nvim-telescope/telescope.nvim/compare/a5b69afa484038f1c4793e979d023edb478ebc0c...aa83606299c5beeaf80e656efbf07bde258db7be) <sub>(2024-02-23 to 2024-03-01)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-flake`](https://github.com/neovim/neovim): [`df1795cd` ➡️ `5d4e1693`](https://github.com/neovim/neovim/compare/df1795cd6bdf7e1db31c87d4a33d89a2c8269560...5d4e1693cb415e8b76749e833e28f00f14630b87) <sub>(2024-02-22 to 2024-02-29)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`14ac5887` ➡️ `0bb67ef9`](https://github.com/nvim-tree/nvim-web-devicons/compare/14ac5887110b06b89a96881d534230dac3ed134d...0bb67ef952ea3eb7b1bac9c011281471d99a27bc) <sub>(2024-02-18 to 2024-02-25)</sub>
 - Removed input `rustacean-nvim/neodev-nvim`.
 - Added input [`rustacean-nvim/gen-luarc/flake-parts`](https://github.com/hercules-ci/flake-parts): [github.com/hercules-ci/flake-parts](https://github.com/hercules-ci/flake-parts/tree/b253292d9c0a5ead9bc98c4e9a26c6312e27d69f/)
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`0e0e9669` ➡️ `2f336776`](https://github.com/nix-community/home-manager/compare/0e0e9669547e45ea6cca2de4044c1a384fd0fe55...2f3367769a93b226c467551315e9e270c3f78b15) <sub>(2024-02-22 to 2024-02-29)</sub>
 - Added input [`rustacean-nvim/gen-luarc`](https://github.com/mrcjkb/nix-gen-luarc-json): [github.com/mrcjkb/nix-gen-luarc-json](https://github.com/mrcjkb/nix-gen-luarc-json/tree/6eb62734dae84e5f79368dfc545b3fff305df754/)
 - Added input [`rustacean-nvim/gen-luarc/nixpkgs`](https://github.com/nixos/nixpkgs): [github.com/nixos/nixpkgs](https://github.com/nixos/nixpkgs/tree/0e74ca98a74bc7270d28838369593635a5db3260/)
 - Updated input [`flake-utils`](https://github.com/numtide/flake-utils): [`1ef2e671` ➡️ `d465f481`](https://github.com/numtide/flake-utils/compare/1ef2e671c3b0c19053962c07dbda38332dcebf26...d465f4819400de7c8d874d50b982301f28a84605) <sub>(2024-01-15 to 2024-02-28)</sub>