### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -152,11 +152,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1714641030,
+        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
         "type": "github"
       },
       "original": {
@@ -369,11 +369,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1712554826,
-        "narHash": "sha256-pmY1EQbupKvsqok9O5omkOWi0BEZ8df7HL0F7ubdY9Q=",
+        "lastModified": 1714601825,
+        "narHash": "sha256-0ujueJ226zEmjkFwodSukO1Zu5gMvTmx/dCtT5VBhek=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "dac8e5c2d85926df92672bf2afb4fc48656d96c7",
+        "rev": "ce882460cf3db12e99f8bf579cbf99e331f6dd4f",
         "type": "github"
       },
       "original": {
@@ -481,11 +481,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1713620636,
-        "narHash": "sha256-UK3DyvrQ0kLm9wrMQ6tLDoDunoThbY/Yfjn+eCZpuMw=",
+        "lastModified": 1714557033,
+        "narHash": "sha256-IpYpya8z6e8t9Lf/ZFx97HsnVwaYLZ44D5rCKvOyybA=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "035da036e68e509ed158414416c827d022d914bd",
+        "rev": "9cafac31a091267838e1e90fd6e083d37611f516",
         "type": "github"
       },
       "original": {
@@ -523,11 +523,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714042918,
-        "narHash": "sha256-4AItZA3EQIiSNAxliuYEJumw/LaVfrMv84gYyrs0r3U=",
+        "lastModified": 1714679908,
+        "narHash": "sha256-KzcXzDvDJjX34en8f3Zimm396x6idbt+cu4tWDVS2FI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0c5704eceefcb7bb238a958f532a86e3b59d76db",
+        "rev": "9036fe9ef8e15a819fa76f47a8b1f287903fb848",
         "type": "github"
       },
       "original": {
@@ -654,11 +654,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1713989118,
-        "narHash": "sha256-+cL5J6xK/UerlKEVzU75Tnsp1HZr9t+LKdTg+8mBjo0=",
+        "lastModified": 1714473569,
+        "narHash": "sha256-SK7IFQgRMAraTzmErl2ldJ62bsfUCbKFW5MesUpDXoQ=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "8f3d3465ba5c7ade0a8adb41eca5736f291a3fa8",
+        "rev": "b152822e1a4bafb6bdf11a16cc26525cbd95ee00",
         "type": "github"
       },
       "original": {
@@ -715,11 +715,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1714087130,
-        "narHash": "sha256-GUf6c7BePyQppbN2zgzrFEf9rQgq/oj7aolupF/KeT4=",
+        "lastModified": 1714683427,
+        "narHash": "sha256-SMfFU+VsRTZLVIkGpf67oOTZ29gWmFvxF0nGO6CRx/4=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "a736e845a48c5ccdcfeb4ea485aa859a04b35d59",
+        "rev": "01e4a70d668d54a7cefa3ff53ec97e39df516265",
         "type": "github"
       },
       "original": {
@@ -765,11 +765,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714089835,
-        "narHash": "sha256-e6ZDjHQSiHWKavqVPN+hvlwkJrW6+2gQp+JqEBnltNk=",
+        "lastModified": 1714694802,
+        "narHash": "sha256-b0+Zrd2PDgRIEeeXbivzw3kcSaXCZItOvgOgdfRsyOo=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "fe6f80a626cfc606eeb3e29e6263d7ee821187fa",
+        "rev": "9b2c33c7fa0287db93868d955e7b3d0da3837a57",
         "type": "github"
       },
       "original": {
@@ -781,11 +781,11 @@
     "nightfox-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1712950762,
-        "narHash": "sha256-2xdwQObHSKC/N17N2yLMWLHYmGg6nBk18jlMX1OSESY=",
+        "lastModified": 1714329621,
+        "narHash": "sha256-ly9yavagB6A8t2plHZyNJt5tqCBq+ExEtYGKR4+9qHQ=",
         "owner": "EdenEast",
         "repo": "nightfox.nvim",
-        "rev": "ce0cdf8538c8c0b9c8fb2884d3d1090c8faf515d",
+        "rev": "df75a6a94910ae47854341d6b5a6fd483192c0eb",
         "type": "github"
       },
       "original": {
@@ -880,11 +880,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1714091391,
-        "narHash": "sha256-68n3GBvlm1MIeJXadPzQ3v8Y9sIW3zmv8gI5w5sliC8=",
+        "lastModified": 1714656196,
+        "narHash": "sha256-kjQkA98lMcsom6Gbhw8SYzmwrSo+2nruiTcTZp5jK7o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4c86138ce486d601d956a165e2f7a0fc029a03c1",
+        "rev": "94035b482d181af0a0f8f77823a790b256b7c3cc",
         "type": "github"
       },
       "original": {
@@ -993,11 +993,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1714156243,
-        "narHash": "sha256-craV/eE1aLB3I/U0x9Fb1DFP2TOdKZd4FVCvzQoTkd0=",
+        "lastModified": 1714406347,
+        "narHash": "sha256-sPM6vYkOCmQ9y+1w6whtDeoWzSzzjabzi9RH9EkZLng=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "7133e85c3df14a387da8942c094c7edddcdef309",
+        "rev": "aa5f4f4ee10b2688fb37fa46215672441d5cd5d9",
         "type": "github"
       },
       "original": {
@@ -1155,11 +1155,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1714151305,
-        "narHash": "sha256-tW4SBMMQScDbax/YNP5CqvmfDywlKNQgYlXh1lHGM9k=",
+        "lastModified": 1714763803,
+        "narHash": "sha256-BwrqxAmmspIHlPPiI53p4jyIhJlZYqGWj73RKSgJm/4=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "cd35b0f7fb0c9fe6879b084096230a74fefa4da8",
+        "rev": "fbcb320d74cdc877d111a6462693059fb819df91",
         "type": "github"
       },
       "original": {
@@ -1307,11 +1307,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1714091142,
-        "narHash": "sha256-AtvZ7b2bg+Iaei4rRzTBYf76vHJH2Yq5tJAJZrZw/pk=",
+        "lastModified": 1714700089,
+        "narHash": "sha256-SoEetPE7f7Y0kUa4+7dH+EOs/0WBsMDxeOkbVNuoSjE=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "35f94f0ef32d70e3664a703cefbe71bd1456d899",
+        "rev": "fac83a556e7b710dc31433dec727361ca062dbe9",
         "type": "github"
       },
       "original": {
@@ -1323,11 +1323,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1713675782,
-        "narHash": "sha256-AW2W6H7OTv52hfZCcYQc5UjFArBWKLeVclrwMt13HOM=",
+        "lastModified": 1714371374,
+        "narHash": "sha256-gc+8GgFSM87dbcYUW8d9If3qY80xJMmy48vnVezNLPk=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "beb6367ab8496c9e43f22e0252735fdadae1872d",
+        "rev": "794bba734ec95eaff9bb82fbd112473be2087283",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/dac8e5c2d85926df92672bf2afb4fc48656d96c7' (2024-04-08)
  → 'github:tpope/vim-fugitive/ce882460cf3db12e99f8bf579cbf99e331f6dd4f' (2024-05-01)
• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/035da036e68e509ed158414416c827d022d914bd' (2024-04-20)
  → 'github:lewis6991/gitsigns.nvim/9cafac31a091267838e1e90fd6e083d37611f516' (2024-05-01)
• Updated input 'home-manager':
    'github:nix-community/home-manager/0c5704eceefcb7bb238a958f532a86e3b59d76db' (2024-04-25)
  → 'github:nix-community/home-manager/9036fe9ef8e15a819fa76f47a8b1f287903fb848' (2024-05-02)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/8f3d3465ba5c7ade0a8adb41eca5736f291a3fa8' (2024-04-24)
  → 'github:L3MON4D3/LuaSnip/b152822e1a4bafb6bdf11a16cc26525cbd95ee00' (2024-04-30)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/fe6f80a626cfc606eeb3e29e6263d7ee821187fa' (2024-04-26)
  → 'github:nix-community/neovim-nightly-overlay/9b2c33c7fa0287db93868d955e7b3d0da3837a57' (2024-05-03)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/9126214d0a59633752a136528f5f3b9aa8565b7d' (2024-04-01)
  → 'github:hercules-ci/flake-parts/e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e' (2024-05-02)
• Updated input 'neovim-nightly-overlay/neovim-flake':
    'github:neovim/neovim/a736e845a48c5ccdcfeb4ea485aa859a04b35d59?dir=contrib' (2024-04-25)
  → 'github:neovim/neovim/01e4a70d668d54a7cefa3ff53ec97e39df516265?dir=contrib' (2024-05-02)
• Updated input 'nightfox-nvim':
    'github:EdenEast/nightfox.nvim/ce0cdf8538c8c0b9c8fb2884d3d1090c8faf515d' (2024-04-12)
  → 'github:EdenEast/nightfox.nvim/df75a6a94910ae47854341d6b5a6fd483192c0eb' (2024-04-28)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/4c86138ce486d601d956a165e2f7a0fc029a03c1' (2024-04-26)
  → 'github:nixos/nixpkgs/94035b482d181af0a0f8f77823a790b256b7c3cc' (2024-05-02)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/7133e85c3df14a387da8942c094c7edddcdef309' (2024-04-26)
  → 'github:neovim/nvim-lspconfig/aa5f4f4ee10b2688fb37fa46215672441d5cd5d9' (2024-04-29)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/cd35b0f7fb0c9fe6879b084096230a74fefa4da8' (2024-04-26)
  → 'github:mrcjkb/rustaceanvim/fbcb320d74cdc877d111a6462693059fb819df91' (2024-05-03)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/35f94f0ef32d70e3664a703cefbe71bd1456d899' (2024-04-26)
  → 'github:nvim-telescope/telescope.nvim/fac83a556e7b710dc31433dec727361ca062dbe9' (2024-05-03)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/beb6367ab8496c9e43f22e0252735fdadae1872d' (2024-04-21)
  → 'github:nvim-tree/nvim-web-devicons/794bba734ec95eaff9bb82fbd112473be2087283' (2024-04-29)

```

</p></details>

 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`cd35b0f7` ➡️ `fbcb320d`](https://github.com/mrcjkb/rustaceanvim/compare/cd35b0f7fb0c9fe6879b084096230a74fefa4da8...fbcb320d74cdc877d111a6462693059fb819df91) <sub>(2024-04-26 to 2024-05-03)</sub>
 - Updated input [`nightfox-nvim`](https://github.com/EdenEast/nightfox.nvim): [`ce0cdf85` ➡️ `df75a6a9`](https://github.com/EdenEast/nightfox.nvim/compare/ce0cdf8538c8c0b9c8fb2884d3d1090c8faf515d...df75a6a94910ae47854341d6b5a6fd483192c0eb) <sub>(2024-04-12 to 2024-04-28)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`dac8e5c2` ➡️ `ce882460`](https://github.com/tpope/vim-fugitive/compare/dac8e5c2d85926df92672bf2afb4fc48656d96c7...ce882460cf3db12e99f8bf579cbf99e331f6dd4f) <sub>(2024-04-08 to 2024-05-01)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`fe6f80a6` ➡️ `9b2c33c7`](https://github.com/nix-community/neovim-nightly-overlay/compare/fe6f80a626cfc606eeb3e29e6263d7ee821187fa...9b2c33c7fa0287db93868d955e7b3d0da3837a57) <sub>(2024-04-26 to 2024-05-03)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`8f3d3465` ➡️ `b152822e`](https://github.com/L3MON4D3/LuaSnip/compare/8f3d3465ba5c7ade0a8adb41eca5736f291a3fa8...b152822e1a4bafb6bdf11a16cc26525cbd95ee00) <sub>(2024-04-24 to 2024-04-30)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`7133e85c` ➡️ `aa5f4f4e`](https://github.com/neovim/nvim-lspconfig/compare/7133e85c3df14a387da8942c094c7edddcdef309...aa5f4f4ee10b2688fb37fa46215672441d5cd5d9) <sub>(2024-04-26 to 2024-04-29)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`035da036` ➡️ `9cafac31`](https://github.com/lewis6991/gitsigns.nvim/compare/035da036e68e509ed158414416c827d022d914bd...9cafac31a091267838e1e90fd6e083d37611f516) <sub>(2024-04-20 to 2024-05-01)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`4c86138c` ➡️ `94035b48`](https://github.com/nixos/nixpkgs/compare/4c86138ce486d601d956a165e2f7a0fc029a03c1...94035b482d181af0a0f8f77823a790b256b7c3cc) <sub>(2024-04-26 to 2024-05-02)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`35f94f0e` ➡️ `fac83a55`](https://github.com/nvim-telescope/telescope.nvim/compare/35f94f0ef32d70e3664a703cefbe71bd1456d899...fac83a556e7b710dc31433dec727361ca062dbe9) <sub>(2024-04-26 to 2024-05-03)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-flake`](https://github.com/neovim/neovim): [`a736e845` ➡️ `01e4a70d`](https://github.com/neovim/neovim/compare/a736e845a48c5ccdcfeb4ea485aa859a04b35d59...01e4a70d668d54a7cefa3ff53ec97e39df516265) <sub>(2024-04-25 to 2024-05-02)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`beb6367a` ➡️ `794bba73`](https://github.com/nvim-tree/nvim-web-devicons/compare/beb6367ab8496c9e43f22e0252735fdadae1872d...794bba734ec95eaff9bb82fbd112473be2087283) <sub>(2024-04-21 to 2024-04-29)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`0c5704ec` ➡️ `9036fe9e`](https://github.com/nix-community/home-manager/compare/0c5704eceefcb7bb238a958f532a86e3b59d76db...9036fe9ef8e15a819fa76f47a8b1f287903fb848) <sub>(2024-04-25 to 2024-05-02)</sub>
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`9126214d` ➡️ `e5d10a24`](https://github.com/hercules-ci/flake-parts/compare/9126214d0a59633752a136528f5f3b9aa8565b7d...e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e) <sub>(2024-04-01 to 2024-05-02)</sub>