### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -174,11 +174,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709336216,
-        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
         "type": "github"
       },
       "original": {
@@ -481,11 +481,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1713431624,
-        "narHash": "sha256-xszsGkEFXHHCY5sFRnbovqlqa5RHqBx5qY0NUc//nkc=",
+        "lastModified": 1713620636,
+        "narHash": "sha256-UK3DyvrQ0kLm9wrMQ6tLDoDunoThbY/Yfjn+eCZpuMw=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "7e38f07cab0e5387f9f41e92474db174a63a4725",
+        "rev": "035da036e68e509ed158414416c827d022d914bd",
         "type": "github"
       },
       "original": {
@@ -503,11 +503,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710478346,
-        "narHash": "sha256-Xjf8BdnQG0tLhPMlqQdwCIjOp7Teox0DP3N/jjyiGM4=",
+        "lastModified": 1713898448,
+        "narHash": "sha256-6q6ojsp/Z9P2goqnxyfCSzFOD92T3Uobmj8oVAicUOs=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "64e7763d72c1e4c1e5e6472640615b6ae2d40fbf",
+        "rev": "c0302ec12d569532a6b6bd218f698bc402e93adc",
         "type": "github"
       },
       "original": {
@@ -523,11 +523,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713547559,
-        "narHash": "sha256-zju60y4pyYQoRmqhbgkw+jwmKZReVsCNvb8mZxID2Do=",
+        "lastModified": 1714042918,
+        "narHash": "sha256-4AItZA3EQIiSNAxliuYEJumw/LaVfrMv84gYyrs0r3U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "938357cb234e85da37109df2cdd9cc59ab9c1cc0",
+        "rev": "0c5704eceefcb7bb238a958f532a86e3b59d76db",
         "type": "github"
       },
       "original": {
@@ -557,11 +557,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1712505318,
-        "narHash": "sha256-fzlBLhXUN6y7mzEtcGNRDXxFakBEfaj4Bmj5PuoCNaM=",
+        "lastModified": 1713780596,
+        "narHash": "sha256-DDAYNGSnrBwvVfpKx+XjkuecpoE9HiEf6JW+DBQgvm0=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "5870244b592c22558b658dbaf94f9e41afb0316f",
+        "rev": "110e6dc761d5c3d352574def3479a9c39dfc4358",
         "type": "github"
       },
       "original": {
@@ -654,11 +654,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1713290802,
-        "narHash": "sha256-E1Ov6aF9DJ0poVM6q6jK1ypsJf6cRzHqC2Gi6u9kai0=",
+        "lastModified": 1713989118,
+        "narHash": "sha256-+cL5J6xK/UerlKEVzU75Tnsp1HZr9t+LKdTg+8mBjo0=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "03c8e67eb7293c404845b3982db895d59c0d1538",
+        "rev": "8f3d3465ba5c7ade0a8adb41eca5736f291a3fa8",
         "type": "github"
       },
       "original": {
@@ -692,11 +692,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1713504178,
-        "narHash": "sha256-3nzJET14rXVGINBPxcxjLAl2h8H6W3cyp/RqUaYkUws=",
+        "lastModified": 1713590539,
+        "narHash": "sha256-mFkkilqCVZl4wjfNNW4SRe+gn2t+PUUMGBp+GwidB/o=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "bdc7c0843c8fc9f3d28e088acf4c524430962d03",
+        "rev": "f72e57d2ebc0cd21d208ecc245a2c6dcd4c8c2b3",
         "type": "github"
       },
       "original": {
@@ -715,11 +715,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1713476725,
-        "narHash": "sha256-OBDeB3+2hgWqABtqg+PwfjbWzL49dmJeG32qOEzhtUY=",
+        "lastModified": 1714087130,
+        "narHash": "sha256-GUf6c7BePyQppbN2zgzrFEf9rQgq/oj7aolupF/KeT4=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "13ebfafc958c6feb4d908eed913c6dc3c6f05b4e",
+        "rev": "a736e845a48c5ccdcfeb4ea485aa859a04b35d59",
         "type": "github"
       },
       "original": {
@@ -740,11 +740,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1713476725,
-        "narHash": "sha256-OBDeB3+2hgWqABtqg+PwfjbWzL49dmJeG32qOEzhtUY=",
+        "lastModified": 1713571965,
+        "narHash": "sha256-MJgRD8o7f3WQNZ2IfH9d9M7LFtUr4DIExBlwt9jdF2A=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "13ebfafc958c6feb4d908eed913c6dc3c6f05b4e",
+        "rev": "4d52b0cf670502caf81b70f2f1e6f8c548b78f58",
         "type": "github"
       },
       "original": {
@@ -765,11 +765,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713485028,
-        "narHash": "sha256-bl1EURik5le68rLBcHsfLKyPtEPlumhcA5kKOx88zkQ=",
+        "lastModified": 1714089835,
+        "narHash": "sha256-e6ZDjHQSiHWKavqVPN+hvlwkJrW6+2gQp+JqEBnltNk=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "403633f6af2703c057707b31b1ca6bec00bdaaca",
+        "rev": "fe6f80a626cfc606eeb3e29e6263d7ee821187fa",
         "type": "github"
       },
       "original": {
@@ -880,11 +880,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1713442664,
-        "narHash": "sha256-LoExypse3c/uun/39u4bPTN4wejIF7hNsdITZO41qTw=",
+        "lastModified": 1714091391,
+        "narHash": "sha256-68n3GBvlm1MIeJXadPzQ3v8Y9sIW3zmv8gI5w5sliC8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d764f230634fa4f86dc8d01c6af9619c7cc5d225",
+        "rev": "4c86138ce486d601d956a165e2f7a0fc029a03c1",
         "type": "github"
       },
       "original": {
@@ -928,11 +928,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1713349283,
-        "narHash": "sha256-2bjFu3+1zPWZPPGqF+7rumTvEwmdBHBhjPva/AMSruQ=",
+        "lastModified": 1713442664,
+        "narHash": "sha256-LoExypse3c/uun/39u4bPTN4wejIF7hNsdITZO41qTw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2e359fb3162c85095409071d131e08252d91a14f",
+        "rev": "d764f230634fa4f86dc8d01c6af9619c7cc5d225",
         "type": "github"
       },
       "original": {
@@ -944,11 +944,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1713442664,
-        "narHash": "sha256-LoExypse3c/uun/39u4bPTN4wejIF7hNsdITZO41qTw=",
+        "lastModified": 1713596654,
+        "narHash": "sha256-LJbHQQ5aX1LVth2ST+Kkse/DRzgxlVhTL1rxthvyhZc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d764f230634fa4f86dc8d01c6af9619c7cc5d225",
+        "rev": "fd16bb6d3bcca96039b11aa52038fafeb6e4f4be",
         "type": "github"
       },
       "original": {
@@ -977,11 +977,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1712041554,
-        "narHash": "sha256-DBxQTmwuEGj2g7LP7d1PJk/SyO0iJq2CIIHsFh0QJ4I=",
+        "lastModified": 1713837627,
+        "narHash": "sha256-rz+JMd/hsUEDNVan2sCuEGtbsOVi6oRmPtps+7qSXQE=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "ce16de5665c766f39c271705b17fff06f7bcb84f",
+        "rev": "8f3c541407e691af6163e2447f3af1bd6e17f9a3",
         "type": "github"
       },
       "original": {
@@ -993,11 +993,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1713507075,
-        "narHash": "sha256-/SqLT0PG2RUWyknYpcXlcU/aUyKWZMBs35s1sPRkEmc=",
+        "lastModified": 1714156243,
+        "narHash": "sha256-craV/eE1aLB3I/U0x9Fb1DFP2TOdKZd4FVCvzQoTkd0=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "ed8b8a15acc441aec669f97d75f2c1f2ac8c8aa5",
+        "rev": "7133e85c3df14a387da8942c094c7edddcdef309",
         "type": "github"
       },
       "original": {
@@ -1031,11 +1031,11 @@
     "plenary-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1711369325,
-        "narHash": "sha256-wM/FuK24NPEyaWntwT+mi2SuPExC/abXDK9c2WvgUBk=",
+        "lastModified": 1714083960,
+        "narHash": "sha256-vy0MXEoSM4rvYpfwbc2PnilvMOA30Urv0FAxjXuvqQ8=",
         "owner": "nvim-lua",
         "repo": "plenary.nvim",
-        "rev": "8aad4396840be7fc42896e3011751b7609ca4119",
+        "rev": "08e301982b9a057110ede7a735dd1b5285eb341f",
         "type": "github"
       },
       "original": {
@@ -1155,11 +1155,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1713524150,
-        "narHash": "sha256-d7suNNEYPFMqu8p5Yiq3eSMZhnrAAlhIzsXi6IvgSOU=",
+        "lastModified": 1714151305,
+        "narHash": "sha256-tW4SBMMQScDbax/YNP5CqvmfDywlKNQgYlXh1lHGM9k=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "2a53e2fe911e971fa90341af27d2fe1447c0cbd2",
+        "rev": "cd35b0f7fb0c9fe6879b084096230a74fefa4da8",
         "type": "github"
       },
       "original": {
@@ -1307,11 +1307,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1713229404,
-        "narHash": "sha256-/4dW4oLN/MnQ6gICNLZkUSr8V4giBINqzo3ev6voarc=",
+        "lastModified": 1714091142,
+        "narHash": "sha256-AtvZ7b2bg+Iaei4rRzTBYf76vHJH2Yq5tJAJZrZw/pk=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "d00d9df48c00d8682c14c2b5da78bda7ef06b939",
+        "rev": "35f94f0ef32d70e3664a703cefbe71bd1456d899",
         "type": "github"
       },
       "original": {
@@ -1323,11 +1323,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1713163533,
-        "narHash": "sha256-nJBAust+dbpartfCnV405i0SbzBy0SmXhe6rqnP0Ruc=",
+        "lastModified": 1713675782,
+        "narHash": "sha256-AW2W6H7OTv52hfZCcYQc5UjFArBWKLeVclrwMt13HOM=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "b3468391470034353f0e5110c70babb5c62967d3",
+        "rev": "beb6367ab8496c9e43f22e0252735fdadae1872d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/7e38f07cab0e5387f9f41e92474db174a63a4725' (2024-04-18)
  → 'github:lewis6991/gitsigns.nvim/035da036e68e509ed158414416c827d022d914bd' (2024-04-20)
• Updated input 'home-manager':
    'github:nix-community/home-manager/938357cb234e85da37109df2cdd9cc59ab9c1cc0' (2024-04-19)
  → 'github:nix-community/home-manager/0c5704eceefcb7bb238a958f532a86e3b59d76db' (2024-04-25)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/5870244b592c22558b658dbaf94f9e41afb0316f' (2024-04-07)
  → 'github:hyprwm/contrib/110e6dc761d5c3d352574def3479a9c39dfc4358' (2024-04-22)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/03c8e67eb7293c404845b3982db895d59c0d1538' (2024-04-16)
  → 'github:L3MON4D3/LuaSnip/8f3d3465ba5c7ade0a8adb41eca5736f291a3fa8' (2024-04-24)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/403633f6af2703c057707b31b1ca6bec00bdaaca' (2024-04-19)
  → 'github:nix-community/neovim-nightly-overlay/fe6f80a626cfc606eeb3e29e6263d7ee821187fa' (2024-04-26)
• Updated input 'neovim-nightly-overlay/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/64e7763d72c1e4c1e5e6472640615b6ae2d40fbf' (2024-03-15)
  → 'github:hercules-ci/hercules-ci-effects/c0302ec12d569532a6b6bd218f698bc402e93adc' (2024-04-23)
• Updated input 'neovim-nightly-overlay/hercules-ci-effects/flake-parts':
    'github:hercules-ci/flake-parts/f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2' (2024-03-01)
  → 'github:hercules-ci/flake-parts/9126214d0a59633752a136528f5f3b9aa8565b7d' (2024-04-01)
• Updated input 'neovim-nightly-overlay/neovim-flake':
    'github:neovim/neovim/13ebfafc958c6feb4d908eed913c6dc3c6f05b4e?dir=contrib' (2024-04-18)
  → 'github:neovim/neovim/a736e845a48c5ccdcfeb4ea485aa859a04b35d59?dir=contrib' (2024-04-25)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d764f230634fa4f86dc8d01c6af9619c7cc5d225' (2024-04-18)
  → 'github:nixos/nixpkgs/4c86138ce486d601d956a165e2f7a0fc029a03c1' (2024-04-26)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/ce16de5665c766f39c271705b17fff06f7bcb84f' (2024-04-02)
  → 'github:hrsh7th/nvim-cmp/8f3c541407e691af6163e2447f3af1bd6e17f9a3' (2024-04-23)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/ed8b8a15acc441aec669f97d75f2c1f2ac8c8aa5' (2024-04-19)
  → 'github:neovim/nvim-lspconfig/7133e85c3df14a387da8942c094c7edddcdef309' (2024-04-26)
• Updated input 'plenary-nvim':
    'github:nvim-lua/plenary.nvim/8aad4396840be7fc42896e3011751b7609ca4119' (2024-03-25)
  → 'github:nvim-lua/plenary.nvim/08e301982b9a057110ede7a735dd1b5285eb341f' (2024-04-25)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/2a53e2fe911e971fa90341af27d2fe1447c0cbd2' (2024-04-19)
  → 'github:mrcjkb/rustaceanvim/cd35b0f7fb0c9fe6879b084096230a74fefa4da8' (2024-04-26)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/bdc7c0843c8fc9f3d28e088acf4c524430962d03' (2024-04-19)
  → 'github:nvim-neorocks/neorocks/f72e57d2ebc0cd21d208ecc245a2c6dcd4c8c2b3' (2024-04-20)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:neovim/neovim/13ebfafc958c6feb4d908eed913c6dc3c6f05b4e?dir=contrib' (2024-04-18)
  → 'github:neovim/neovim/4d52b0cf670502caf81b70f2f1e6f8c548b78f58?dir=contrib' (2024-04-20)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/2e359fb3162c85095409071d131e08252d91a14f' (2024-04-17)
  → 'github:nixos/nixpkgs/d764f230634fa4f86dc8d01c6af9619c7cc5d225' (2024-04-18)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/d764f230634fa4f86dc8d01c6af9619c7cc5d225' (2024-04-18)
  → 'github:nixos/nixpkgs/fd16bb6d3bcca96039b11aa52038fafeb6e4f4be' (2024-04-20)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/d00d9df48c00d8682c14c2b5da78bda7ef06b939' (2024-04-16)
  → 'github:nvim-telescope/telescope.nvim/35f94f0ef32d70e3664a703cefbe71bd1456d899' (2024-04-26)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/b3468391470034353f0e5110c70babb5c62967d3' (2024-04-15)
  → 'github:nvim-tree/nvim-web-devicons/beb6367ab8496c9e43f22e0252735fdadae1872d' (2024-04-21)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/neovim/neovim): [`13ebfafc` ➡️ `4d52b0cf`](https://github.com/neovim/neovim/compare/13ebfafc958c6feb4d908eed913c6dc3c6f05b4e...4d52b0cf670502caf81b70f2f1e6f8c548b78f58) <sub>(2024-04-18 to 2024-04-20)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`2a53e2fe` ➡️ `cd35b0f7`](https://github.com/mrcjkb/rustaceanvim/compare/2a53e2fe911e971fa90341af27d2fe1447c0cbd2...cd35b0f7fb0c9fe6879b084096230a74fefa4da8) <sub>(2024-04-19 to 2024-04-26)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`2e359fb3` ➡️ `d764f230`](https://github.com/nixos/nixpkgs/compare/2e359fb3162c85095409071d131e08252d91a14f...d764f230634fa4f86dc8d01c6af9619c7cc5d225) <sub>(2024-04-17 to 2024-04-18)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`bdc7c084` ➡️ `f72e57d2`](https://github.com/nvim-neorocks/neorocks/compare/bdc7c0843c8fc9f3d28e088acf4c524430962d03...f72e57d2ebc0cd21d208ecc245a2c6dcd4c8c2b3) <sub>(2024-04-19 to 2024-04-20)</sub>
 - Updated input [`neovim-nightly-overlay/hercules-ci-effects/flake-parts`](https://github.com/hercules-ci/flake-parts): [`f7b3c975` ➡️ `9126214d`](https://github.com/hercules-ci/flake-parts/compare/f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2...9126214d0a59633752a136528f5f3b9aa8565b7d) <sub>(2024-03-01 to 2024-04-01)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`403633f6` ➡️ `fe6f80a6`](https://github.com/nix-community/neovim-nightly-overlay/compare/403633f6af2703c057707b31b1ca6bec00bdaaca...fe6f80a626cfc606eeb3e29e6263d7ee821187fa) <sub>(2024-04-19 to 2024-04-26)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`03c8e67e` ➡️ `8f3d3465`](https://github.com/L3MON4D3/LuaSnip/compare/03c8e67eb7293c404845b3982db895d59c0d1538...8f3d3465ba5c7ade0a8adb41eca5736f291a3fa8) <sub>(2024-04-16 to 2024-04-24)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`5870244b` ➡️ `110e6dc7`](https://github.com/hyprwm/contrib/compare/5870244b592c22558b658dbaf94f9e41afb0316f...110e6dc761d5c3d352574def3479a9c39dfc4358) <sub>(2024-04-07 to 2024-04-22)</sub>
 - Updated input [`plenary-nvim`](https://github.com/nvim-lua/plenary.nvim): [`8aad4396` ➡️ `08e30198`](https://github.com/nvim-lua/plenary.nvim/compare/8aad4396840be7fc42896e3011751b7609ca4119...08e301982b9a057110ede7a735dd1b5285eb341f) <sub>(2024-03-25 to 2024-04-25)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`ed8b8a15` ➡️ `7133e85c`](https://github.com/neovim/nvim-lspconfig/compare/ed8b8a15acc441aec669f97d75f2c1f2ac8c8aa5...7133e85c3df14a387da8942c094c7edddcdef309) <sub>(2024-04-19 to 2024-04-26)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`ce16de56` ➡️ `8f3c5414`](https://github.com/hrsh7th/nvim-cmp/compare/ce16de5665c766f39c271705b17fff06f7bcb84f...8f3c541407e691af6163e2447f3af1bd6e17f9a3) <sub>(2024-04-02 to 2024-04-23)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`d764f230` ➡️ `fd16bb6d`](https://github.com/nixos/nixpkgs/compare/d764f230634fa4f86dc8d01c6af9619c7cc5d225...fd16bb6d3bcca96039b11aa52038fafeb6e4f4be) <sub>(2024-04-18 to 2024-04-20)</sub>
 - Updated input [`neovim-nightly-overlay/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`64e7763d` ➡️ `c0302ec1`](https://github.com/hercules-ci/hercules-ci-effects/compare/64e7763d72c1e4c1e5e6472640615b6ae2d40fbf...c0302ec12d569532a6b6bd218f698bc402e93adc) <sub>(2024-03-15 to 2024-04-23)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`7e38f07c` ➡️ `035da036`](https://github.com/lewis6991/gitsigns.nvim/compare/7e38f07cab0e5387f9f41e92474db174a63a4725...035da036e68e509ed158414416c827d022d914bd) <sub>(2024-04-18 to 2024-04-20)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`d764f230` ➡️ `4c86138c`](https://github.com/nixos/nixpkgs/compare/d764f230634fa4f86dc8d01c6af9619c7cc5d225...4c86138ce486d601d956a165e2f7a0fc029a03c1) <sub>(2024-04-18 to 2024-04-26)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`d00d9df4` ➡️ `35f94f0e`](https://github.com/nvim-telescope/telescope.nvim/compare/d00d9df48c00d8682c14c2b5da78bda7ef06b939...35f94f0ef32d70e3664a703cefbe71bd1456d899) <sub>(2024-04-16 to 2024-04-26)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-flake`](https://github.com/neovim/neovim): [`13ebfafc` ➡️ `a736e845`](https://github.com/neovim/neovim/compare/13ebfafc958c6feb4d908eed913c6dc3c6f05b4e...a736e845a48c5ccdcfeb4ea485aa859a04b35d59) <sub>(2024-04-18 to 2024-04-25)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`b3468391` ➡️ `beb6367a`](https://github.com/nvim-tree/nvim-web-devicons/compare/b3468391470034353f0e5110c70babb5c62967d3...beb6367ab8496c9e43f22e0252735fdadae1872d) <sub>(2024-04-15 to 2024-04-21)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`938357cb` ➡️ `0c5704ec`](https://github.com/nix-community/home-manager/compare/938357cb234e85da37109df2cdd9cc59ab9c1cc0...0c5704eceefcb7bb238a958f532a86e3b59d76db) <sub>(2024-04-19 to 2024-04-25)</sub>