### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706830856,
-        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
         "type": "github"
       },
       "original": {
@@ -191,11 +191,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1706830856,
-        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
         "type": "github"
       },
       "original": {
@@ -347,11 +347,11 @@
         "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
         "type": "github"
       },
       "original": {
@@ -399,11 +399,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1708801287,
-        "narHash": "sha256-1fnKrjX3eq05K9Flw5peGtD8zBTbuIEGoz+pb3DCKIg=",
+        "lastModified": 1709513879,
+        "narHash": "sha256-DILFvQnXprugbYS9NWsa3elP7/g0jKSFP7MvdCrzfJ8=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "2e88f14a585c014691904ba8fe39e6ea851c9422",
+        "rev": "41beedabc7e948c787ea5696e04c3544c3674e23",
         "type": "github"
       },
       "original": {
@@ -553,11 +553,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709204054,
-        "narHash": "sha256-U1idK0JHs1XOfSI1APYuXi4AEADf+B+ZU4Wifc0pBHk=",
+        "lastModified": 1709904018,
+        "narHash": "sha256-fVp/89wNjWg7OQ/Gj3eSK2IXKDk9mXSj5ltOz98Ce2w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f3367769a93b226c467551315e9e270c3f78b15",
+        "rev": "8b07ca541939211d3cc437ddfd74ebdef3d72471",
         "type": "github"
       },
       "original": {
@@ -587,11 +587,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1706198673,
-        "narHash": "sha256-bHlxFd+3QHy6eXtTzzhwVNcyxBSOxTvBuJGNUzI4C4M=",
+        "lastModified": 1709391291,
+        "narHash": "sha256-NJwAgXRKLVuO3YLkGxXIanLvTKN+cJsYwbLoWOa7ODk=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "16884001b26e6955ff4b88b4dfe4c8986e20f153",
+        "rev": "2d4ece4a008feefddc194bde785b1d39f987b5a7",
         "type": "github"
       },
       "original": {
@@ -636,11 +636,11 @@
     "lsp-signature-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1701211782,
-        "narHash": "sha256-4GcTfu7MRpZUi5dqewaddSvaOezRl9ROKrR7wnnLnKE=",
+        "lastModified": 1709592196,
+        "narHash": "sha256-WAQ8DWjNWKYBbELC/M8ClGxU0cAqB4X1TlkWIEBqp24=",
         "owner": "ray-x",
         "repo": "lsp_signature.nvim",
-        "rev": "fed2c8389c148ff1dfdcdca63c2b48d08a50dea0",
+        "rev": "e92b4e7073345b2a30a56b20db3d541a9aa2771e",
         "type": "github"
       },
       "original": {
@@ -705,11 +705,11 @@
     "lualine-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1706181415,
-        "narHash": "sha256-LMMcRY4qnGywdK6Bl4YeAEKLhnRuOZ2txn4oYoso2gI=",
+        "lastModified": 1709556301,
+        "narHash": "sha256-G4npmdS7vue68h5QN8vWx3Oh5FHdvmzFHGxqMIRC+Mk=",
         "owner": "nvim-lualine",
         "repo": "lualine.nvim",
-        "rev": "7d131a8d3ba5016229e8a1d08bf8782acea98852",
+        "rev": "8b56462bfb746760465264de41b4907310f113ec",
         "type": "github"
       },
       "original": {
@@ -721,11 +721,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1708014104,
-        "narHash": "sha256-J20Zrdw8EmiA0ATgmoSYbej6mkoXD/b5eOy+IvprMHQ=",
+        "lastModified": 1709453917,
+        "narHash": "sha256-oyMykjBLkk/9S5AutnPKL+DKgfW59TS+kGUE2GsVbHk=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "f3b3d3446bcbfa62d638b1903ff00a78b2b730a1",
+        "rev": "a7a4b4682c4b3e2ba82b82a4e6e5f5a0e79dec32",
         "type": "github"
       },
       "original": {
@@ -799,11 +799,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1709011371,
-        "narHash": "sha256-JUfnTaZZ0nuPK0lGzxz3dVXJG6Vg/DnA0VHBQQ5uFPs=",
+        "lastModified": 1709357749,
+        "narHash": "sha256-I9hqwBcYrpqBe8l4U4rBW1nBzYjawRvz/LsTCxHsVNQ=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "b19f1764dc04fd97d5f592d74a9df72846ae454c",
+        "rev": "f15a5851c48791fb8700015cf67fc9712acc64cd",
         "type": "github"
       },
       "original": {
@@ -822,11 +822,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1709244818,
-        "narHash": "sha256-dCwN7Z4t+pmGuH90Dff5h1qIm2Rh917cZX3GF/W5GYk=",
+        "lastModified": 1709853674,
+        "narHash": "sha256-Cs+4eVrrNuOqWPPdmW/gdkfrwkD99OTadft97Wsev+E=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "5d4e1693cb415e8b76749e833e28f00f14630b87",
+        "rev": "dc2379b89bd00cf7aa661e1b000d2a419843df3f",
         "type": "github"
       },
       "original": {
@@ -847,11 +847,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1708986177,
-        "narHash": "sha256-DgSR8cL6c+rqOwvCFFz9lKBLa6XweNBTMrMhL4X1THI=",
+        "lastModified": 1709335880,
+        "narHash": "sha256-npzdh3iY1Ku0NTFxntvNgMpJbLBIzbDfGtKyTbv90T4=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "a4b4442524b0fc7d4b79383786391427e200c194",
+        "rev": "39928a7f24916b35577864e28e505dda74103fb8",
         "type": "github"
       },
       "original": {
@@ -872,11 +872,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709251411,
-        "narHash": "sha256-gqdsGpxOYeVKL20NkzXhO34j+/acwf6cPP3WyNawO2A=",
+        "lastModified": 1709856615,
+        "narHash": "sha256-FMH6VzbgpnljnRE5s7anzMLy8+JEWoFFOMLgXhhO1W0=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "cc9a9e3382376958422b12170c7edd78087c7a98",
+        "rev": "4e6758ba6616b7b9a251d1815d858d5f4897bea4",
         "type": "github"
       },
       "original": {
@@ -920,11 +920,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1706550542,
-        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
         "type": "github"
       },
       "original": {
@@ -1034,11 +1034,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1709294055,
-        "narHash": "sha256-7EECkQYoNKJZOf2+miJdrMpxpvsn/qZFwIhUI3fQpLs=",
+        "lastModified": 1709780214,
+        "narHash": "sha256-p4iDKdveHMhfGAlpxmkCtfQO3WRzmlD11aIcThwPqhk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ec869190b56a1b4677d24a8bdbcfe80ccea2ece6",
+        "rev": "f945939fd679284d736112d3d5410eb867f3b31c",
         "type": "github"
       },
       "original": {
@@ -1097,11 +1097,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1708943256,
-        "narHash": "sha256-K9VeHrhXsigdhNMZ8hqAk7jtRy4ollqhkYYNZqbfssg=",
+        "lastModified": 1709294055,
+        "narHash": "sha256-7EECkQYoNKJZOf2+miJdrMpxpvsn/qZFwIhUI3fQpLs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fcea2b6260dd566c28c894b4207a5f2b56c2cba3",
+        "rev": "ec869190b56a1b4677d24a8bdbcfe80ccea2ece6",
         "type": "github"
       },
       "original": {
@@ -1113,11 +1113,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1709038661,
-        "narHash": "sha256-Ys611iT6pChGv954aa4f8oKoDKJG3IXjJjPhnj6uaLY=",
+        "lastModified": 1709356872,
+        "narHash": "sha256-mvxCirJbtkP0cZ6ABdwcgTk0u3bgLoIoEFIoYBvD6+4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8520c158aee718c6e87b56881105fc4223c3c723",
+        "rev": "458b097d81f90275b3fdf03796f0563844926708",
         "type": "github"
       },
       "original": {
@@ -1146,11 +1146,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1709187572,
-        "narHash": "sha256-adi0xaaBzrDnN9TzG0WsLb+i5xBdguZbQ8hrwe0Z3r4=",
+        "lastModified": 1709879366,
+        "narHash": "sha256-sRu8LtKcxqjKpCdYUeHAvL48i6eaC9SKzxF+XlqIJsY=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "9553725789be682ecd945a527ec552e489ea8534",
+        "rev": "94cf4adb81158817520e18d2174963d8e1424df9",
         "type": "github"
       },
       "original": {
@@ -1200,11 +1200,11 @@
     "plenary-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1706563407,
-        "narHash": "sha256-AWJHxehKUkEV6N+n78urqHjMVUsMfDK3lvHs/VxhKE8=",
+        "lastModified": 1709720625,
+        "narHash": "sha256-/ltkFqa5MTAI9z8oLv7+5SJ/Qq9l1kkuKGD955NbLi8=",
         "owner": "nvim-lua",
         "repo": "plenary.nvim",
-        "rev": "4f71c0c4a196ceb656c824a70792f3df3ce6bb6d",
+        "rev": "f7adfc4b3f4f91aab6caebf42b3682945fbc35be",
         "type": "github"
       },
       "original": {
@@ -1338,11 +1338,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1709308484,
-        "narHash": "sha256-JyvaDySQp8qhC8u0sswjfPq5HlnK0CN9O7NbqacBgEI=",
+        "lastModified": 1709911615,
+        "narHash": "sha256-CqfStiDkbqBuqExxbocUFKARzGBzFthqhzV1zXl1Pa4=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "001dd498894e4c554e92af507fb27739146c177d",
+        "rev": "19f12173ccb7993f86ea26b0e21bbb883c3b86c7",
         "type": "github"
       },
       "original": {
@@ -1474,11 +1474,11 @@
     "telescope-fzf-native-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1694359266,
-        "narHash": "sha256-Hob1x/jwQYfphYGWQ/i44NVyCM+WFT5/4+J5J4/tLYA=",
+        "lastModified": 1709647247,
+        "narHash": "sha256-rycebls3g0JCHM2+aG7xlJnX7ZPowqviaLbQrFSdflM=",
         "owner": "nvim-telescope",
         "repo": "telescope-fzf-native.nvim",
-        "rev": "6c921ca12321edaa773e324ef64ea301a1d0da62",
+        "rev": "9ef21b2e6bb6ebeaf349a0781745549bbb870d27",
         "type": "github"
       },
       "original": {
@@ -1490,11 +1490,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1709316544,
-        "narHash": "sha256-nn5GvqS7BH2FuTnx2jMkGtBKfFIpn1J2FTXLJYyyIsQ=",
+        "lastModified": 1709849420,
+        "narHash": "sha256-i+pGEMw8MQnFse5WGZdX9MMjEoR4H4rzHswCaT/zoso=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "aa83606299c5beeaf80e656efbf07bde258db7be",
+        "rev": "7472420f8734c710bd7009081cef9b97f08a3821",
         "type": "github"
       },
       "original": {
@@ -1506,11 +1506,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1708837217,
-        "narHash": "sha256-66BJaZJdxtfcXPU4pDVvG2RrTg+1E4YA4SGE7e9X02c=",
+        "lastModified": 1709357380,
+        "narHash": "sha256-XYE+LI9meFwI5VX/dVOm23DywZo2RPkvRj1YUQGJoUo=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "0bb67ef952ea3eb7b1bac9c011281471d99a27bc",
+        "rev": "4adea17610d140a99c313e3f79a9dc01825d59ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/2e88f14a585c014691904ba8fe39e6ea851c9422' (2024-02-24)
  → 'github:tpope/vim-fugitive/41beedabc7e948c787ea5696e04c3544c3674e23' (2024-03-04)
• Updated input 'home-manager':
    'github:nix-community/home-manager/2f3367769a93b226c467551315e9e270c3f78b15' (2024-02-29)
  → 'github:nix-community/home-manager/8b07ca541939211d3cc437ddfd74ebdef3d72471' (2024-03-08)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/16884001b26e6955ff4b88b4dfe4c8986e20f153' (2024-01-25)
  → 'github:hyprwm/contrib/2d4ece4a008feefddc194bde785b1d39f987b5a7' (2024-03-02)
• Updated input 'lsp-signature-nvim':
    'github:ray-x/lsp_signature.nvim/fed2c8389c148ff1dfdcdca63c2b48d08a50dea0' (2023-11-28)
  → 'github:ray-x/lsp_signature.nvim/e92b4e7073345b2a30a56b20db3d541a9aa2771e' (2024-03-04)
• Updated input 'lualine-nvim':
    'github:nvim-lualine/lualine.nvim/7d131a8d3ba5016229e8a1d08bf8782acea98852' (2024-01-25)
  → 'github:nvim-lualine/lualine.nvim/8b56462bfb746760465264de41b4907310f113ec' (2024-03-04)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/f3b3d3446bcbfa62d638b1903ff00a78b2b730a1' (2024-02-15)
  → 'github:L3MON4D3/LuaSnip/a7a4b4682c4b3e2ba82b82a4e6e5f5a0e79dec32' (2024-03-03)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/cc9a9e3382376958422b12170c7edd78087c7a98' (2024-03-01)
  → 'github:nix-community/neovim-nightly-overlay/4e6758ba6616b7b9a251d1815d858d5f4897bea4' (2024-03-08)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/b253292d9c0a5ead9bc98c4e9a26c6312e27d69f' (2024-02-01)
  → 'github:hercules-ci/flake-parts/f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2' (2024-03-01)
• Updated input 'neovim-nightly-overlay/neovim-flake':
    'github:neovim/neovim/5d4e1693cb415e8b76749e833e28f00f14630b87?dir=contrib' (2024-02-29)
  → 'github:neovim/neovim/dc2379b89bd00cf7aa661e1b000d2a419843df3f?dir=contrib' (2024-03-07)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/ec869190b56a1b4677d24a8bdbcfe80ccea2ece6' (2024-03-01)
  → 'github:nixos/nixpkgs/f945939fd679284d736112d3d5410eb867f3b31c' (2024-03-07)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/9553725789be682ecd945a527ec552e489ea8534' (2024-02-29)
  → 'github:neovim/nvim-lspconfig/94cf4adb81158817520e18d2174963d8e1424df9' (2024-03-08)
• Updated input 'plenary-nvim':
    'github:nvim-lua/plenary.nvim/4f71c0c4a196ceb656c824a70792f3df3ce6bb6d' (2024-01-29)
  → 'github:nvim-lua/plenary.nvim/f7adfc4b3f4f91aab6caebf42b3682945fbc35be' (2024-03-06)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/001dd498894e4c554e92af507fb27739146c177d' (2024-03-01)
  → 'github:mrcjkb/rustaceanvim/19f12173ccb7993f86ea26b0e21bbb883c3b86c7' (2024-03-08)
• Updated input 'rustacean-nvim/flake-parts':
    'github:hercules-ci/flake-parts/b253292d9c0a5ead9bc98c4e9a26c6312e27d69f' (2024-02-01)
  → 'github:hercules-ci/flake-parts/f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2' (2024-03-01)
• Updated input 'rustacean-nvim/flake-parts/nixpkgs-lib':
    'github:NixOS/nixpkgs/97b17f32362e475016f942bbdfda4a4a72a8a652?dir=lib' (2024-01-29)
  → 'github:NixOS/nixpkgs/1536926ef5621b09bba54035ae2bb6d806d72ac8?dir=lib' (2024-02-29)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/b19f1764dc04fd97d5f592d74a9df72846ae454c' (2024-02-27)
  → 'github:nvim-neorocks/neorocks/f15a5851c48791fb8700015cf67fc9712acc64cd' (2024-03-02)
• Updated input 'rustacean-nvim/neorocks/flake-utils':
    'github:numtide/flake-utils/1ef2e671c3b0c19053962c07dbda38332dcebf26' (2024-01-15)
  → 'github:numtide/flake-utils/d465f4819400de7c8d874d50b982301f28a84605' (2024-02-28)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:neovim/neovim/a4b4442524b0fc7d4b79383786391427e200c194?dir=contrib' (2024-02-26)
  → 'github:neovim/neovim/39928a7f24916b35577864e28e505dda74103fb8?dir=contrib' (2024-03-01)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/fcea2b6260dd566c28c894b4207a5f2b56c2cba3' (2024-02-26)
  → 'github:nixos/nixpkgs/ec869190b56a1b4677d24a8bdbcfe80ccea2ece6' (2024-03-01)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/8520c158aee718c6e87b56881105fc4223c3c723' (2024-02-27)
  → 'github:nixos/nixpkgs/458b097d81f90275b3fdf03796f0563844926708' (2024-03-02)
• Updated input 'telescope-fzf-native-nvim':
    'github:nvim-telescope/telescope-fzf-native.nvim/6c921ca12321edaa773e324ef64ea301a1d0da62' (2023-09-10)
  → 'github:nvim-telescope/telescope-fzf-native.nvim/9ef21b2e6bb6ebeaf349a0781745549bbb870d27' (2024-03-05)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/aa83606299c5beeaf80e656efbf07bde258db7be' (2024-03-01)
  → 'github:nvim-telescope/telescope.nvim/7472420f8734c710bd7009081cef9b97f08a3821' (2024-03-07)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/0bb67ef952ea3eb7b1bac9c011281471d99a27bc' (2024-02-25)
  → 'github:nvim-tree/nvim-web-devicons/4adea17610d140a99c313e3f79a9dc01825d59ae' (2024-03-02)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/neovim/neovim): [`a4b44425` ➡️ `39928a7f`](https://github.com/neovim/neovim/compare/a4b4442524b0fc7d4b79383786391427e200c194...39928a7f24916b35577864e28e505dda74103fb8) <sub>(2024-02-26 to 2024-03-01)</sub>
 - Updated input [`rustacean-nvim/flake-parts/nixpkgs-lib`](https://github.com/NixOS/nixpkgs): [`97b17f32` ➡️ `1536926e`](https://github.com/NixOS/nixpkgs/compare/97b17f32362e475016f942bbdfda4a4a72a8a652...1536926ef5621b09bba54035ae2bb6d806d72ac8) <sub>(2024-01-29 to 2024-02-29)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`001dd498` ➡️ `19f12173`](https://github.com/mrcjkb/rustaceanvim/compare/001dd498894e4c554e92af507fb27739146c177d...19f12173ccb7993f86ea26b0e21bbb883c3b86c7) <sub>(2024-03-01 to 2024-03-08)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`fcea2b62` ➡️ `ec869190`](https://github.com/nixos/nixpkgs/compare/fcea2b6260dd566c28c894b4207a5f2b56c2cba3...ec869190b56a1b4677d24a8bdbcfe80ccea2ece6) <sub>(2024-02-26 to 2024-03-01)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`b19f1764` ➡️ `f15a5851`](https://github.com/nvim-neorocks/neorocks/compare/b19f1764dc04fd97d5f592d74a9df72846ae454c...f15a5851c48791fb8700015cf67fc9712acc64cd) <sub>(2024-02-27 to 2024-03-02)</sub>
 - Updated input [`lsp-signature-nvim`](https://github.com/ray-x/lsp_signature.nvim): [`fed2c838` ➡️ `e92b4e70`](https://github.com/ray-x/lsp_signature.nvim/compare/fed2c8389c148ff1dfdcdca63c2b48d08a50dea0...e92b4e7073345b2a30a56b20db3d541a9aa2771e) <sub>(2023-11-28 to 2024-03-04)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`2e88f14a` ➡️ `41beedab`](https://github.com/tpope/vim-fugitive/compare/2e88f14a585c014691904ba8fe39e6ea851c9422...41beedabc7e948c787ea5696e04c3544c3674e23) <sub>(2024-02-24 to 2024-03-04)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`cc9a9e33` ➡️ `4e6758ba`](https://github.com/nix-community/neovim-nightly-overlay/compare/cc9a9e3382376958422b12170c7edd78087c7a98...4e6758ba6616b7b9a251d1815d858d5f4897bea4) <sub>(2024-03-01 to 2024-03-08)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`f3b3d344` ➡️ `a7a4b468`](https://github.com/L3MON4D3/LuaSnip/compare/f3b3d3446bcbfa62d638b1903ff00a78b2b730a1...a7a4b4682c4b3e2ba82b82a4e6e5f5a0e79dec32) <sub>(2024-02-15 to 2024-03-03)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`16884001` ➡️ `2d4ece4a`](https://github.com/hyprwm/contrib/compare/16884001b26e6955ff4b88b4dfe4c8986e20f153...2d4ece4a008feefddc194bde785b1d39f987b5a7) <sub>(2024-01-25 to 2024-03-02)</sub>
 - Updated input [`rustacean-nvim/flake-parts`](https://github.com/hercules-ci/flake-parts): [`b253292d` ➡️ `f7b3c975`](https://github.com/hercules-ci/flake-parts/compare/b253292d9c0a5ead9bc98c4e9a26c6312e27d69f...f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2) <sub>(2024-02-01 to 2024-03-01)</sub>
 - Updated input [`plenary-nvim`](https://github.com/nvim-lua/plenary.nvim): [`4f71c0c4` ➡️ `f7adfc4b`](https://github.com/nvim-lua/plenary.nvim/compare/4f71c0c4a196ceb656c824a70792f3df3ce6bb6d...f7adfc4b3f4f91aab6caebf42b3682945fbc35be) <sub>(2024-01-29 to 2024-03-06)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`95537257` ➡️ `94cf4adb`](https://github.com/neovim/nvim-lspconfig/compare/9553725789be682ecd945a527ec552e489ea8534...94cf4adb81158817520e18d2174963d8e1424df9) <sub>(2024-02-29 to 2024-03-08)</sub>
 - Updated input [`telescope-fzf-native-nvim`](https://github.com/nvim-telescope/telescope-fzf-native.nvim): [`6c921ca1` ➡️ `9ef21b2e`](https://github.com/nvim-telescope/telescope-fzf-native.nvim/compare/6c921ca12321edaa773e324ef64ea301a1d0da62...9ef21b2e6bb6ebeaf349a0781745549bbb870d27) <sub>(2023-09-10 to 2024-03-05)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`8520c158` ➡️ `458b097d`](https://github.com/nixos/nixpkgs/compare/8520c158aee718c6e87b56881105fc4223c3c723...458b097d81f90275b3fdf03796f0563844926708) <sub>(2024-02-27 to 2024-03-02)</sub>
 - Updated input [`rustacean-nvim/neorocks/flake-utils`](https://github.com/numtide/flake-utils): [`1ef2e671` ➡️ `d465f481`](https://github.com/numtide/flake-utils/compare/1ef2e671c3b0c19053962c07dbda38332dcebf26...d465f4819400de7c8d874d50b982301f28a84605) <sub>(2024-01-15 to 2024-02-28)</sub>
 - Updated input [`lualine-nvim`](https://github.com/nvim-lualine/lualine.nvim): [`7d131a8d` ➡️ `8b56462b`](https://github.com/nvim-lualine/lualine.nvim/compare/7d131a8d3ba5016229e8a1d08bf8782acea98852...8b56462bfb746760465264de41b4907310f113ec) <sub>(2024-01-25 to 2024-03-04)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`ec869190` ➡️ `f945939f`](https://github.com/nixos/nixpkgs/compare/ec869190b56a1b4677d24a8bdbcfe80ccea2ece6...f945939fd679284d736112d3d5410eb867f3b31c) <sub>(2024-03-01 to 2024-03-07)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`aa836062` ➡️ `7472420f`](https://github.com/nvim-telescope/telescope.nvim/compare/aa83606299c5beeaf80e656efbf07bde258db7be...7472420f8734c710bd7009081cef9b97f08a3821) <sub>(2024-03-01 to 2024-03-07)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-flake`](https://github.com/neovim/neovim): [`5d4e1693` ➡️ `dc2379b8`](https://github.com/neovim/neovim/compare/5d4e1693cb415e8b76749e833e28f00f14630b87...dc2379b89bd00cf7aa661e1b000d2a419843df3f) <sub>(2024-02-29 to 2024-03-07)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`0bb67ef9` ➡️ `4adea176`](https://github.com/nvim-tree/nvim-web-devicons/compare/0bb67ef952ea3eb7b1bac9c011281471d99a27bc...4adea17610d140a99c313e3f79a9dc01825d59ae) <sub>(2024-02-25 to 2024-03-02)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`2f336776` ➡️ `8b07ca54`](https://github.com/nix-community/home-manager/compare/2f3367769a93b226c467551315e9e270c3f78b15...8b07ca541939211d3cc437ddfd74ebdef3d72471) <sub>(2024-02-29 to 2024-03-08)</sub>
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`b253292d` ➡️ `f7b3c975`](https://github.com/hercules-ci/flake-parts/compare/b253292d9c0a5ead9bc98c4e9a26c6312e27d69f...f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2) <sub>(2024-02-01 to 2024-03-01)</sub>