### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709336216,
-        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
         "type": "github"
       },
       "original": {
@@ -402,11 +402,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1711658626,
-        "narHash": "sha256-/aB2VBIqqAb6nWtEd/XloZelCT0iPXujZQVB9JuNNog=",
+        "lastModified": 1711915965,
+        "narHash": "sha256-nbYPtHxbS7kaCTv/RTnjZ/tyi5lTaSi7ByOQDLBW/zM=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "a83135b55b018a891e0803199c3d418010a404d8",
+        "rev": "c0b03f1cac242d96837326d300f42a660306fc1a",
         "type": "github"
       },
       "original": {
@@ -514,11 +514,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1711702445,
-        "narHash": "sha256-aC51sAF+xCIE+k2SkkbbnbTKFWYhL2aPqrRwhX+CMno=",
+        "lastModified": 1712330088,
+        "narHash": "sha256-Ob9TixRbr0RswCeQrDbFGRyCyvuoaOJMzZhzevly/mQ=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "70584ff9aae8078b64430c574079d79620b8f06d",
+        "rev": "81369ed5405ec0c5d55a9608b495dbf827415116",
         "type": "github"
       },
       "original": {
@@ -556,11 +556,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711625603,
-        "narHash": "sha256-W+9dfqA9bqUIBV5u7jaIARAzMe3kTq/Hp2SpSVXKRQw=",
+        "lastModified": 1712317700,
+        "narHash": "sha256-rnkQ6qMhlxfjpCECkTMlFXHU/88QvC5KpdJWq5H6F1E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c0ef0dab55611c676ad7539bf4e41b3ec6fa87d2",
+        "rev": "782eed8bb64b27acaeb7c17be4a095c85e65717f",
         "type": "github"
       },
       "original": {
@@ -708,11 +708,11 @@
     "lualine-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1710998293,
-        "narHash": "sha256-+2fi58GolO3e0O7+kl+idNeFuTfJA1b5yCBdY2RnVjA=",
+        "lastModified": 1712310396,
+        "narHash": "sha256-WcH2dWdRDgMkwBQhcgT+Z/ArMdm+VbRhmQftx4t2kNI=",
         "owner": "nvim-lualine",
         "repo": "lualine.nvim",
-        "rev": "b5e8bb642138f787a2c1c5aedc2a78cb2cebbd67",
+        "rev": "0a5a66803c7407767b799067986b4dc3036e1983",
         "type": "github"
       },
       "original": {
@@ -724,11 +724,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1709453917,
-        "narHash": "sha256-oyMykjBLkk/9S5AutnPKL+DKgfW59TS+kGUE2GsVbHk=",
+        "lastModified": 1712299925,
+        "narHash": "sha256-4PMfcwCo4EiAvrEVpNfQYIZJXnZVKsb5xUdtJtbUEho=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "a7a4b4682c4b3e2ba82b82a4e6e5f5a0e79dec32",
+        "rev": "be7be2ca7f55bb881a7ffc16b2efa5af034ab06b",
         "type": "github"
       },
       "original": {
@@ -782,11 +782,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1711085087,
-        "narHash": "sha256-qfGgoV9AD1vjWIYxpgTKaGgrpjXUBghKsqjz9fO6Ilg=",
+        "lastModified": 1711349030,
+        "narHash": "sha256-2JXpaRqWcC63lfTcP51YUqg/qgp2a/e7VgQTWPazsrk=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "a9381d4efeed2a00fd0968abbf221ab21800236d",
+        "rev": "93a0d0791b5bf1ff79e961570506924f7edbd7f4",
         "type": "github"
       },
       "original": {
@@ -805,11 +805,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1711669189,
-        "narHash": "sha256-VVRFhOKS/MmhV2u6av2e9Qzg4WE24vEmrW/JKed6tlo=",
+        "lastModified": 1712335782,
+        "narHash": "sha256-ZHZPTruLB6OP8DCmBBzhIHtPNN5I2V4lE0iqFOStdhs=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "e2224a7933b6e30ab6efb0b7ad4e3f26da57c226",
+        "rev": "7098341387346a95647e3521a4c30e904fc0ac50",
         "type": "github"
       },
       "original": {
@@ -855,11 +855,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711670984,
-        "narHash": "sha256-orA2u5/LqpdPCvYUZnQStarJjjRMylTDYS8JKf97ZfU=",
+        "lastModified": 1712341694,
+        "narHash": "sha256-MW884/mKqEn07lecyjUrSS1G7w7iWI4iu+wJMigtS2Q=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "6a5e80c188d3f3763a624df1610294b4a11764a0",
+        "rev": "4eeae4a14ac05f16d1841cf93f956ad3ae71ec5f",
         "type": "github"
       },
       "original": {
@@ -1065,11 +1065,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1711200738,
-        "narHash": "sha256-dkJmk/ET/tRV4007O6kU101UEg1svUwiyk/zEEX9Tdg=",
+        "lastModified": 1711715736,
+        "narHash": "sha256-9slQ609YqT9bT/MNX9+5k5jltL9zgpn36DpFB7TkttM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "20bc93ca7b2158ebc99b8cef987a2173a81cde35",
+        "rev": "807c549feabce7eddbf259dbdcec9e0600a0660d",
         "type": "github"
       },
       "original": {
@@ -1098,11 +1098,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1711280674,
-        "narHash": "sha256-VFtf1mI1ucClWzsWn+rf+TlC3ZgkYPiHrPTQZci9zrQ=",
+        "lastModified": 1712041554,
+        "narHash": "sha256-DBxQTmwuEGj2g7LP7d1PJk/SyO0iJq2CIIHsFh0QJ4I=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "97dc716fc914c46577a4f254035ebef1aa72558a",
+        "rev": "ce16de5665c766f39c271705b17fff06f7bcb84f",
         "type": "github"
       },
       "original": {
@@ -1114,11 +1114,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1711258752,
-        "narHash": "sha256-kLL+kw0TaMA4uWC5Rng+v1Enm4N+Te8he/eU/ijQSvA=",
+        "lastModified": 1712317013,
+        "narHash": "sha256-Rsuq3P3aSg03ErqMCaqgFxPhlKO5NTrFA4wphpqVoD0=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "6e5c78ebc9936ca74add66bda22c566f951b6ee5",
+        "rev": "e13ef0c5c8ccdbb9c84682522d6ad5923a65c1a8",
         "type": "github"
       },
       "original": {
@@ -1200,11 +1200,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1710923068,
-        "narHash": "sha256-6hOpUiuxuwpXXc/xfJsBUJeqqgGI+JMJuLo45aG3cKc=",
+        "lastModified": 1711760932,
+        "narHash": "sha256-DqUTQ2iAAqSDwMhKBqvi24v0Oc7pD3LCK/0FCG//TdA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e611897ddfdde3ed3eaac4758635d7177ff78673",
+        "rev": "c11e43aed6f17336c25cd120eac886b96c455731",
         "type": "github"
       },
       "original": {
@@ -1293,11 +1293,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1711641251,
-        "narHash": "sha256-sWyYEpvXKhYdtGdYobNrSHun4q5Z76UPy6NGnRtv2Qg=",
+        "lastModified": 1712253243,
+        "narHash": "sha256-4bGt7ZPCv7JKfPsY8MpZOVBnXJ4emtINLcmuBWMEhmA=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "b1433cb70569b888d26a26232da93fdbc76cb4a8",
+        "rev": "dfa964bdef1a856052eed58d2ccbd199e927e197",
         "type": "github"
       },
       "original": {
@@ -1460,11 +1460,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1711597154,
-        "narHash": "sha256-mimZJmyq5K2x6EkMnR5T6Q1lOy4E3YcDKX0W3OR4JXA=",
+        "lastModified": 1712279028,
+        "narHash": "sha256-um0vpDgI3kBb0lRr9HKZKQXUMUU1aNQiLwSEhxttLW8=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "b22e6f6896cd64b109bd0807a24098d225d5fb49",
+        "rev": "d26b666b45e5dde23332e4bde1227677f2d92e31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/a83135b55b018a891e0803199c3d418010a404d8' (2024-03-28)
  → 'github:tpope/vim-fugitive/c0b03f1cac242d96837326d300f42a660306fc1a' (2024-03-31)
• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/70584ff9aae8078b64430c574079d79620b8f06d' (2024-03-29)
  → 'github:lewis6991/gitsigns.nvim/81369ed5405ec0c5d55a9608b495dbf827415116' (2024-04-05)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c0ef0dab55611c676ad7539bf4e41b3ec6fa87d2' (2024-03-28)
  → 'github:nix-community/home-manager/782eed8bb64b27acaeb7c17be4a095c85e65717f' (2024-04-05)
• Updated input 'lualine-nvim':
    'github:nvim-lualine/lualine.nvim/b5e8bb642138f787a2c1c5aedc2a78cb2cebbd67' (2024-03-21)
  → 'github:nvim-lualine/lualine.nvim/0a5a66803c7407767b799067986b4dc3036e1983' (2024-04-05)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/a7a4b4682c4b3e2ba82b82a4e6e5f5a0e79dec32' (2024-03-03)
  → 'github:L3MON4D3/LuaSnip/be7be2ca7f55bb881a7ffc16b2efa5af034ab06b' (2024-04-05)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/6a5e80c188d3f3763a624df1610294b4a11764a0' (2024-03-29)
  → 'github:nix-community/neovim-nightly-overlay/4eeae4a14ac05f16d1841cf93f956ad3ae71ec5f' (2024-04-05)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2' (2024-03-01)
  → 'github:hercules-ci/flake-parts/9126214d0a59633752a136528f5f3b9aa8565b7d' (2024-04-01)
• Updated input 'neovim-nightly-overlay/neovim-flake':
    'github:neovim/neovim/e2224a7933b6e30ab6efb0b7ad4e3f26da57c226?dir=contrib' (2024-03-28)
  → 'github:neovim/neovim/7098341387346a95647e3521a4c30e904fc0ac50?dir=contrib' (2024-04-05)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/97dc716fc914c46577a4f254035ebef1aa72558a' (2024-03-24)
  → 'github:hrsh7th/nvim-cmp/ce16de5665c766f39c271705b17fff06f7bcb84f' (2024-04-02)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/6e5c78ebc9936ca74add66bda22c566f951b6ee5' (2024-03-24)
  → 'github:neovim/nvim-lspconfig/e13ef0c5c8ccdbb9c84682522d6ad5923a65c1a8' (2024-04-05)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/b1433cb70569b888d26a26232da93fdbc76cb4a8' (2024-03-28)
  → 'github:mrcjkb/rustaceanvim/dfa964bdef1a856052eed58d2ccbd199e927e197' (2024-04-04)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/a9381d4efeed2a00fd0968abbf221ab21800236d' (2024-03-22)
  → 'github:nvim-neorocks/neorocks/93a0d0791b5bf1ff79e961570506924f7edbd7f4' (2024-03-25)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/20bc93ca7b2158ebc99b8cef987a2173a81cde35' (2024-03-23)
  → 'github:nixos/nixpkgs/807c549feabce7eddbf259dbdcec9e0600a0660d' (2024-03-29)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/e611897ddfdde3ed3eaac4758635d7177ff78673' (2024-03-20)
  → 'github:cachix/pre-commit-hooks.nix/c11e43aed6f17336c25cd120eac886b96c455731' (2024-03-30)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/b22e6f6896cd64b109bd0807a24098d225d5fb49' (2024-03-28)
  → 'github:nvim-telescope/telescope.nvim/d26b666b45e5dde23332e4bde1227677f2d92e31' (2024-04-05)

```

</p></details>

 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`b1433cb7` ➡️ `dfa964bd`](https://github.com/mrcjkb/rustaceanvim/compare/b1433cb70569b888d26a26232da93fdbc76cb4a8...dfa964bdef1a856052eed58d2ccbd199e927e197) <sub>(2024-03-28 to 2024-04-04)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`a9381d4e` ➡️ `93a0d079`](https://github.com/nvim-neorocks/neorocks/compare/a9381d4efeed2a00fd0968abbf221ab21800236d...93a0d0791b5bf1ff79e961570506924f7edbd7f4) <sub>(2024-03-22 to 2024-03-25)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`a83135b5` ➡️ `c0b03f1c`](https://github.com/tpope/vim-fugitive/compare/a83135b55b018a891e0803199c3d418010a404d8...c0b03f1cac242d96837326d300f42a660306fc1a) <sub>(2024-03-28 to 2024-03-31)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`6a5e80c1` ➡️ `4eeae4a1`](https://github.com/nix-community/neovim-nightly-overlay/compare/6a5e80c188d3f3763a624df1610294b4a11764a0...4eeae4a14ac05f16d1841cf93f956ad3ae71ec5f) <sub>(2024-03-29 to 2024-04-05)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`a7a4b468` ➡️ `be7be2ca`](https://github.com/L3MON4D3/LuaSnip/compare/a7a4b4682c4b3e2ba82b82a4e6e5f5a0e79dec32...be7be2ca7f55bb881a7ffc16b2efa5af034ab06b) <sub>(2024-03-03 to 2024-04-05)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`6e5c78eb` ➡️ `e13ef0c5`](https://github.com/neovim/nvim-lspconfig/compare/6e5c78ebc9936ca74add66bda22c566f951b6ee5...e13ef0c5c8ccdbb9c84682522d6ad5923a65c1a8) <sub>(2024-03-24 to 2024-04-05)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`97dc716f` ➡️ `ce16de56`](https://github.com/hrsh7th/nvim-cmp/compare/97dc716fc914c46577a4f254035ebef1aa72558a...ce16de5665c766f39c271705b17fff06f7bcb84f) <sub>(2024-03-24 to 2024-04-02)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`e611897d` ➡️ `c11e43ae`](https://github.com/cachix/pre-commit-hooks.nix/compare/e611897ddfdde3ed3eaac4758635d7177ff78673...c11e43aed6f17336c25cd120eac886b96c455731) <sub>(2024-03-20 to 2024-03-30)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`20bc93ca` ➡️ `807c549f`](https://github.com/nixos/nixpkgs/compare/20bc93ca7b2158ebc99b8cef987a2173a81cde35...807c549feabce7eddbf259dbdcec9e0600a0660d) <sub>(2024-03-23 to 2024-03-29)</sub>
 - Updated input [`lualine-nvim`](https://github.com/nvim-lualine/lualine.nvim): [`b5e8bb64` ➡️ `0a5a6680`](https://github.com/nvim-lualine/lualine.nvim/compare/b5e8bb642138f787a2c1c5aedc2a78cb2cebbd67...0a5a66803c7407767b799067986b4dc3036e1983) <sub>(2024-03-21 to 2024-04-05)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`70584ff9` ➡️ `81369ed5`](https://github.com/lewis6991/gitsigns.nvim/compare/70584ff9aae8078b64430c574079d79620b8f06d...81369ed5405ec0c5d55a9608b495dbf827415116) <sub>(2024-03-29 to 2024-04-05)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`b22e6f68` ➡️ `d26b666b`](https://github.com/nvim-telescope/telescope.nvim/compare/b22e6f6896cd64b109bd0807a24098d225d5fb49...d26b666b45e5dde23332e4bde1227677f2d92e31) <sub>(2024-03-28 to 2024-04-05)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-flake`](https://github.com/neovim/neovim): [`e2224a79` ➡️ `70983413`](https://github.com/neovim/neovim/compare/e2224a7933b6e30ab6efb0b7ad4e3f26da57c226...7098341387346a95647e3521a4c30e904fc0ac50) <sub>(2024-03-28 to 2024-04-05)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`c0ef0dab` ➡️ `782eed8b`](https://github.com/nix-community/home-manager/compare/c0ef0dab55611c676ad7539bf4e41b3ec6fa87d2...782eed8bb64b27acaeb7c17be4a095c85e65717f) <sub>(2024-03-28 to 2024-04-05)</sub>
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`f7b3c975` ➡️ `9126214d`](https://github.com/hercules-ci/flake-parts/compare/f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2...9126214d0a59633752a136528f5f3b9aa8565b7d) <sub>(2024-03-01 to 2024-04-01)</sub>