### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -245,11 +245,11 @@
         "systems": "systems_9"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -386,11 +386,11 @@
         "systems": "systems_8"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -402,11 +402,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1711041425,
-        "narHash": "sha256-rqaEkm4prxiKnhzZBwRNEVOaFE+zg+zG5gatNAQkecw=",
+        "lastModified": 1711658626,
+        "narHash": "sha256-/aB2VBIqqAb6nWtEd/XloZelCT0iPXujZQVB9JuNNog=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "193ba9b393931bad768c1d2eed688b0bcc240858",
+        "rev": "a83135b55b018a891e0803199c3d418010a404d8",
         "type": "github"
       },
       "original": {
@@ -453,11 +453,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1708688915,
-        "narHash": "sha256-Vcfbdo2IOEiimRnehGLUM5l2VEIjZYZdKS0sjYWwfb4=",
+        "lastModified": 1710933866,
+        "narHash": "sha256-GtYTuxY6AdFxl3uwFkTkqpvOP4lQLzu2YwqnejhDs1Q=",
         "owner": "mrcjkb",
         "repo": "nix-gen-luarc-json",
-        "rev": "6eb62734dae84e5f79368dfc545b3fff305df754",
+        "rev": "6e8912ea4fbfaa10797caafb1f5628fb4178b6e8",
         "type": "github"
       },
       "original": {
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703887061,
-        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -498,11 +498,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703887061,
-        "narHash": "sha256-gGPa9qWNc6eCXT/+Z5/zMkyYOuRZqeFZBDbopNZQkuY=",
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -514,11 +514,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1710707879,
-        "narHash": "sha256-Hde3mGfqPYd8U5JExTei+TBHo2DHl+i07+1yEHQj6sw=",
+        "lastModified": 1711702445,
+        "narHash": "sha256-aC51sAF+xCIE+k2SkkbbnbTKFWYhL2aPqrRwhX+CMno=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "078041e9d060a386b0c9d3a8c7a7b019a35d3fb0",
+        "rev": "70584ff9aae8078b64430c574079d79620b8f06d",
         "type": "github"
       },
       "original": {
@@ -556,11 +556,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711122977,
-        "narHash": "sha256-EnHux7wf7/7r+YMv8d/Ym1OTllp4sqqq0Bws1a4s2Zo=",
+        "lastModified": 1711625603,
+        "narHash": "sha256-W+9dfqA9bqUIBV5u7jaIARAzMe3kTq/Hp2SpSVXKRQw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "19b87b9ae6ecfd81104a2a36ef8364f1de1b54b1",
+        "rev": "c0ef0dab55611c676ad7539bf4e41b3ec6fa87d2",
         "type": "github"
       },
       "original": {
@@ -760,11 +760,11 @@
     "neodev-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1711095673,
-        "narHash": "sha256-rQ36aBEvLCq33qnek9oYFKMCoog5Ap51rI9xb+Rj7xw=",
+        "lastModified": 1711715247,
+        "narHash": "sha256-mAJOMVN7/xO7ykVNAeTeX+z2A/7yB8zdqlEKHL6Pb74=",
         "owner": "folke",
         "repo": "neodev.nvim",
-        "rev": "6a533ed9d3435dcaa456380d833ea04da37ea2ed",
+        "rev": "ce9a2e8eaba5649b553529c5498acb43a6c317cd",
         "type": "github"
       },
       "original": {
@@ -782,11 +782,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1710566618,
-        "narHash": "sha256-kdgbHV5nFeuQ4sXBQ/RsHFwnOrdls9y/t9xzORfSkQg=",
+        "lastModified": 1711085087,
+        "narHash": "sha256-qfGgoV9AD1vjWIYxpgTKaGgrpjXUBghKsqjz9fO6Ilg=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "94ffc4f19b2a1e8f874b1074765de61cf803fa9f",
+        "rev": "a9381d4efeed2a00fd0968abbf221ab21800236d",
         "type": "github"
       },
       "original": {
@@ -805,11 +805,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1711063903,
-        "narHash": "sha256-O0xgUE0BPHiVVoHm/WnRBZMCW5qJSuqPZZhVqF6uZv8=",
+        "lastModified": 1711669189,
+        "narHash": "sha256-VVRFhOKS/MmhV2u6av2e9Qzg4WE24vEmrW/JKed6tlo=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "15c6909bb198ca8a1a22405a4a7e96357716e57e",
+        "rev": "e2224a7933b6e30ab6efb0b7ad4e3f26da57c226",
         "type": "github"
       },
       "original": {
@@ -830,11 +830,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1710554218,
-        "narHash": "sha256-LymCZqLO+aJ3Xf5QEwhSfizH1OxoKmvQZluaFomTWRQ=",
+        "lastModified": 1711070082,
+        "narHash": "sha256-vfO7iy2rnPOzn3EbgPoFrYO3dJtNGYHSDyBnhTxpRwI=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "59aadf33efc2755ef52ff224e7d279a9ee9cd5dd",
+        "rev": "dc110cba3c0d48d7c9dbb91900f8be0cf6cf0c9b",
         "type": "github"
       },
       "original": {
@@ -855,11 +855,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711065810,
-        "narHash": "sha256-QasZbe7PZF/e0i3SAKhKoF6LCXJ2QdtAgbFAdpYCrFA=",
+        "lastModified": 1711670984,
+        "narHash": "sha256-orA2u5/LqpdPCvYUZnQStarJjjRMylTDYS8JKf97ZfU=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "278fc96760142b5e569636776344f3af16e281ee",
+        "rev": "6a5e80c188d3f3763a624df1610294b4a11764a0",
         "type": "github"
       },
       "original": {
@@ -938,11 +938,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1704874635,
-        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
+        "lastModified": 1710695816,
+        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
+        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
         "type": "github"
       },
       "original": {
@@ -954,11 +954,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1704874635,
-        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
+        "lastModified": 1710695816,
+        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
+        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
         "type": "github"
       },
       "original": {
@@ -1001,11 +1001,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1711106783,
-        "narHash": "sha256-PDwAcHahc6hEimyrgGmFdft75gmLrJOZ0txX7lFqq+I=",
+        "lastModified": 1711715736,
+        "narHash": "sha256-9slQ609YqT9bT/MNX9+5k5jltL9zgpn36DpFB7TkttM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a3ed7406349a9335cb4c2a71369b697cecd9d351",
+        "rev": "807c549feabce7eddbf259dbdcec9e0600a0660d",
         "type": "github"
       },
       "original": {
@@ -1049,11 +1049,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1710534455,
-        "narHash": "sha256-huQT4Xs0y4EeFKn2BTBVYgEwJSv8SDlm82uWgMnCMmI=",
+        "lastModified": 1710889954,
+        "narHash": "sha256-Pr6F5Pmd7JnNEMHHmspZ0qVqIBVxyZ13ik1pJtm2QXk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9af9c1c87ed3e3ed271934cb896e0cdd33dae212",
+        "rev": "7872526e9c5332274ea5932a0c3270d6e4724f3b",
         "type": "github"
       },
       "original": {
@@ -1065,11 +1065,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1710534455,
-        "narHash": "sha256-huQT4Xs0y4EeFKn2BTBVYgEwJSv8SDlm82uWgMnCMmI=",
+        "lastModified": 1711200738,
+        "narHash": "sha256-dkJmk/ET/tRV4007O6kU101UEg1svUwiyk/zEEX9Tdg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9af9c1c87ed3e3ed271934cb896e0cdd33dae212",
+        "rev": "20bc93ca7b2158ebc99b8cef987a2173a81cde35",
         "type": "github"
       },
       "original": {
@@ -1081,11 +1081,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1704842529,
-        "narHash": "sha256-OTeQA+F8d/Evad33JMfuXC89VMetQbsU4qcaePchGr4=",
+        "lastModified": 1710765496,
+        "narHash": "sha256-p7ryWEeQfMwTB6E0wIUd5V2cFTgq+DRRBz2hYGnJZyA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eabe8d3eface69f5bb16c18f8662a702f50c20d5",
+        "rev": "e367f7a1fb93137af22a3908f00b9a35e2d286a7",
         "type": "github"
       },
       "original": {
@@ -1098,11 +1098,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1711120055,
-        "narHash": "sha256-uRQUz2Y07raZ36dR1oWwXfOIkzya6ERkZNNNLh9xJhA=",
+        "lastModified": 1711280674,
+        "narHash": "sha256-VFtf1mI1ucClWzsWn+rf+TlC3ZgkYPiHrPTQZci9zrQ=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "6ed1c93465c33f6a53b4c3f103bf9d1ab696382a",
+        "rev": "97dc716fc914c46577a4f254035ebef1aa72558a",
         "type": "github"
       },
       "original": {
@@ -1114,11 +1114,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1711089429,
-        "narHash": "sha256-LNiNplctUT31dH94p09+1lxbYaGVioB6zyhr96Yo2hc=",
+        "lastModified": 1711258752,
+        "narHash": "sha256-kLL+kw0TaMA4uWC5Rng+v1Enm4N+Te8he/eU/ijQSvA=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "24662f92c18edd397ef12d635b11dbdedef2d094",
+        "rev": "6e5c78ebc9936ca74add66bda22c566f951b6ee5",
         "type": "github"
       },
       "original": {
@@ -1136,11 +1136,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1711133402,
-        "narHash": "sha256-HVA7t/3qOulSrm/6MFCS4HWZImo9+koACaTLbtJEU6Q=",
+        "lastModified": 1711204433,
+        "narHash": "sha256-JR9934Jd4D6zKl3sadCt8L/5ILJs+BUnLgL8fmwGNpg=",
         "owner": "iff",
         "repo": "osh-oxy",
-        "rev": "065fbccdc2e107a614085560ce21d302cd9a1401",
+        "rev": "ac460755a3fd9b38b101050272c45d8151c5c270",
         "type": "github"
       },
       "original": {
@@ -1152,11 +1152,11 @@
     "plenary-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1709720625,
-        "narHash": "sha256-/ltkFqa5MTAI9z8oLv7+5SJ/Qq9l1kkuKGD955NbLi8=",
+        "lastModified": 1711369325,
+        "narHash": "sha256-wM/FuK24NPEyaWntwT+mi2SuPExC/abXDK9c2WvgUBk=",
         "owner": "nvim-lua",
         "repo": "plenary.nvim",
-        "rev": "f7adfc4b3f4f91aab6caebf42b3682945fbc35be",
+        "rev": "8aad4396840be7fc42896e3011751b7609ca4119",
         "type": "github"
       },
       "original": {
@@ -1178,11 +1178,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1708018599,
-        "narHash": "sha256-M+Ng6+SePmA8g06CmUZWi1AjG2tFBX9WCXElBHEKnyM=",
+        "lastModified": 1710923068,
+        "narHash": "sha256-6hOpUiuxuwpXXc/xfJsBUJeqqgGI+JMJuLo45aG3cKc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5df5a70ad7575f6601d91f0efec95dd9bc619431",
+        "rev": "e611897ddfdde3ed3eaac4758635d7177ff78673",
         "type": "github"
       },
       "original": {
@@ -1200,11 +1200,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1708018599,
-        "narHash": "sha256-M+Ng6+SePmA8g06CmUZWi1AjG2tFBX9WCXElBHEKnyM=",
+        "lastModified": 1710923068,
+        "narHash": "sha256-6hOpUiuxuwpXXc/xfJsBUJeqqgGI+JMJuLo45aG3cKc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5df5a70ad7575f6601d91f0efec95dd9bc619431",
+        "rev": "e611897ddfdde3ed3eaac4758635d7177ff78673",
         "type": "github"
       },
       "original": {
@@ -1293,11 +1293,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1710901916,
-        "narHash": "sha256-86+Ej47bhRj1WHtoxVuUih1/wFeosNOC10WuLAVTBOA=",
+        "lastModified": 1711641251,
+        "narHash": "sha256-sWyYEpvXKhYdtGdYobNrSHun4q5Z76UPy6NGnRtv2Qg=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "597c8d6c7b4433ec4577b73bced1df41c132b077",
+        "rev": "b1433cb70569b888d26a26232da93fdbc76cb4a8",
         "type": "github"
       },
       "original": {
@@ -1460,11 +1460,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1710983957,
-        "narHash": "sha256-7dNteBl4vCkJCSM9xVO3YwyyGI1A5x2ksFHQlP8wamE=",
+        "lastModified": 1711597154,
+        "narHash": "sha256-mimZJmyq5K2x6EkMnR5T6Q1lOy4E3YcDKX0W3OR4JXA=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "221778e93bfaa58bce4be4e055ed2edecc26f799",
+        "rev": "b22e6f6896cd64b109bd0807a24098d225d5fb49",
         "type": "github"
       },
       "original": {
@@ -1476,11 +1476,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1710551591,
-        "narHash": "sha256-3AKsnCvNiQloFfgFKsAHTga0rEEfL8TGmN0BEeO0EQ0=",
+        "lastModified": 1711417099,
+        "narHash": "sha256-G8URFQdABLf3ptj+9kwSFGXly9D+4lkt3SXfbhVDH6g=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "cb0c967c9723a76ccb1be0cc3a9a10e577d2f6ec",
+        "rev": "3ee60deaa539360518eaab93a6c701fe9f4d82ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/193ba9b393931bad768c1d2eed688b0bcc240858' (2024-03-21)
  → 'github:tpope/vim-fugitive/a83135b55b018a891e0803199c3d418010a404d8' (2024-03-28)
• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/078041e9d060a386b0c9d3a8c7a7b019a35d3fb0' (2024-03-17)
  → 'github:lewis6991/gitsigns.nvim/70584ff9aae8078b64430c574079d79620b8f06d' (2024-03-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/19b87b9ae6ecfd81104a2a36ef8364f1de1b54b1' (2024-03-22)
  → 'github:nix-community/home-manager/c0ef0dab55611c676ad7539bf4e41b3ec6fa87d2' (2024-03-28)
• Updated input 'neodev-nvim':
    'github:folke/neodev.nvim/6a533ed9d3435dcaa456380d833ea04da37ea2ed' (2024-03-22)
  → 'github:folke/neodev.nvim/ce9a2e8eaba5649b553529c5498acb43a6c317cd' (2024-03-29)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/278fc96760142b5e569636776344f3af16e281ee' (2024-03-22)
  → 'github:nix-community/neovim-nightly-overlay/6a5e80c188d3f3763a624df1610294b4a11764a0' (2024-03-29)
• Updated input 'neovim-nightly-overlay/neovim-flake':
    'github:neovim/neovim/15c6909bb198ca8a1a22405a4a7e96357716e57e?dir=contrib' (2024-03-21)
  → 'github:neovim/neovim/e2224a7933b6e30ab6efb0b7ad4e3f26da57c226?dir=contrib' (2024-03-28)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/a3ed7406349a9335cb4c2a71369b697cecd9d351' (2024-03-22)
  → 'github:nixos/nixpkgs/807c549feabce7eddbf259dbdcec9e0600a0660d' (2024-03-29)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/6ed1c93465c33f6a53b4c3f103bf9d1ab696382a' (2024-03-22)
  → 'github:hrsh7th/nvim-cmp/97dc716fc914c46577a4f254035ebef1aa72558a' (2024-03-24)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/24662f92c18edd397ef12d635b11dbdedef2d094' (2024-03-22)
  → 'github:neovim/nvim-lspconfig/6e5c78ebc9936ca74add66bda22c566f951b6ee5' (2024-03-24)
• Updated input 'osh-oxy':
    'github:iff/osh-oxy/065fbccdc2e107a614085560ce21d302cd9a1401' (2024-03-22)
  → 'github:iff/osh-oxy/ac460755a3fd9b38b101050272c45d8151c5c270' (2024-03-23)
• Updated input 'plenary-nvim':
    'github:nvim-lua/plenary.nvim/f7adfc4b3f4f91aab6caebf42b3682945fbc35be' (2024-03-06)
  → 'github:nvim-lua/plenary.nvim/8aad4396840be7fc42896e3011751b7609ca4119' (2024-03-25)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/597c8d6c7b4433ec4577b73bced1df41c132b077' (2024-03-20)
  → 'github:mrcjkb/rustaceanvim/b1433cb70569b888d26a26232da93fdbc76cb4a8' (2024-03-28)
• Updated input 'rustacean-nvim/gen-luarc':
    'github:mrcjkb/nix-gen-luarc-json/6eb62734dae84e5f79368dfc545b3fff305df754' (2024-02-23)
  → 'github:mrcjkb/nix-gen-luarc-json/6e8912ea4fbfaa10797caafb1f5628fb4178b6e8' (2024-03-20)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/94ffc4f19b2a1e8f874b1074765de61cf803fa9f' (2024-03-16)
  → 'github:nvim-neorocks/neorocks/a9381d4efeed2a00fd0968abbf221ab21800236d' (2024-03-22)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:neovim/neovim/59aadf33efc2755ef52ff224e7d279a9ee9cd5dd?dir=contrib' (2024-03-16)
  → 'github:neovim/neovim/dc110cba3c0d48d7c9dbb91900f8be0cf6cf0c9b?dir=contrib' (2024-03-22)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/9af9c1c87ed3e3ed271934cb896e0cdd33dae212' (2024-03-15)
  → 'github:nixos/nixpkgs/7872526e9c5332274ea5932a0c3270d6e4724f3b' (2024-03-19)
• Updated input 'rustacean-nvim/neorocks/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/5df5a70ad7575f6601d91f0efec95dd9bc619431' (2024-02-15)
  → 'github:cachix/pre-commit-hooks.nix/e611897ddfdde3ed3eaac4758635d7177ff78673' (2024-03-20)
• Updated input 'rustacean-nvim/neorocks/pre-commit-hooks/flake-utils':
    'github:numtide/flake-utils/4022d587cbbfd70fe950c1e2083a02621806a725' (2023-12-04)
  → 'github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a' (2024-03-11)
• Updated input 'rustacean-nvim/neorocks/pre-commit-hooks/gitignore':
    'github:hercules-ci/gitignore.nix/43e1aa1308018f37118e34d3a9cb4f5e75dc11d5' (2023-12-29)
  → 'github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394' (2024-02-28)
• Updated input 'rustacean-nvim/neorocks/pre-commit-hooks/nixpkgs-stable':
    'github:NixOS/nixpkgs/3dc440faeee9e889fe2d1b4d25ad0f430d449356' (2024-01-10)
  → 'github:NixOS/nixpkgs/614b4613980a522ba49f0d194531beddbb7220d3' (2024-03-17)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/9af9c1c87ed3e3ed271934cb896e0cdd33dae212' (2024-03-15)
  → 'github:nixos/nixpkgs/20bc93ca7b2158ebc99b8cef987a2173a81cde35' (2024-03-23)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/5df5a70ad7575f6601d91f0efec95dd9bc619431' (2024-02-15)
  → 'github:cachix/pre-commit-hooks.nix/e611897ddfdde3ed3eaac4758635d7177ff78673' (2024-03-20)
• Updated input 'rustacean-nvim/pre-commit-hooks/flake-utils':
    'github:numtide/flake-utils/4022d587cbbfd70fe950c1e2083a02621806a725' (2023-12-04)
  → 'github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a' (2024-03-11)
• Updated input 'rustacean-nvim/pre-commit-hooks/gitignore':
    'github:hercules-ci/gitignore.nix/43e1aa1308018f37118e34d3a9cb4f5e75dc11d5' (2023-12-29)
  → 'github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394' (2024-02-28)
• Updated input 'rustacean-nvim/pre-commit-hooks/nixpkgs':
    'github:NixOS/nixpkgs/eabe8d3eface69f5bb16c18f8662a702f50c20d5' (2024-01-09)
  → 'github:NixOS/nixpkgs/e367f7a1fb93137af22a3908f00b9a35e2d286a7' (2024-03-18)
• Updated input 'rustacean-nvim/pre-commit-hooks/nixpkgs-stable':
    'github:NixOS/nixpkgs/3dc440faeee9e889fe2d1b4d25ad0f430d449356' (2024-01-10)
  → 'github:NixOS/nixpkgs/614b4613980a522ba49f0d194531beddbb7220d3' (2024-03-17)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/221778e93bfaa58bce4be4e055ed2edecc26f799' (2024-03-21)
  → 'github:nvim-telescope/telescope.nvim/b22e6f6896cd64b109bd0807a24098d225d5fb49' (2024-03-28)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/cb0c967c9723a76ccb1be0cc3a9a10e577d2f6ec' (2024-03-16)
  → 'github:nvim-tree/nvim-web-devicons/3ee60deaa539360518eaab93a6c701fe9f4d82ef' (2024-03-26)

```

</p></details>

 - Updated input [`rustacean-nvim/pre-commit-hooks/nixpkgs`](https://github.com/NixOS/nixpkgs): [`eabe8d3e` ➡️ `e367f7a1`](https://github.com/NixOS/nixpkgs/compare/eabe8d3eface69f5bb16c18f8662a702f50c20d5...e367f7a1fb93137af22a3908f00b9a35e2d286a7) <sub>(2024-01-09 to 2024-03-18)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/neovim/neovim): [`59aadf33` ➡️ `dc110cba`](https://github.com/neovim/neovim/compare/59aadf33efc2755ef52ff224e7d279a9ee9cd5dd...dc110cba3c0d48d7c9dbb91900f8be0cf6cf0c9b) <sub>(2024-03-16 to 2024-03-22)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`597c8d6c` ➡️ `b1433cb7`](https://github.com/mrcjkb/rustaceanvim/compare/597c8d6c7b4433ec4577b73bced1df41c132b077...b1433cb70569b888d26a26232da93fdbc76cb4a8) <sub>(2024-03-20 to 2024-03-28)</sub>
 - Updated input [`neodev-nvim`](https://github.com/folke/neodev.nvim): [`6a533ed9` ➡️ `ce9a2e8e`](https://github.com/folke/neodev.nvim/compare/6a533ed9d3435dcaa456380d833ea04da37ea2ed...ce9a2e8eaba5649b553529c5498acb43a6c317cd) <sub>(2024-03-22 to 2024-03-29)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`9af9c1c8` ➡️ `7872526e`](https://github.com/nixos/nixpkgs/compare/9af9c1c87ed3e3ed271934cb896e0cdd33dae212...7872526e9c5332274ea5932a0c3270d6e4724f3b) <sub>(2024-03-15 to 2024-03-19)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`94ffc4f1` ➡️ `a9381d4e`](https://github.com/nvim-neorocks/neorocks/compare/94ffc4f19b2a1e8f874b1074765de61cf803fa9f...a9381d4efeed2a00fd0968abbf221ab21800236d) <sub>(2024-03-16 to 2024-03-22)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`193ba9b3` ➡️ `a83135b5`](https://github.com/tpope/vim-fugitive/compare/193ba9b393931bad768c1d2eed688b0bcc240858...a83135b55b018a891e0803199c3d418010a404d8) <sub>(2024-03-21 to 2024-03-28)</sub>
 - Updated input [`rustacean-nvim/neorocks/pre-commit-hooks/flake-utils`](https://github.com/numtide/flake-utils): [`4022d587` ➡️ `b1d9ab70`](https://github.com/numtide/flake-utils/compare/4022d587cbbfd70fe950c1e2083a02621806a725...b1d9ab70662946ef0850d488da1c9019f3a9752a) <sub>(2023-12-04 to 2024-03-11)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`278fc967` ➡️ `6a5e80c1`](https://github.com/nix-community/neovim-nightly-overlay/compare/278fc96760142b5e569636776344f3af16e281ee...6a5e80c188d3f3763a624df1610294b4a11764a0) <sub>(2024-03-22 to 2024-03-29)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks/flake-utils`](https://github.com/numtide/flake-utils): [`4022d587` ➡️ `b1d9ab70`](https://github.com/numtide/flake-utils/compare/4022d587cbbfd70fe950c1e2083a02621806a725...b1d9ab70662946ef0850d488da1c9019f3a9752a) <sub>(2023-12-04 to 2024-03-11)</sub>
 - Updated input [`rustacean-nvim/neorocks/pre-commit-hooks/gitignore`](https://github.com/hercules-ci/gitignore.nix): [`43e1aa13` ➡️ `637db329`](https://github.com/hercules-ci/gitignore.nix/compare/43e1aa1308018f37118e34d3a9cb4f5e75dc11d5...637db329424fd7e46cf4185293b9cc8c88c95394) <sub>(2023-12-29 to 2024-02-28)</sub>
 - Updated input [`plenary-nvim`](https://github.com/nvim-lua/plenary.nvim): [`f7adfc4b` ➡️ `8aad4396`](https://github.com/nvim-lua/plenary.nvim/compare/f7adfc4b3f4f91aab6caebf42b3682945fbc35be...8aad4396840be7fc42896e3011751b7609ca4119) <sub>(2024-03-06 to 2024-03-25)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`24662f92` ➡️ `6e5c78eb`](https://github.com/neovim/nvim-lspconfig/compare/24662f92c18edd397ef12d635b11dbdedef2d094...6e5c78ebc9936ca74add66bda22c566f951b6ee5) <sub>(2024-03-22 to 2024-03-24)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`6ed1c934` ➡️ `97dc716f`](https://github.com/hrsh7th/nvim-cmp/compare/6ed1c93465c33f6a53b4c3f103bf9d1ab696382a...97dc716fc914c46577a4f254035ebef1aa72558a) <sub>(2024-03-22 to 2024-03-24)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`5df5a70a` ➡️ `e611897d`](https://github.com/cachix/pre-commit-hooks.nix/compare/5df5a70ad7575f6601d91f0efec95dd9bc619431...e611897ddfdde3ed3eaac4758635d7177ff78673) <sub>(2024-02-15 to 2024-03-20)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`9af9c1c8` ➡️ `20bc93ca`](https://github.com/nixos/nixpkgs/compare/9af9c1c87ed3e3ed271934cb896e0cdd33dae212...20bc93ca7b2158ebc99b8cef987a2173a81cde35) <sub>(2024-03-15 to 2024-03-23)</sub>
 - Updated input [`rustacean-nvim/neorocks/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`5df5a70a` ➡️ `e611897d`](https://github.com/cachix/pre-commit-hooks.nix/compare/5df5a70ad7575f6601d91f0efec95dd9bc619431...e611897ddfdde3ed3eaac4758635d7177ff78673) <sub>(2024-02-15 to 2024-03-20)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`078041e9` ➡️ `70584ff9`](https://github.com/lewis6991/gitsigns.nvim/compare/078041e9d060a386b0c9d3a8c7a7b019a35d3fb0...70584ff9aae8078b64430c574079d79620b8f06d) <sub>(2024-03-17 to 2024-03-29)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks/gitignore`](https://github.com/hercules-ci/gitignore.nix): [`43e1aa13` ➡️ `637db329`](https://github.com/hercules-ci/gitignore.nix/compare/43e1aa1308018f37118e34d3a9cb4f5e75dc11d5...637db329424fd7e46cf4185293b9cc8c88c95394) <sub>(2023-12-29 to 2024-02-28)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`a3ed7406` ➡️ `807c549f`](https://github.com/nixos/nixpkgs/compare/a3ed7406349a9335cb4c2a71369b697cecd9d351...807c549feabce7eddbf259dbdcec9e0600a0660d) <sub>(2024-03-22 to 2024-03-29)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`221778e9` ➡️ `b22e6f68`](https://github.com/nvim-telescope/telescope.nvim/compare/221778e93bfaa58bce4be4e055ed2edecc26f799...b22e6f6896cd64b109bd0807a24098d225d5fb49) <sub>(2024-03-21 to 2024-03-28)</sub>
 - Updated input [`rustacean-nvim/neorocks/pre-commit-hooks/nixpkgs-stable`](https://github.com/NixOS/nixpkgs): [`3dc440fa` ➡️ `614b4613`](https://github.com/NixOS/nixpkgs/compare/3dc440faeee9e889fe2d1b4d25ad0f430d449356...614b4613980a522ba49f0d194531beddbb7220d3) <sub>(2024-01-10 to 2024-03-17)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-flake`](https://github.com/neovim/neovim): [`15c6909b` ➡️ `e2224a79`](https://github.com/neovim/neovim/compare/15c6909bb198ca8a1a22405a4a7e96357716e57e...e2224a7933b6e30ab6efb0b7ad4e3f26da57c226) <sub>(2024-03-21 to 2024-03-28)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`cb0c967c` ➡️ `3ee60dea`](https://github.com/nvim-tree/nvim-web-devicons/compare/cb0c967c9723a76ccb1be0cc3a9a10e577d2f6ec...3ee60deaa539360518eaab93a6c701fe9f4d82ef) <sub>(2024-03-16 to 2024-03-26)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`19b87b9a` ➡️ `c0ef0dab`](https://github.com/nix-community/home-manager/compare/19b87b9ae6ecfd81104a2a36ef8364f1de1b54b1...c0ef0dab55611c676ad7539bf4e41b3ec6fa87d2) <sub>(2024-03-22 to 2024-03-28)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks/nixpkgs-stable`](https://github.com/NixOS/nixpkgs): [`3dc440fa` ➡️ `614b4613`](https://github.com/NixOS/nixpkgs/compare/3dc440faeee9e889fe2d1b4d25ad0f430d449356...614b4613980a522ba49f0d194531beddbb7220d3) <sub>(2024-01-10 to 2024-03-17)</sub>
 - Updated input [`rustacean-nvim/gen-luarc`](https://github.com/mrcjkb/nix-gen-luarc-json): [`6eb62734` ➡️ `6e8912ea`](https://github.com/mrcjkb/nix-gen-luarc-json/compare/6eb62734dae84e5f79368dfc545b3fff305df754...6e8912ea4fbfaa10797caafb1f5628fb4178b6e8) <sub>(2024-02-23 to 2024-03-20)</sub>
 - Updated input [`osh-oxy`](https://github.com/iff/osh-oxy): [`065fbccd` ➡️ `ac460755`](https://github.com/iff/osh-oxy/compare/065fbccdc2e107a614085560ce21d302cd9a1401...ac460755a3fd9b38b101050272c45d8151c5c270) <sub>(2024-03-22 to 2024-03-23)</sub>