### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1709126324,
-        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -402,11 +402,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1709513879,
-        "narHash": "sha256-DILFvQnXprugbYS9NWsa3elP7/g0jKSFP7MvdCrzfJ8=",
+        "lastModified": 1711041425,
+        "narHash": "sha256-rqaEkm4prxiKnhzZBwRNEVOaFE+zg+zG5gatNAQkecw=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "41beedabc7e948c787ea5696e04c3544c3674e23",
+        "rev": "193ba9b393931bad768c1d2eed688b0bcc240858",
         "type": "github"
       },
       "original": {
@@ -514,11 +514,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1710342888,
-        "narHash": "sha256-pYoG/k3yClSPLa/0ZH7mEStbbH6bxpsBPFgnGS/V/yo=",
+        "lastModified": 1710707879,
+        "narHash": "sha256-Hde3mGfqPYd8U5JExTei+TBHo2DHl+i07+1yEHQj6sw=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "4e348641b8206c3b8d23080999e3ddbe4ca90efc",
+        "rev": "078041e9d060a386b0c9d3a8c7a7b019a35d3fb0",
         "type": "github"
       },
       "original": {
@@ -536,11 +536,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710309369,
-        "narHash": "sha256-pQo1vDEEyULfvTQeqZixryrDVpGICzGBtj4uIfP4cs0=",
+        "lastModified": 1710478346,
+        "narHash": "sha256-Xjf8BdnQG0tLhPMlqQdwCIjOp7Teox0DP3N/jjyiGM4=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "9cc7ed20043adf381f1b8354c54ba667b527d538",
+        "rev": "64e7763d72c1e4c1e5e6472640615b6ae2d40fbf",
         "type": "github"
       },
       "original": {
@@ -556,11 +556,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710527391,
-        "narHash": "sha256-3uM8+g/nb7ROgzSmJwOrKefctZpjR5uBJtUz4lpwWJI=",
+        "lastModified": 1711122977,
+        "narHash": "sha256-EnHux7wf7/7r+YMv8d/Ym1OTllp4sqqq0Bws1a4s2Zo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c781b28add41b74423ab2e64496d4fc91192e13a",
+        "rev": "19b87b9ae6ecfd81104a2a36ef8364f1de1b54b1",
         "type": "github"
       },
       "original": {
@@ -590,11 +590,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1710415616,
-        "narHash": "sha256-1qVByzzCcKoCmP8ReUSAjKU5V9pfTLHQIM4WI1tvQ9E=",
+        "lastModified": 1711036118,
+        "narHash": "sha256-BxWizZAc845ks9BjEXosRjfBv/NMr1WwoORBQuixfII=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "75420d09f93346d9d23d5a1e26b42699f6b66cd6",
+        "rev": "536f00c5895015da1e7aa85bbee9aa6dcd149e69",
         "type": "github"
       },
       "original": {
@@ -639,11 +639,11 @@
     "lsp-signature-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1710061951,
-        "narHash": "sha256-iGLjYeOT7b1XvztRLLrzm6fb54Hkcw1nsU892++D7gg=",
+        "lastModified": 1710647656,
+        "narHash": "sha256-O7y7pcCvF0xUFamG+wMLe4mC6hUQ679rJV+ZUoWB0oY=",
         "owner": "ray-x",
         "repo": "lsp_signature.nvim",
-        "rev": "1b32f64549478efd8f9e0d00517db84cf41aa0ea",
+        "rev": "c6aeb2f1d2538bbdfdaab1664d9d4c3c75aa9db8",
         "type": "github"
       },
       "original": {
@@ -708,11 +708,11 @@
     "lualine-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1710524016,
-        "narHash": "sha256-RWAWTTj6mpksUSn25Ov7OrOc/4XZViFilYp5Svgjv1s=",
+        "lastModified": 1710998293,
+        "narHash": "sha256-+2fi58GolO3e0O7+kl+idNeFuTfJA1b5yCBdY2RnVjA=",
         "owner": "nvim-lualine",
         "repo": "lualine.nvim",
-        "rev": "af4c3cf17206810880d2a93562e0a4c0d901c684",
+        "rev": "b5e8bb642138f787a2c1c5aedc2a78cb2cebbd67",
         "type": "github"
       },
       "original": {
@@ -760,11 +760,11 @@
     "neodev-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1709144748,
-        "narHash": "sha256-VyJTGbWBzGmuEkotKwTxAVpznfrrQ26aaBc31n6ZjlE=",
+        "lastModified": 1711095673,
+        "narHash": "sha256-rQ36aBEvLCq33qnek9oYFKMCoog5Ap51rI9xb+Rj7xw=",
         "owner": "folke",
         "repo": "neodev.nvim",
-        "rev": "84e0290f5600e8b89c0dfcafc864f45496a53400",
+        "rev": "6a533ed9d3435dcaa456380d833ea04da37ea2ed",
         "type": "github"
       },
       "original": {
@@ -782,11 +782,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1709961913,
-        "narHash": "sha256-IRSChjhNfpqWKwiC83knmxJ3NUpgcAk4xj3SB99PVkQ=",
+        "lastModified": 1710566618,
+        "narHash": "sha256-kdgbHV5nFeuQ4sXBQ/RsHFwnOrdls9y/t9xzORfSkQg=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "b6f97791287e1974699fa502590c4c36b6a5faff",
+        "rev": "94ffc4f19b2a1e8f874b1074765de61cf803fa9f",
         "type": "github"
       },
       "original": {
@@ -805,11 +805,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1710457005,
-        "narHash": "sha256-6VuJK8M/Ihm6i+0kzLXHbByIyTbgpPdhVa6VPfiZWF0=",
+        "lastModified": 1711063903,
+        "narHash": "sha256-O0xgUE0BPHiVVoHm/WnRBZMCW5qJSuqPZZhVqF6uZv8=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "60491466f951f93d8d9010645e1dac367f3ea979",
+        "rev": "15c6909bb198ca8a1a22405a4a7e96357716e57e",
         "type": "github"
       },
       "original": {
@@ -830,11 +830,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1709934546,
-        "narHash": "sha256-S24CAQvkeivCFM6tK4D10AEyjsMgE07XVgLIkrh6Ljc=",
+        "lastModified": 1710554218,
+        "narHash": "sha256-LymCZqLO+aJ3Xf5QEwhSfizH1OxoKmvQZluaFomTWRQ=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "a69c72063994f8e9064b6d9c9f280120423897b8",
+        "rev": "59aadf33efc2755ef52ff224e7d279a9ee9cd5dd",
         "type": "github"
       },
       "original": {
@@ -855,11 +855,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710461031,
-        "narHash": "sha256-qo4tdzb645+22HKC9m2vxbu1+KGoq358zggkBlC1sVA=",
+        "lastModified": 1711065810,
+        "narHash": "sha256-QasZbe7PZF/e0i3SAKhKoF6LCXJ2QdtAgbFAdpYCrFA=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "1718bc91d79aed50f87933c8682099948ee4c2ec",
+        "rev": "278fc96760142b5e569636776344f3af16e281ee",
         "type": "github"
       },
       "original": {
@@ -871,11 +871,11 @@
     "nightfox-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1710194326,
-        "narHash": "sha256-9i7Gm3Z/xmA2zDPq8Oez1VXK8EyXvKz3WLS7xH5Yl+0=",
+        "lastModified": 1710800073,
+        "narHash": "sha256-wNLvE2D9WTBIxHw6NZ+J/wvvcBWEJQB1xz1rvxSFIIc=",
         "owner": "EdenEast",
         "repo": "nightfox.nvim",
-        "rev": "a4eb88b2dad3fba5c2d87f82cd15dfb9de73913d",
+        "rev": "e352a32e0f54feb2550ebdab815ae8f7f26ed63b",
         "type": "github"
       },
       "original": {
@@ -1001,11 +1001,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1710503106,
-        "narHash": "sha256-WQenjcuNH9cnEYqh/PFxpmjK9PQnEPGt1Z7TCfYBhXs=",
+        "lastModified": 1711106783,
+        "narHash": "sha256-PDwAcHahc6hEimyrgGmFdft75gmLrJOZ0txX7lFqq+I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b1d47989352fcb722a1f19295a9461ed1ef8435a",
+        "rev": "a3ed7406349a9335cb4c2a71369b697cecd9d351",
         "type": "github"
       },
       "original": {
@@ -1049,11 +1049,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1709780214,
-        "narHash": "sha256-p4iDKdveHMhfGAlpxmkCtfQO3WRzmlD11aIcThwPqhk=",
+        "lastModified": 1710534455,
+        "narHash": "sha256-huQT4Xs0y4EeFKn2BTBVYgEwJSv8SDlm82uWgMnCMmI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f945939fd679284d736112d3d5410eb867f3b31c",
+        "rev": "9af9c1c87ed3e3ed271934cb896e0cdd33dae212",
         "type": "github"
       },
       "original": {
@@ -1065,11 +1065,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1709968316,
-        "narHash": "sha256-4rZEtEDT6jcgRaqxsatBeds7x1PoEiEjb6QNGb4mNrk=",
+        "lastModified": 1710534455,
+        "narHash": "sha256-huQT4Xs0y4EeFKn2BTBVYgEwJSv8SDlm82uWgMnCMmI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e7f98a5f30166cbed344569426850b21e4091d4",
+        "rev": "9af9c1c87ed3e3ed271934cb896e0cdd33dae212",
         "type": "github"
       },
       "original": {
@@ -1098,11 +1098,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1706857187,
-        "narHash": "sha256-FF7OHYUC4VFwFvqWKI/R5BSAC0JL6qFKUS6/XRSd9H8=",
+        "lastModified": 1711120055,
+        "narHash": "sha256-uRQUz2Y07raZ36dR1oWwXfOIkzya6ERkZNNNLh9xJhA=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "04e0ca376d6abdbfc8b52180f8ea236cbfddf782",
+        "rev": "6ed1c93465c33f6a53b4c3f103bf9d1ab696382a",
         "type": "github"
       },
       "original": {
@@ -1114,11 +1114,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1710224960,
-        "narHash": "sha256-b+AVhjKf36Y00YSCgfOn/cg+GYJTs1011KiRAaM1I7o=",
+        "lastModified": 1711089429,
+        "narHash": "sha256-LNiNplctUT31dH94p09+1lxbYaGVioB6zyhr96Yo2hc=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "4bdd3800b4148f670c6cf55ef65f490148eeb550",
+        "rev": "24662f92c18edd397ef12d635b11dbdedef2d094",
         "type": "github"
       },
       "original": {
@@ -1293,11 +1293,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1710468696,
-        "narHash": "sha256-kd0IgnjkLWGgNE1WoY4w6WpTpZBkE/YH6Y1mbupHJFs=",
+        "lastModified": 1710901916,
+        "narHash": "sha256-86+Ej47bhRj1WHtoxVuUih1/wFeosNOC10WuLAVTBOA=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "69a22c2ec63ab375190006751562b62ebb318250",
+        "rev": "597c8d6c7b4433ec4577b73bced1df41c132b077",
         "type": "github"
       },
       "original": {
@@ -1460,11 +1460,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1710533811,
-        "narHash": "sha256-fuX07ITxPGwDFshNbdzSNR5NfyZURXEe/JIb91p3nlw=",
+        "lastModified": 1710983957,
+        "narHash": "sha256-7dNteBl4vCkJCSM9xVO3YwyyGI1A5x2ksFHQlP8wamE=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "e9e01d699843af530ef4ad2c8679a7e273bb3dd1",
+        "rev": "221778e93bfaa58bce4be4e055ed2edecc26f799",
         "type": "github"
       },
       "original": {
@@ -1476,11 +1476,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1710465360,
-        "narHash": "sha256-Y7BL2uIeqFXC/Z69vuEFd0MWwxJr5uthJXpDqElB2So=",
+        "lastModified": 1710551591,
+        "narHash": "sha256-3AKsnCvNiQloFfgFKsAHTga0rEEfL8TGmN0BEeO0EQ0=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "a851380fbea4c1312d11f13d5cdc86a7a19808dd",
+        "rev": "cb0c967c9723a76ccb1be0cc3a9a10e577d2f6ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/41beedabc7e948c787ea5696e04c3544c3674e23' (2024-03-04)
  → 'github:tpope/vim-fugitive/193ba9b393931bad768c1d2eed688b0bcc240858' (2024-03-21)
• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/4e348641b8206c3b8d23080999e3ddbe4ca90efc' (2024-03-13)
  → 'github:lewis6991/gitsigns.nvim/078041e9d060a386b0c9d3a8c7a7b019a35d3fb0' (2024-03-17)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c781b28add41b74423ab2e64496d4fc91192e13a' (2024-03-15)
  → 'github:nix-community/home-manager/19b87b9ae6ecfd81104a2a36ef8364f1de1b54b1' (2024-03-22)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/75420d09f93346d9d23d5a1e26b42699f6b66cd6' (2024-03-14)
  → 'github:hyprwm/contrib/536f00c5895015da1e7aa85bbee9aa6dcd149e69' (2024-03-21)
• Updated input 'lsp-signature-nvim':
    'github:ray-x/lsp_signature.nvim/1b32f64549478efd8f9e0d00517db84cf41aa0ea' (2024-03-10)
  → 'github:ray-x/lsp_signature.nvim/c6aeb2f1d2538bbdfdaab1664d9d4c3c75aa9db8' (2024-03-17)
• Updated input 'lualine-nvim':
    'github:nvim-lualine/lualine.nvim/af4c3cf17206810880d2a93562e0a4c0d901c684' (2024-03-15)
  → 'github:nvim-lualine/lualine.nvim/b5e8bb642138f787a2c1c5aedc2a78cb2cebbd67' (2024-03-21)
• Updated input 'neodev-nvim':
    'github:folke/neodev.nvim/84e0290f5600e8b89c0dfcafc864f45496a53400' (2024-02-28)
  → 'github:folke/neodev.nvim/6a533ed9d3435dcaa456380d833ea04da37ea2ed' (2024-03-22)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/1718bc91d79aed50f87933c8682099948ee4c2ec' (2024-03-15)
  → 'github:nix-community/neovim-nightly-overlay/278fc96760142b5e569636776344f3af16e281ee' (2024-03-22)
• Updated input 'neovim-nightly-overlay/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/9cc7ed20043adf381f1b8354c54ba667b527d538' (2024-03-13)
  → 'github:hercules-ci/hercules-ci-effects/64e7763d72c1e4c1e5e6472640615b6ae2d40fbf' (2024-03-15)
• Updated input 'neovim-nightly-overlay/neovim-flake':
    'github:neovim/neovim/60491466f951f93d8d9010645e1dac367f3ea979?dir=contrib' (2024-03-14)
  → 'github:neovim/neovim/15c6909bb198ca8a1a22405a4a7e96357716e57e?dir=contrib' (2024-03-21)
• Updated input 'nightfox-nvim':
    'github:EdenEast/nightfox.nvim/a4eb88b2dad3fba5c2d87f82cd15dfb9de73913d' (2024-03-11)
  → 'github:EdenEast/nightfox.nvim/e352a32e0f54feb2550ebdab815ae8f7f26ed63b' (2024-03-18)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b1d47989352fcb722a1f19295a9461ed1ef8435a' (2024-03-15)
  → 'github:nixos/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351' (2024-03-22)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/04e0ca376d6abdbfc8b52180f8ea236cbfddf782' (2024-02-02)
  → 'github:hrsh7th/nvim-cmp/6ed1c93465c33f6a53b4c3f103bf9d1ab696382a' (2024-03-22)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/4bdd3800b4148f670c6cf55ef65f490148eeb550' (2024-03-12)
  → 'github:neovim/nvim-lspconfig/24662f92c18edd397ef12d635b11dbdedef2d094' (2024-03-22)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/69a22c2ec63ab375190006751562b62ebb318250' (2024-03-15)
  → 'github:mrcjkb/rustaceanvim/597c8d6c7b4433ec4577b73bced1df41c132b077' (2024-03-20)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/b6f97791287e1974699fa502590c4c36b6a5faff' (2024-03-09)
  → 'github:nvim-neorocks/neorocks/94ffc4f19b2a1e8f874b1074765de61cf803fa9f' (2024-03-16)
• Updated input 'rustacean-nvim/neorocks/flake-utils':
    'github:numtide/flake-utils/d465f4819400de7c8d874d50b982301f28a84605' (2024-02-28)
  → 'github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a' (2024-03-11)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:neovim/neovim/a69c72063994f8e9064b6d9c9f280120423897b8?dir=contrib' (2024-03-08)
  → 'github:neovim/neovim/59aadf33efc2755ef52ff224e7d279a9ee9cd5dd?dir=contrib' (2024-03-16)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/f945939fd679284d736112d3d5410eb867f3b31c' (2024-03-07)
  → 'github:nixos/nixpkgs/9af9c1c87ed3e3ed271934cb896e0cdd33dae212' (2024-03-15)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/0e7f98a5f30166cbed344569426850b21e4091d4' (2024-03-09)
  → 'github:nixos/nixpkgs/9af9c1c87ed3e3ed271934cb896e0cdd33dae212' (2024-03-15)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/e9e01d699843af530ef4ad2c8679a7e273bb3dd1' (2024-03-15)
  → 'github:nvim-telescope/telescope.nvim/221778e93bfaa58bce4be4e055ed2edecc26f799' (2024-03-21)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/a851380fbea4c1312d11f13d5cdc86a7a19808dd' (2024-03-15)
  → 'github:nvim-tree/nvim-web-devicons/cb0c967c9723a76ccb1be0cc3a9a10e577d2f6ec' (2024-03-16)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/neovim/neovim): [`a69c7206` ➡️ `59aadf33`](https://github.com/neovim/neovim/compare/a69c72063994f8e9064b6d9c9f280120423897b8...59aadf33efc2755ef52ff224e7d279a9ee9cd5dd) <sub>(2024-03-08 to 2024-03-16)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`69a22c2e` ➡️ `597c8d6c`](https://github.com/mrcjkb/rustaceanvim/compare/69a22c2ec63ab375190006751562b62ebb318250...597c8d6c7b4433ec4577b73bced1df41c132b077) <sub>(2024-03-15 to 2024-03-20)</sub>
 - Updated input [`neodev-nvim`](https://github.com/folke/neodev.nvim): [`84e0290f` ➡️ `6a533ed9`](https://github.com/folke/neodev.nvim/compare/84e0290f5600e8b89c0dfcafc864f45496a53400...6a533ed9d3435dcaa456380d833ea04da37ea2ed) <sub>(2024-02-28 to 2024-03-22)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`f945939f` ➡️ `9af9c1c8`](https://github.com/nixos/nixpkgs/compare/f945939fd679284d736112d3d5410eb867f3b31c...9af9c1c87ed3e3ed271934cb896e0cdd33dae212) <sub>(2024-03-07 to 2024-03-15)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`b6f97791` ➡️ `94ffc4f1`](https://github.com/nvim-neorocks/neorocks/compare/b6f97791287e1974699fa502590c4c36b6a5faff...94ffc4f19b2a1e8f874b1074765de61cf803fa9f) <sub>(2024-03-09 to 2024-03-16)</sub>
 - Updated input [`nightfox-nvim`](https://github.com/EdenEast/nightfox.nvim): [`a4eb88b2` ➡️ `e352a32e`](https://github.com/EdenEast/nightfox.nvim/compare/a4eb88b2dad3fba5c2d87f82cd15dfb9de73913d...e352a32e0f54feb2550ebdab815ae8f7f26ed63b) <sub>(2024-03-11 to 2024-03-18)</sub>
 - Updated input [`lsp-signature-nvim`](https://github.com/ray-x/lsp_signature.nvim): [`1b32f645` ➡️ `c6aeb2f1`](https://github.com/ray-x/lsp_signature.nvim/compare/1b32f64549478efd8f9e0d00517db84cf41aa0ea...c6aeb2f1d2538bbdfdaab1664d9d4c3c75aa9db8) <sub>(2024-03-10 to 2024-03-17)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`41beedab` ➡️ `193ba9b3`](https://github.com/tpope/vim-fugitive/compare/41beedabc7e948c787ea5696e04c3544c3674e23...193ba9b393931bad768c1d2eed688b0bcc240858) <sub>(2024-03-04 to 2024-03-21)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`1718bc91` ➡️ `278fc967`](https://github.com/nix-community/neovim-nightly-overlay/compare/1718bc91d79aed50f87933c8682099948ee4c2ec...278fc96760142b5e569636776344f3af16e281ee) <sub>(2024-03-15 to 2024-03-22)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`75420d09` ➡️ `536f00c5`](https://github.com/hyprwm/contrib/compare/75420d09f93346d9d23d5a1e26b42699f6b66cd6...536f00c5895015da1e7aa85bbee9aa6dcd149e69) <sub>(2024-03-14 to 2024-03-21)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`4bdd3800` ➡️ `24662f92`](https://github.com/neovim/nvim-lspconfig/compare/4bdd3800b4148f670c6cf55ef65f490148eeb550...24662f92c18edd397ef12d635b11dbdedef2d094) <sub>(2024-03-12 to 2024-03-22)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`04e0ca37` ➡️ `6ed1c934`](https://github.com/hrsh7th/nvim-cmp/compare/04e0ca376d6abdbfc8b52180f8ea236cbfddf782...6ed1c93465c33f6a53b4c3f103bf9d1ab696382a) <sub>(2024-02-02 to 2024-03-22)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`0e7f98a5` ➡️ `9af9c1c8`](https://github.com/nixos/nixpkgs/compare/0e7f98a5f30166cbed344569426850b21e4091d4...9af9c1c87ed3e3ed271934cb896e0cdd33dae212) <sub>(2024-03-09 to 2024-03-15)</sub>
 - Updated input [`rustacean-nvim/neorocks/flake-utils`](https://github.com/numtide/flake-utils): [`d465f481` ➡️ `b1d9ab70`](https://github.com/numtide/flake-utils/compare/d465f4819400de7c8d874d50b982301f28a84605...b1d9ab70662946ef0850d488da1c9019f3a9752a) <sub>(2024-02-28 to 2024-03-11)</sub>
 - Updated input [`neovim-nightly-overlay/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`9cc7ed20` ➡️ `64e7763d`](https://github.com/hercules-ci/hercules-ci-effects/compare/9cc7ed20043adf381f1b8354c54ba667b527d538...64e7763d72c1e4c1e5e6472640615b6ae2d40fbf) <sub>(2024-03-13 to 2024-03-15)</sub>
 - Updated input [`lualine-nvim`](https://github.com/nvim-lualine/lualine.nvim): [`af4c3cf1` ➡️ `b5e8bb64`](https://github.com/nvim-lualine/lualine.nvim/compare/af4c3cf17206810880d2a93562e0a4c0d901c684...b5e8bb642138f787a2c1c5aedc2a78cb2cebbd67) <sub>(2024-03-15 to 2024-03-21)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`4e348641` ➡️ `078041e9`](https://github.com/lewis6991/gitsigns.nvim/compare/4e348641b8206c3b8d23080999e3ddbe4ca90efc...078041e9d060a386b0c9d3a8c7a7b019a35d3fb0) <sub>(2024-03-13 to 2024-03-17)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`b1d47989` ➡️ `a3ed7406`](https://github.com/nixos/nixpkgs/compare/b1d47989352fcb722a1f19295a9461ed1ef8435a...a3ed7406349a9335cb4c2a71369b697cecd9d351) <sub>(2024-03-15 to 2024-03-22)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`e9e01d69` ➡️ `221778e9`](https://github.com/nvim-telescope/telescope.nvim/compare/e9e01d699843af530ef4ad2c8679a7e273bb3dd1...221778e93bfaa58bce4be4e055ed2edecc26f799) <sub>(2024-03-15 to 2024-03-21)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-flake`](https://github.com/neovim/neovim): [`60491466` ➡️ `15c6909b`](https://github.com/neovim/neovim/compare/60491466f951f93d8d9010645e1dac367f3ea979...15c6909bb198ca8a1a22405a4a7e96357716e57e) <sub>(2024-03-14 to 2024-03-21)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`a851380f` ➡️ `cb0c967c`](https://github.com/nvim-tree/nvim-web-devicons/compare/a851380fbea4c1312d11f13d5cdc86a7a19808dd...cb0c967c9723a76ccb1be0cc3a9a10e577d2f6ec) <sub>(2024-03-15 to 2024-03-16)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`c781b28a` ➡️ `19b87b9a`](https://github.com/nix-community/home-manager/compare/c781b28add41b74423ab2e64496d4fc91192e13a...19b87b9ae6ecfd81104a2a36ef8364f1de1b54b1) <sub>(2024-03-15 to 2024-03-22)</sub>