### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -191,11 +191,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1709336216,
-        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
         "type": "github"
       },
       "original": {
@@ -369,11 +369,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1711915965,
-        "narHash": "sha256-nbYPtHxbS7kaCTv/RTnjZ/tyi5lTaSi7ByOQDLBW/zM=",
+        "lastModified": 1712554826,
+        "narHash": "sha256-pmY1EQbupKvsqok9O5omkOWi0BEZ8df7HL0F7ubdY9Q=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "c0b03f1cac242d96837326d300f42a660306fc1a",
+        "rev": "dac8e5c2d85926df92672bf2afb4fc48656d96c7",
         "type": "github"
       },
       "original": {
@@ -481,11 +481,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1712330088,
-        "narHash": "sha256-Ob9TixRbr0RswCeQrDbFGRyCyvuoaOJMzZhzevly/mQ=",
+        "lastModified": 1712937200,
+        "narHash": "sha256-8pAy6mICiXpUO36ctWXbmRVB7cDSSDIArh9Nq59az9I=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "81369ed5405ec0c5d55a9608b495dbf827415116",
+        "rev": "d96ef3bbff0bdbc3916a220f5c74a04c4db033f2",
         "type": "github"
       },
       "original": {
@@ -523,11 +523,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712317700,
-        "narHash": "sha256-rnkQ6qMhlxfjpCECkTMlFXHU/88QvC5KpdJWq5H6F1E=",
+        "lastModified": 1712759992,
+        "narHash": "sha256-2APpO3ZW4idlgtlb8hB04u/rmIcKA8O7pYqxF66xbNY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "782eed8bb64b27acaeb7c17be4a095c85e65717f",
+        "rev": "31357486b0ef6f4e161e002b6893eeb4fafc3ca9",
         "type": "github"
       },
       "original": {
@@ -557,11 +557,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1711036118,
-        "narHash": "sha256-BxWizZAc845ks9BjEXosRjfBv/NMr1WwoORBQuixfII=",
+        "lastModified": 1712505318,
+        "narHash": "sha256-fzlBLhXUN6y7mzEtcGNRDXxFakBEfaj4Bmj5PuoCNaM=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "536f00c5895015da1e7aa85bbee9aa6dcd149e69",
+        "rev": "5870244b592c22558b658dbaf94f9e41afb0316f",
         "type": "github"
       },
       "original": {
@@ -692,11 +692,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1711349030,
-        "narHash": "sha256-2JXpaRqWcC63lfTcP51YUqg/qgp2a/e7VgQTWPazsrk=",
+        "lastModified": 1712420718,
+        "narHash": "sha256-8EGvWILBdYgKp44LXbgA8/rrLPtbBWAKQnRCb1JmhW0=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "93a0d0791b5bf1ff79e961570506924f7edbd7f4",
+        "rev": "1b7ae79f1121e121cd736fd356d035bb1686280b",
         "type": "github"
       },
       "original": {
@@ -715,11 +715,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1712335782,
-        "narHash": "sha256-ZHZPTruLB6OP8DCmBBzhIHtPNN5I2V4lE0iqFOStdhs=",
+        "lastModified": 1712877603,
+        "narHash": "sha256-8JesAgnsv1bD+xHNoqefz0Gv243wSiCKnzh4rhZLopU=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "7098341387346a95647e3521a4c30e904fc0ac50",
+        "rev": "18ee9f9e7dbbc9709ee9c1572870b4ad31443569",
         "type": "github"
       },
       "original": {
@@ -765,11 +765,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712341694,
-        "narHash": "sha256-MW884/mKqEn07lecyjUrSS1G7w7iWI4iu+wJMigtS2Q=",
+        "lastModified": 1712880226,
+        "narHash": "sha256-2CGLzsFft8zF/gEY4qDN0uAjRCWUqvNJ9yV118NlzTg=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "4eeae4a14ac05f16d1841cf93f956ad3ae71ec5f",
+        "rev": "58d367a1924bf0d02bcc5bd2c5af8ac97f178381",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
     "nightfox-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1710800073,
-        "narHash": "sha256-wNLvE2D9WTBIxHw6NZ+J/wvvcBWEJQB1xz1rvxSFIIc=",
+        "lastModified": 1712950762,
+        "narHash": "sha256-2xdwQObHSKC/N17N2yLMWLHYmGg6nBk18jlMX1OSESY=",
         "owner": "EdenEast",
         "repo": "nightfox.nvim",
-        "rev": "e352a32e0f54feb2550ebdab815ae8f7f26ed63b",
+        "rev": "ce0cdf8538c8c0b9c8fb2884d3d1090c8faf515d",
         "type": "github"
       },
       "original": {
@@ -796,11 +796,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658161305,
-        "narHash": "sha256-X/nhnMCa1Wx4YapsspyAs6QYz6T/85FofrI6NpdPDHg=",
+        "lastModified": 1712163089,
+        "narHash": "sha256-Um+8kTIrC19vD4/lUCN9/cU9kcOsD1O1m+axJqQPyMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e4d49de45a3b5dbcb881656b4e3986e666141ea9",
+        "rev": "fd281bd6b7d3e32ddfa399853946f782553163b5",
         "type": "github"
       },
       "original": {
@@ -813,11 +813,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1709237383,
-        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {
@@ -880,11 +880,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1712757991,
-        "narHash": "sha256-kR7C7Fqt3JP40h0mzmSZeWI5pk1iwqj4CSeGjnUbVHc=",
+        "lastModified": 1712849433,
+        "narHash": "sha256-flQtf/ZPJgkLY/So3Fd+dGilw2DKIsiwgMEn7BbBHL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d6b3ddd253c578a7ab98f8011e59990f21dc3932",
+        "rev": "f173d0881eff3b21ebb29a2ef8bedbc106c86ea5",
         "type": "github"
       },
       "original": {
@@ -944,11 +944,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1711715736,
-        "narHash": "sha256-9slQ609YqT9bT/MNX9+5k5jltL9zgpn36DpFB7TkttM=",
+        "lastModified": 1712420723,
+        "narHash": "sha256-VnG0Eu394Ga2FCe8Q66m6OEQF8iAqjDYsjmtl+N2omk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "807c549feabce7eddbf259dbdcec9e0600a0660d",
+        "rev": "9e7f26f82acb057498335362905fde6fea4ca50a",
         "type": "github"
       },
       "original": {
@@ -993,11 +993,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1712317013,
-        "narHash": "sha256-Rsuq3P3aSg03ErqMCaqgFxPhlKO5NTrFA4wphpqVoD0=",
+        "lastModified": 1712815465,
+        "narHash": "sha256-0X78oc+cGaGoAvLllDgG+VCFOWwDl5U/kSS+uBoVDck=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "e13ef0c5c8ccdbb9c84682522d6ad5923a65c1a8",
+        "rev": "b3014f2209503944f2714cf27c95591433a0c7d8",
         "type": "github"
       },
       "original": {
@@ -1079,11 +1079,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1711760932,
-        "narHash": "sha256-DqUTQ2iAAqSDwMhKBqvi24v0Oc7pD3LCK/0FCG//TdA=",
+        "lastModified": 1712055707,
+        "narHash": "sha256-4XLvuSIDZJGS17xEwSrNuJLL7UjDYKGJSbK1WWX2AK8=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c11e43aed6f17336c25cd120eac886b96c455731",
+        "rev": "e35aed5fda3cc79f88ed7f1795021e559582093a",
         "type": "github"
       },
       "original": {
@@ -1155,11 +1155,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1712253243,
-        "narHash": "sha256-4bGt7ZPCv7JKfPsY8MpZOVBnXJ4emtINLcmuBWMEhmA=",
+        "lastModified": 1712854883,
+        "narHash": "sha256-gG127D4DyLABGHLQVqLG3tO3VlquwYDodcpm/ueRSaM=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "dfa964bdef1a856052eed58d2ccbd199e927e197",
+        "rev": "c1d79cdd069f4d4882eee453a69d55b8bd7c1ba9",
         "type": "github"
       },
       "original": {
@@ -1307,11 +1307,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1712279028,
-        "narHash": "sha256-um0vpDgI3kBb0lRr9HKZKQXUMUU1aNQiLwSEhxttLW8=",
+        "lastModified": 1712712411,
+        "narHash": "sha256-BaXngm6xnwsfuHpdEKzKTZPpmR4WhFoOfG5catQ5qAk=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "d26b666b45e5dde23332e4bde1227677f2d92e31",
+        "rev": "5a701e99906961218b55d7ad6c2a998f066c6fe0",
         "type": "github"
       },
       "original": {
@@ -1323,11 +1323,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1711417099,
-        "narHash": "sha256-G8URFQdABLf3ptj+9kwSFGXly9D+4lkt3SXfbhVDH6g=",
+        "lastModified": 1712684166,
+        "narHash": "sha256-v+dhVbAN2OKLdS5YbSLmZsLijO4meSUBG26R+Ivm/BM=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "3ee60deaa539360518eaab93a6c701fe9f4d82ef",
+        "rev": "6e355632387a085f15a66ad68cf681c1d7374a04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/c0b03f1cac242d96837326d300f42a660306fc1a' (2024-03-31)
  → 'github:tpope/vim-fugitive/dac8e5c2d85926df92672bf2afb4fc48656d96c7' (2024-04-08)
• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/81369ed5405ec0c5d55a9608b495dbf827415116' (2024-04-05)
  → 'github:lewis6991/gitsigns.nvim/d96ef3bbff0bdbc3916a220f5c74a04c4db033f2' (2024-04-12)
• Updated input 'home-manager':
    'github:nix-community/home-manager/782eed8bb64b27acaeb7c17be4a095c85e65717f' (2024-04-05)
  → 'github:nix-community/home-manager/31357486b0ef6f4e161e002b6893eeb4fafc3ca9' (2024-04-10)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/536f00c5895015da1e7aa85bbee9aa6dcd149e69' (2024-03-21)
  → 'github:hyprwm/contrib/5870244b592c22558b658dbaf94f9e41afb0316f' (2024-04-07)
• Updated input 'hypr-contrib/nixpkgs':
    'github:NixOS/nixpkgs/e4d49de45a3b5dbcb881656b4e3986e666141ea9' (2022-07-18)
  → 'github:NixOS/nixpkgs/fd281bd6b7d3e32ddfa399853946f782553163b5' (2024-04-03)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/4eeae4a14ac05f16d1841cf93f956ad3ae71ec5f' (2024-04-05)
  → 'github:nix-community/neovim-nightly-overlay/58d367a1924bf0d02bcc5bd2c5af8ac97f178381' (2024-04-12)
• Updated input 'neovim-nightly-overlay/neovim-flake':
    'github:neovim/neovim/7098341387346a95647e3521a4c30e904fc0ac50?dir=contrib' (2024-04-05)
  → 'github:neovim/neovim/18ee9f9e7dbbc9709ee9c1572870b4ad31443569?dir=contrib' (2024-04-11)
• Updated input 'nightfox-nvim':
    'github:EdenEast/nightfox.nvim/e352a32e0f54feb2550ebdab815ae8f7f26ed63b' (2024-03-18)
  → 'github:EdenEast/nightfox.nvim/ce0cdf8538c8c0b9c8fb2884d3d1090c8faf515d' (2024-04-12)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d6b3ddd253c578a7ab98f8011e59990f21dc3932' (2024-04-10)
  → 'github:nixos/nixpkgs/f173d0881eff3b21ebb29a2ef8bedbc106c86ea5' (2024-04-11)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/e13ef0c5c8ccdbb9c84682522d6ad5923a65c1a8' (2024-04-05)
  → 'github:neovim/nvim-lspconfig/b3014f2209503944f2714cf27c95591433a0c7d8' (2024-04-11)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/dfa964bdef1a856052eed58d2ccbd199e927e197' (2024-04-04)
  → 'github:mrcjkb/rustaceanvim/c1d79cdd069f4d4882eee453a69d55b8bd7c1ba9' (2024-04-11)
• Updated input 'rustacean-nvim/flake-parts':
    'github:hercules-ci/flake-parts/f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2' (2024-03-01)
  → 'github:hercules-ci/flake-parts/9126214d0a59633752a136528f5f3b9aa8565b7d' (2024-04-01)
• Updated input 'rustacean-nvim/flake-parts/nixpkgs-lib':
    'github:NixOS/nixpkgs/1536926ef5621b09bba54035ae2bb6d806d72ac8?dir=lib' (2024-02-29)
  → 'github:NixOS/nixpkgs/d8fe5e6c92d0d190646fb9f1056741a229980089?dir=lib' (2024-03-29)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/93a0d0791b5bf1ff79e961570506924f7edbd7f4' (2024-03-25)
  → 'github:nvim-neorocks/neorocks/1b7ae79f1121e121cd736fd356d035bb1686280b' (2024-04-06)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/807c549feabce7eddbf259dbdcec9e0600a0660d' (2024-03-29)
  → 'github:nixos/nixpkgs/9e7f26f82acb057498335362905fde6fea4ca50a' (2024-04-06)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/c11e43aed6f17336c25cd120eac886b96c455731' (2024-03-30)
  → 'github:cachix/pre-commit-hooks.nix/e35aed5fda3cc79f88ed7f1795021e559582093a' (2024-04-02)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/d26b666b45e5dde23332e4bde1227677f2d92e31' (2024-04-05)
  → 'github:nvim-telescope/telescope.nvim/5a701e99906961218b55d7ad6c2a998f066c6fe0' (2024-04-10)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/3ee60deaa539360518eaab93a6c701fe9f4d82ef' (2024-03-26)
  → 'github:nvim-tree/nvim-web-devicons/6e355632387a085f15a66ad68cf681c1d7374a04' (2024-04-09)

```

</p></details>

 - Updated input [`rustacean-nvim/flake-parts/nixpkgs-lib`](https://github.com/NixOS/nixpkgs): [`1536926e` ➡️ `d8fe5e6c`](https://github.com/NixOS/nixpkgs/compare/1536926ef5621b09bba54035ae2bb6d806d72ac8...d8fe5e6c92d0d190646fb9f1056741a229980089) <sub>(2024-02-29 to 2024-03-29)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`dfa964bd` ➡️ `c1d79cdd`](https://github.com/mrcjkb/rustaceanvim/compare/dfa964bdef1a856052eed58d2ccbd199e927e197...c1d79cdd069f4d4882eee453a69d55b8bd7c1ba9) <sub>(2024-04-04 to 2024-04-11)</sub>
 - Updated input [`hypr-contrib/nixpkgs`](https://github.com/NixOS/nixpkgs): [`e4d49de4` ➡️ `fd281bd6`](https://github.com/NixOS/nixpkgs/compare/e4d49de45a3b5dbcb881656b4e3986e666141ea9...fd281bd6b7d3e32ddfa399853946f782553163b5) <sub>(2022-07-18 to 2024-04-03)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`93a0d079` ➡️ `1b7ae79f`](https://github.com/nvim-neorocks/neorocks/compare/93a0d0791b5bf1ff79e961570506924f7edbd7f4...1b7ae79f1121e121cd736fd356d035bb1686280b) <sub>(2024-03-25 to 2024-04-06)</sub>
 - Updated input [`nightfox-nvim`](https://github.com/EdenEast/nightfox.nvim): [`e352a32e` ➡️ `ce0cdf85`](https://github.com/EdenEast/nightfox.nvim/compare/e352a32e0f54feb2550ebdab815ae8f7f26ed63b...ce0cdf8538c8c0b9c8fb2884d3d1090c8faf515d) <sub>(2024-03-18 to 2024-04-12)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`c0b03f1c` ➡️ `dac8e5c2`](https://github.com/tpope/vim-fugitive/compare/c0b03f1cac242d96837326d300f42a660306fc1a...dac8e5c2d85926df92672bf2afb4fc48656d96c7) <sub>(2024-03-31 to 2024-04-08)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`4eeae4a1` ➡️ `58d367a1`](https://github.com/nix-community/neovim-nightly-overlay/compare/4eeae4a14ac05f16d1841cf93f956ad3ae71ec5f...58d367a1924bf0d02bcc5bd2c5af8ac97f178381) <sub>(2024-04-05 to 2024-04-12)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`536f00c5` ➡️ `5870244b`](https://github.com/hyprwm/contrib/compare/536f00c5895015da1e7aa85bbee9aa6dcd149e69...5870244b592c22558b658dbaf94f9e41afb0316f) <sub>(2024-03-21 to 2024-04-07)</sub>
 - Updated input [`rustacean-nvim/flake-parts`](https://github.com/hercules-ci/flake-parts): [`f7b3c975` ➡️ `9126214d`](https://github.com/hercules-ci/flake-parts/compare/f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2...9126214d0a59633752a136528f5f3b9aa8565b7d) <sub>(2024-03-01 to 2024-04-01)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`e13ef0c5` ➡️ `b3014f22`](https://github.com/neovim/nvim-lspconfig/compare/e13ef0c5c8ccdbb9c84682522d6ad5923a65c1a8...b3014f2209503944f2714cf27c95591433a0c7d8) <sub>(2024-04-05 to 2024-04-11)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`c11e43ae` ➡️ `e35aed5f`](https://github.com/cachix/pre-commit-hooks.nix/compare/c11e43aed6f17336c25cd120eac886b96c455731...e35aed5fda3cc79f88ed7f1795021e559582093a) <sub>(2024-03-30 to 2024-04-02)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`807c549f` ➡️ `9e7f26f8`](https://github.com/nixos/nixpkgs/compare/807c549feabce7eddbf259dbdcec9e0600a0660d...9e7f26f82acb057498335362905fde6fea4ca50a) <sub>(2024-03-29 to 2024-04-06)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`81369ed5` ➡️ `d96ef3bb`](https://github.com/lewis6991/gitsigns.nvim/compare/81369ed5405ec0c5d55a9608b495dbf827415116...d96ef3bbff0bdbc3916a220f5c74a04c4db033f2) <sub>(2024-04-05 to 2024-04-12)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`d6b3ddd2` ➡️ `f173d088`](https://github.com/nixos/nixpkgs/compare/d6b3ddd253c578a7ab98f8011e59990f21dc3932...f173d0881eff3b21ebb29a2ef8bedbc106c86ea5) <sub>(2024-04-10 to 2024-04-11)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`d26b666b` ➡️ `5a701e99`](https://github.com/nvim-telescope/telescope.nvim/compare/d26b666b45e5dde23332e4bde1227677f2d92e31...5a701e99906961218b55d7ad6c2a998f066c6fe0) <sub>(2024-04-05 to 2024-04-10)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-flake`](https://github.com/neovim/neovim): [`70983413` ➡️ `18ee9f9e`](https://github.com/neovim/neovim/compare/7098341387346a95647e3521a4c30e904fc0ac50...18ee9f9e7dbbc9709ee9c1572870b4ad31443569) <sub>(2024-04-05 to 2024-04-11)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`3ee60dea` ➡️ `6e355632`](https://github.com/nvim-tree/nvim-web-devicons/compare/3ee60deaa539360518eaab93a6c701fe9f4d82ef...6e355632387a085f15a66ad68cf681c1d7374a04) <sub>(2024-03-26 to 2024-04-09)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`782eed8b` ➡️ `31357486`](https://github.com/nix-community/home-manager/compare/782eed8bb64b27acaeb7c17be4a095c85e65717f...31357486b0ef6f4e161e002b6893eeb4fafc3ca9) <sub>(2024-04-05 to 2024-04-10)</sub>