### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -245,11 +245,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -317,11 +317,11 @@
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -481,11 +481,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1712937200,
-        "narHash": "sha256-8pAy6mICiXpUO36ctWXbmRVB7cDSSDIArh9Nq59az9I=",
+        "lastModified": 1713431624,
+        "narHash": "sha256-xszsGkEFXHHCY5sFRnbovqlqa5RHqBx5qY0NUc//nkc=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "d96ef3bbff0bdbc3916a220f5c74a04c4db033f2",
+        "rev": "7e38f07cab0e5387f9f41e92474db174a63a4725",
         "type": "github"
       },
       "original": {
@@ -523,11 +523,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712759992,
-        "narHash": "sha256-2APpO3ZW4idlgtlb8hB04u/rmIcKA8O7pYqxF66xbNY=",
+        "lastModified": 1713547559,
+        "narHash": "sha256-zju60y4pyYQoRmqhbgkw+jwmKZReVsCNvb8mZxID2Do=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "31357486b0ef6f4e161e002b6893eeb4fafc3ca9",
+        "rev": "938357cb234e85da37109df2cdd9cc59ab9c1cc0",
         "type": "github"
       },
       "original": {
@@ -654,11 +654,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1712299925,
-        "narHash": "sha256-4PMfcwCo4EiAvrEVpNfQYIZJXnZVKsb5xUdtJtbUEho=",
+        "lastModified": 1713290802,
+        "narHash": "sha256-E1Ov6aF9DJ0poVM6q6jK1ypsJf6cRzHqC2Gi6u9kai0=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "be7be2ca7f55bb881a7ffc16b2efa5af034ab06b",
+        "rev": "03c8e67eb7293c404845b3982db895d59c0d1538",
         "type": "github"
       },
       "original": {
@@ -692,11 +692,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1712420718,
-        "narHash": "sha256-8EGvWILBdYgKp44LXbgA8/rrLPtbBWAKQnRCb1JmhW0=",
+        "lastModified": 1713504178,
+        "narHash": "sha256-3nzJET14rXVGINBPxcxjLAl2h8H6W3cyp/RqUaYkUws=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "1b7ae79f1121e121cd736fd356d035bb1686280b",
+        "rev": "bdc7c0843c8fc9f3d28e088acf4c524430962d03",
         "type": "github"
       },
       "original": {
@@ -715,11 +715,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1712877603,
-        "narHash": "sha256-8JesAgnsv1bD+xHNoqefz0Gv243wSiCKnzh4rhZLopU=",
+        "lastModified": 1713476725,
+        "narHash": "sha256-OBDeB3+2hgWqABtqg+PwfjbWzL49dmJeG32qOEzhtUY=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "18ee9f9e7dbbc9709ee9c1572870b4ad31443569",
+        "rev": "13ebfafc958c6feb4d908eed913c6dc3c6f05b4e",
         "type": "github"
       },
       "original": {
@@ -740,11 +740,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1711070082,
-        "narHash": "sha256-vfO7iy2rnPOzn3EbgPoFrYO3dJtNGYHSDyBnhTxpRwI=",
+        "lastModified": 1713476725,
+        "narHash": "sha256-OBDeB3+2hgWqABtqg+PwfjbWzL49dmJeG32qOEzhtUY=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "dc110cba3c0d48d7c9dbb91900f8be0cf6cf0c9b",
+        "rev": "13ebfafc958c6feb4d908eed913c6dc3c6f05b4e",
         "type": "github"
       },
       "original": {
@@ -765,11 +765,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712880226,
-        "narHash": "sha256-2CGLzsFft8zF/gEY4qDN0uAjRCWUqvNJ9yV118NlzTg=",
+        "lastModified": 1713485028,
+        "narHash": "sha256-bl1EURik5le68rLBcHsfLKyPtEPlumhcA5kKOx88zkQ=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "58d367a1924bf0d02bcc5bd2c5af8ac97f178381",
+        "rev": "403633f6af2703c057707b31b1ca6bec00bdaaca",
         "type": "github"
       },
       "original": {
@@ -880,11 +880,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1712849433,
-        "narHash": "sha256-flQtf/ZPJgkLY/So3Fd+dGilw2DKIsiwgMEn7BbBHL0=",
+        "lastModified": 1713442664,
+        "narHash": "sha256-LoExypse3c/uun/39u4bPTN4wejIF7hNsdITZO41qTw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f173d0881eff3b21ebb29a2ef8bedbc106c86ea5",
+        "rev": "d764f230634fa4f86dc8d01c6af9619c7cc5d225",
         "type": "github"
       },
       "original": {
@@ -928,11 +928,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1710889954,
-        "narHash": "sha256-Pr6F5Pmd7JnNEMHHmspZ0qVqIBVxyZ13ik1pJtm2QXk=",
+        "lastModified": 1713349283,
+        "narHash": "sha256-2bjFu3+1zPWZPPGqF+7rumTvEwmdBHBhjPva/AMSruQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7872526e9c5332274ea5932a0c3270d6e4724f3b",
+        "rev": "2e359fb3162c85095409071d131e08252d91a14f",
         "type": "github"
       },
       "original": {
@@ -944,11 +944,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1712420723,
-        "narHash": "sha256-VnG0Eu394Ga2FCe8Q66m6OEQF8iAqjDYsjmtl+N2omk=",
+        "lastModified": 1713442664,
+        "narHash": "sha256-LoExypse3c/uun/39u4bPTN4wejIF7hNsdITZO41qTw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9e7f26f82acb057498335362905fde6fea4ca50a",
+        "rev": "d764f230634fa4f86dc8d01c6af9619c7cc5d225",
         "type": "github"
       },
       "original": {
@@ -993,11 +993,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1712815465,
-        "narHash": "sha256-0X78oc+cGaGoAvLllDgG+VCFOWwDl5U/kSS+uBoVDck=",
+        "lastModified": 1713507075,
+        "narHash": "sha256-/SqLT0PG2RUWyknYpcXlcU/aUyKWZMBs35s1sPRkEmc=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "b3014f2209503944f2714cf27c95591433a0c7d8",
+        "rev": "ed8b8a15acc441aec669f97d75f2c1f2ac8c8aa5",
         "type": "github"
       },
       "original": {
@@ -1057,11 +1057,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1710923068,
-        "narHash": "sha256-6hOpUiuxuwpXXc/xfJsBUJeqqgGI+JMJuLo45aG3cKc=",
+        "lastModified": 1712897695,
+        "narHash": "sha256-nMirxrGteNAl9sWiOhoN5tIHyjBbVi5e2tgZUgZlK3Y=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e611897ddfdde3ed3eaac4758635d7177ff78673",
+        "rev": "40e6053ecb65fcbf12863338a6dcefb3f55f1bf8",
         "type": "github"
       },
       "original": {
@@ -1079,11 +1079,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1712055707,
-        "narHash": "sha256-4XLvuSIDZJGS17xEwSrNuJLL7UjDYKGJSbK1WWX2AK8=",
+        "lastModified": 1712897695,
+        "narHash": "sha256-nMirxrGteNAl9sWiOhoN5tIHyjBbVi5e2tgZUgZlK3Y=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e35aed5fda3cc79f88ed7f1795021e559582093a",
+        "rev": "40e6053ecb65fcbf12863338a6dcefb3f55f1bf8",
         "type": "github"
       },
       "original": {
@@ -1155,11 +1155,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1712854883,
-        "narHash": "sha256-gG127D4DyLABGHLQVqLG3tO3VlquwYDodcpm/ueRSaM=",
+        "lastModified": 1713524150,
+        "narHash": "sha256-d7suNNEYPFMqu8p5Yiq3eSMZhnrAAlhIzsXi6IvgSOU=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "c1d79cdd069f4d4882eee453a69d55b8bd7c1ba9",
+        "rev": "2a53e2fe911e971fa90341af27d2fe1447c0cbd2",
         "type": "github"
       },
       "original": {
@@ -1307,11 +1307,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1712712411,
-        "narHash": "sha256-BaXngm6xnwsfuHpdEKzKTZPpmR4WhFoOfG5catQ5qAk=",
+        "lastModified": 1713229404,
+        "narHash": "sha256-/4dW4oLN/MnQ6gICNLZkUSr8V4giBINqzo3ev6voarc=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "5a701e99906961218b55d7ad6c2a998f066c6fe0",
+        "rev": "d00d9df48c00d8682c14c2b5da78bda7ef06b939",
         "type": "github"
       },
       "original": {
@@ -1323,11 +1323,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1712684166,
-        "narHash": "sha256-v+dhVbAN2OKLdS5YbSLmZsLijO4meSUBG26R+Ivm/BM=",
+        "lastModified": 1713163533,
+        "narHash": "sha256-nJBAust+dbpartfCnV405i0SbzBy0SmXhe6rqnP0Ruc=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "6e355632387a085f15a66ad68cf681c1d7374a04",
+        "rev": "b3468391470034353f0e5110c70babb5c62967d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/d96ef3bbff0bdbc3916a220f5c74a04c4db033f2' (2024-04-12)
  → 'github:lewis6991/gitsigns.nvim/7e38f07cab0e5387f9f41e92474db174a63a4725' (2024-04-18)
• Updated input 'home-manager':
    'github:nix-community/home-manager/31357486b0ef6f4e161e002b6893eeb4fafc3ca9' (2024-04-10)
  → 'github:nix-community/home-manager/938357cb234e85da37109df2cdd9cc59ab9c1cc0' (2024-04-19)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/be7be2ca7f55bb881a7ffc16b2efa5af034ab06b' (2024-04-05)
  → 'github:L3MON4D3/LuaSnip/03c8e67eb7293c404845b3982db895d59c0d1538' (2024-04-16)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/58d367a1924bf0d02bcc5bd2c5af8ac97f178381' (2024-04-12)
  → 'github:nix-community/neovim-nightly-overlay/403633f6af2703c057707b31b1ca6bec00bdaaca' (2024-04-19)
• Updated input 'neovim-nightly-overlay/neovim-flake':
    'github:neovim/neovim/18ee9f9e7dbbc9709ee9c1572870b4ad31443569?dir=contrib' (2024-04-11)
  → 'github:neovim/neovim/13ebfafc958c6feb4d908eed913c6dc3c6f05b4e?dir=contrib' (2024-04-18)
• Updated input 'neovim-nightly-overlay/neovim-flake/flake-utils':
    'github:numtide/flake-utils/4022d587cbbfd70fe950c1e2083a02621806a725' (2023-12-04)
  → 'github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a' (2024-03-11)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/f173d0881eff3b21ebb29a2ef8bedbc106c86ea5' (2024-04-11)
  → 'github:nixos/nixpkgs/d764f230634fa4f86dc8d01c6af9619c7cc5d225' (2024-04-18)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/b3014f2209503944f2714cf27c95591433a0c7d8' (2024-04-11)
  → 'github:neovim/nvim-lspconfig/ed8b8a15acc441aec669f97d75f2c1f2ac8c8aa5' (2024-04-19)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/c1d79cdd069f4d4882eee453a69d55b8bd7c1ba9' (2024-04-11)
  → 'github:mrcjkb/rustaceanvim/2a53e2fe911e971fa90341af27d2fe1447c0cbd2' (2024-04-19)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/1b7ae79f1121e121cd736fd356d035bb1686280b' (2024-04-06)
  → 'github:nvim-neorocks/neorocks/bdc7c0843c8fc9f3d28e088acf4c524430962d03' (2024-04-19)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:neovim/neovim/dc110cba3c0d48d7c9dbb91900f8be0cf6cf0c9b?dir=contrib' (2024-03-22)
  → 'github:neovim/neovim/13ebfafc958c6feb4d908eed913c6dc3c6f05b4e?dir=contrib' (2024-04-18)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/flake-utils':
    'github:numtide/flake-utils/4022d587cbbfd70fe950c1e2083a02621806a725' (2023-12-04)
  → 'github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a' (2024-03-11)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/7872526e9c5332274ea5932a0c3270d6e4724f3b' (2024-03-19)
  → 'github:nixos/nixpkgs/2e359fb3162c85095409071d131e08252d91a14f' (2024-04-17)
• Updated input 'rustacean-nvim/neorocks/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/e611897ddfdde3ed3eaac4758635d7177ff78673' (2024-03-20)
  → 'github:cachix/pre-commit-hooks.nix/40e6053ecb65fcbf12863338a6dcefb3f55f1bf8' (2024-04-12)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/9e7f26f82acb057498335362905fde6fea4ca50a' (2024-04-06)
  → 'github:nixos/nixpkgs/d764f230634fa4f86dc8d01c6af9619c7cc5d225' (2024-04-18)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/e35aed5fda3cc79f88ed7f1795021e559582093a' (2024-04-02)
  → 'github:cachix/pre-commit-hooks.nix/40e6053ecb65fcbf12863338a6dcefb3f55f1bf8' (2024-04-12)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/5a701e99906961218b55d7ad6c2a998f066c6fe0' (2024-04-10)
  → 'github:nvim-telescope/telescope.nvim/d00d9df48c00d8682c14c2b5da78bda7ef06b939' (2024-04-16)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/6e355632387a085f15a66ad68cf681c1d7374a04' (2024-04-09)
  → 'github:nvim-tree/nvim-web-devicons/b3468391470034353f0e5110c70babb5c62967d3' (2024-04-15)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/neovim/neovim): [`dc110cba` ➡️ `13ebfafc`](https://github.com/neovim/neovim/compare/dc110cba3c0d48d7c9dbb91900f8be0cf6cf0c9b...13ebfafc958c6feb4d908eed913c6dc3c6f05b4e) <sub>(2024-03-22 to 2024-04-18)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`c1d79cdd` ➡️ `2a53e2fe`](https://github.com/mrcjkb/rustaceanvim/compare/c1d79cdd069f4d4882eee453a69d55b8bd7c1ba9...2a53e2fe911e971fa90341af27d2fe1447c0cbd2) <sub>(2024-04-11 to 2024-04-19)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-flake/flake-utils`](https://github.com/numtide/flake-utils): [`4022d587` ➡️ `b1d9ab70`](https://github.com/numtide/flake-utils/compare/4022d587cbbfd70fe950c1e2083a02621806a725...b1d9ab70662946ef0850d488da1c9019f3a9752a) <sub>(2023-12-04 to 2024-03-11)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`7872526e` ➡️ `2e359fb3`](https://github.com/nixos/nixpkgs/compare/7872526e9c5332274ea5932a0c3270d6e4724f3b...2e359fb3162c85095409071d131e08252d91a14f) <sub>(2024-03-19 to 2024-04-17)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`1b7ae79f` ➡️ `bdc7c084`](https://github.com/nvim-neorocks/neorocks/compare/1b7ae79f1121e121cd736fd356d035bb1686280b...bdc7c0843c8fc9f3d28e088acf4c524430962d03) <sub>(2024-04-06 to 2024-04-19)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`58d367a1` ➡️ `403633f6`](https://github.com/nix-community/neovim-nightly-overlay/compare/58d367a1924bf0d02bcc5bd2c5af8ac97f178381...403633f6af2703c057707b31b1ca6bec00bdaaca) <sub>(2024-04-12 to 2024-04-19)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`be7be2ca` ➡️ `03c8e67e`](https://github.com/L3MON4D3/LuaSnip/compare/be7be2ca7f55bb881a7ffc16b2efa5af034ab06b...03c8e67eb7293c404845b3982db895d59c0d1538) <sub>(2024-04-05 to 2024-04-16)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/flake-utils`](https://github.com/numtide/flake-utils): [`4022d587` ➡️ `b1d9ab70`](https://github.com/numtide/flake-utils/compare/4022d587cbbfd70fe950c1e2083a02621806a725...b1d9ab70662946ef0850d488da1c9019f3a9752a) <sub>(2023-12-04 to 2024-03-11)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`b3014f22` ➡️ `ed8b8a15`](https://github.com/neovim/nvim-lspconfig/compare/b3014f2209503944f2714cf27c95591433a0c7d8...ed8b8a15acc441aec669f97d75f2c1f2ac8c8aa5) <sub>(2024-04-11 to 2024-04-19)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`e35aed5f` ➡️ `40e6053e`](https://github.com/cachix/pre-commit-hooks.nix/compare/e35aed5fda3cc79f88ed7f1795021e559582093a...40e6053ecb65fcbf12863338a6dcefb3f55f1bf8) <sub>(2024-04-02 to 2024-04-12)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`9e7f26f8` ➡️ `d764f230`](https://github.com/nixos/nixpkgs/compare/9e7f26f82acb057498335362905fde6fea4ca50a...d764f230634fa4f86dc8d01c6af9619c7cc5d225) <sub>(2024-04-06 to 2024-04-18)</sub>
 - Updated input [`rustacean-nvim/neorocks/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`e611897d` ➡️ `40e6053e`](https://github.com/cachix/pre-commit-hooks.nix/compare/e611897ddfdde3ed3eaac4758635d7177ff78673...40e6053ecb65fcbf12863338a6dcefb3f55f1bf8) <sub>(2024-03-20 to 2024-04-12)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`d96ef3bb` ➡️ `7e38f07c`](https://github.com/lewis6991/gitsigns.nvim/compare/d96ef3bbff0bdbc3916a220f5c74a04c4db033f2...7e38f07cab0e5387f9f41e92474db174a63a4725) <sub>(2024-04-12 to 2024-04-18)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`f173d088` ➡️ `d764f230`](https://github.com/nixos/nixpkgs/compare/f173d0881eff3b21ebb29a2ef8bedbc106c86ea5...d764f230634fa4f86dc8d01c6af9619c7cc5d225) <sub>(2024-04-11 to 2024-04-18)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`5a701e99` ➡️ `d00d9df4`](https://github.com/nvim-telescope/telescope.nvim/compare/5a701e99906961218b55d7ad6c2a998f066c6fe0...d00d9df48c00d8682c14c2b5da78bda7ef06b939) <sub>(2024-04-10 to 2024-04-16)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-flake`](https://github.com/neovim/neovim): [`18ee9f9e` ➡️ `13ebfafc`](https://github.com/neovim/neovim/compare/18ee9f9e7dbbc9709ee9c1572870b4ad31443569...13ebfafc958c6feb4d908eed913c6dc3c6f05b4e) <sub>(2024-04-11 to 2024-04-18)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`6e355632` ➡️ `b3468391`](https://github.com/nvim-tree/nvim-web-devicons/compare/6e355632387a085f15a66ad68cf681c1d7374a04...b3468391470034353f0e5110c70babb5c62967d3) <sub>(2024-04-09 to 2024-04-15)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`31357486` ➡️ `938357cb`](https://github.com/nix-community/home-manager/compare/31357486b0ef6f4e161e002b6893eeb4fafc3ca9...938357cb234e85da37109df2cdd9cc59ab9c1cc0) <sub>(2024-04-10 to 2024-04-19)</sub>