### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1714557033,
-        "narHash": "sha256-IpYpya8z6e8t9Lf/ZFx97HsnVwaYLZ44D5rCKvOyybA=",
+        "lastModified": 1715007445,
+        "narHash": "sha256-v21qTJfiv57vSUDGCJ4wM+L0Ixwh2b3pkoESFAHBrDM=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "9cafac31a091267838e1e90fd6e083d37611f516",
+        "rev": "805610a9393fa231f2c2b49cb521bfa413fadb3d",
         "type": "github"
       },
       "original": {
@@ -523,11 +523,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714679908,
-        "narHash": "sha256-KzcXzDvDJjX34en8f3Zimm396x6idbt+cu4tWDVS2FI=",
+        "lastModified": 1715359697,
+        "narHash": "sha256-FJYyXqulIbCdsUCTFBTu/bIH4aN+7jzjQAn52Qc6qPg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9036fe9ef8e15a819fa76f47a8b1f287903fb848",
+        "rev": "f2c5ba5e720fd584d83f2f97399dac0d26ae60b9",
         "type": "github"
       },
       "original": {
@@ -606,11 +606,11 @@
     "lsp-signature-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1710647656,
-        "narHash": "sha256-O7y7pcCvF0xUFamG+wMLe4mC6hUQ679rJV+ZUoWB0oY=",
+        "lastModified": 1715342515,
+        "narHash": "sha256-f4AuZnt2m2VA90baSbZt6+elzjXmJKPFTO28v8auoYc=",
         "owner": "ray-x",
         "repo": "lsp_signature.nvim",
-        "rev": "c6aeb2f1d2538bbdfdaab1664d9d4c3c75aa9db8",
+        "rev": "aed5d1162b0f07bb3af34bedcc5f70a2b6466ed8",
         "type": "github"
       },
       "original": {
@@ -692,11 +692,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1713590539,
-        "narHash": "sha256-mFkkilqCVZl4wjfNNW4SRe+gn2t+PUUMGBp+GwidB/o=",
+        "lastModified": 1714773380,
+        "narHash": "sha256-UyBGSuwwbDCAXDm0AII7Xmld1n7mqziQaqQJ/SSI6mI=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "f72e57d2ebc0cd21d208ecc245a2c6dcd4c8c2b3",
+        "rev": "4333320b464e10e1e8ffefbf6e0b4055c79bbfd3",
         "type": "github"
       },
       "original": {
@@ -715,11 +715,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1714683427,
-        "narHash": "sha256-SMfFU+VsRTZLVIkGpf67oOTZ29gWmFvxF0nGO6CRx/4=",
+        "lastModified": 1715292729,
+        "narHash": "sha256-Ml5HzPmVx/fnLedNpBYQs3YG2zhSKsPga89yaCDVYlM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "01e4a70d668d54a7cefa3ff53ec97e39df516265",
+        "rev": "ca735c7554701a1191e6afdac2ea4b4f94ba6d88",
         "type": "github"
       },
       "original": {
@@ -740,11 +740,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1713571965,
-        "narHash": "sha256-MJgRD8o7f3WQNZ2IfH9d9M7LFtUr4DIExBlwt9jdF2A=",
+        "lastModified": 1714703732,
+        "narHash": "sha256-RZymn1F/tWGKv/SjQc/Os5GOWpfUPnRvTRdZUHhEqq8=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "4d52b0cf670502caf81b70f2f1e6f8c548b78f58",
+        "rev": "cf9f002f31c8b4d9d42912a3f45f5d3db4462fd9",
         "type": "github"
       },
       "original": {
@@ -765,11 +765,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714694802,
-        "narHash": "sha256-b0+Zrd2PDgRIEeeXbivzw3kcSaXCZItOvgOgdfRsyOo=",
+        "lastModified": 1715299512,
+        "narHash": "sha256-IYOsXQt04EIHfNhjwbDhSY/n3vQGhSiL/XHuMGnZnek=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "9b2c33c7fa0287db93868d955e7b3d0da3837a57",
+        "rev": "2b11e4433355b57784dd002d34cf810874fa044d",
         "type": "github"
       },
       "original": {
@@ -880,11 +880,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1714656196,
-        "narHash": "sha256-kjQkA98lMcsom6Gbhw8SYzmwrSo+2nruiTcTZp5jK7o=",
+        "lastModified": 1715220225,
+        "narHash": "sha256-X0xvboLSjfC5s/M1yuPdSdc6yzKV8536hTTWCSKF5Xc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "94035b482d181af0a0f8f77823a790b256b7c3cc",
+        "rev": "ac34158a823c7596e0106c806d0b7df47885fa73",
         "type": "github"
       },
       "original": {
@@ -928,11 +928,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1713442664,
-        "narHash": "sha256-LoExypse3c/uun/39u4bPTN4wejIF7hNsdITZO41qTw=",
+        "lastModified": 1714594348,
+        "narHash": "sha256-fL6twwN/npU94mvumU5ho/uhM/fwePCRQ9lwamm2lds=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d764f230634fa4f86dc8d01c6af9619c7cc5d225",
+        "rev": "1c74cc292b61614e74c1cf0d372f79d57fb4936b",
         "type": "github"
       },
       "original": {
@@ -944,11 +944,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1713596654,
-        "narHash": "sha256-LJbHQQ5aX1LVth2ST+Kkse/DRzgxlVhTL1rxthvyhZc=",
+        "lastModified": 1714213793,
+        "narHash": "sha256-Yg5D5LhyAZvd3DZrQQfJAVK8K3TkUYKooFtH1ulM0mw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fd16bb6d3bcca96039b11aa52038fafeb6e4f4be",
+        "rev": "d6f6eb2a984f2ba9a366c31e4d36d65465683450",
         "type": "github"
       },
       "original": {
@@ -977,11 +977,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1713837627,
-        "narHash": "sha256-rz+JMd/hsUEDNVan2sCuEGtbsOVi6oRmPtps+7qSXQE=",
+        "lastModified": 1715160812,
+        "narHash": "sha256-/zTOFwCSBETBgkILpP8h82ZjN7LiMV0Uk5d2TEnQVU4=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "8f3c541407e691af6163e2447f3af1bd6e17f9a3",
+        "rev": "cd2cf0c124d3de577fb5449746568ee8e601afc8",
         "type": "github"
       },
       "original": {
@@ -993,11 +993,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1714406347,
-        "narHash": "sha256-sPM6vYkOCmQ9y+1w6whtDeoWzSzzjabzi9RH9EkZLng=",
+        "lastModified": 1715152811,
+        "narHash": "sha256-LMzLDbkKVmRRhwaUaroCRGUsKe/fwzgwV1gbvr/t6WQ=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "aa5f4f4ee10b2688fb37fa46215672441d5cd5d9",
+        "rev": "a3d9395455f2b2e3b50a0b0f37b8b4c23683f44a",
         "type": "github"
       },
       "original": {
@@ -1057,11 +1057,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712897695,
-        "narHash": "sha256-nMirxrGteNAl9sWiOhoN5tIHyjBbVi5e2tgZUgZlK3Y=",
+        "lastModified": 1714478972,
+        "narHash": "sha256-q//cgb52vv81uOuwz1LaXElp3XAe1TqrABXODAEF6Sk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "40e6053ecb65fcbf12863338a6dcefb3f55f1bf8",
+        "rev": "2849da033884f54822af194400f8dff435ada242",
         "type": "github"
       },
       "original": {
@@ -1079,11 +1079,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1712897695,
-        "narHash": "sha256-nMirxrGteNAl9sWiOhoN5tIHyjBbVi5e2tgZUgZlK3Y=",
+        "lastModified": 1713954846,
+        "narHash": "sha256-RWFafuSb5nkWGu8dDbW7gVb8FOQOPqmX/9MlxUUDguw=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "40e6053ecb65fcbf12863338a6dcefb3f55f1bf8",
+        "rev": "6fb82e44254d6a0ece014ec423cb62d92435336f",
         "type": "github"
       },
       "original": {
@@ -1155,11 +1155,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1714763803,
-        "narHash": "sha256-BwrqxAmmspIHlPPiI53p4jyIhJlZYqGWj73RKSgJm/4=",
+        "lastModified": 1714829223,
+        "narHash": "sha256-d/7geM2EKyysTwqJqliZo1qbbeezH1DzpxczyKZO84w=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "fbcb320d74cdc877d111a6462693059fb819df91",
+        "rev": "2eb8776df1aab03f514b38ddc39af57efbd8970b",
         "type": "github"
       },
       "original": {
@@ -1323,11 +1323,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1714371374,
-        "narHash": "sha256-gc+8GgFSM87dbcYUW8d9If3qY80xJMmy48vnVezNLPk=",
+        "lastModified": 1715028064,
+        "narHash": "sha256-DSUTxUFCesXuaJjrDNvurILUt1IrO5MI5ukbZ8D87zQ=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "794bba734ec95eaff9bb82fbd112473be2087283",
+        "rev": "5b9067899ee6a2538891573500e8fd6ff008440f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/9cafac31a091267838e1e90fd6e083d37611f516' (2024-05-01)
  → 'github:lewis6991/gitsigns.nvim/805610a9393fa231f2c2b49cb521bfa413fadb3d' (2024-05-06)
• Updated input 'home-manager':
    'github:nix-community/home-manager/9036fe9ef8e15a819fa76f47a8b1f287903fb848' (2024-05-02)
  → 'github:nix-community/home-manager/f2c5ba5e720fd584d83f2f97399dac0d26ae60b9' (2024-05-10)
• Updated input 'lsp-signature-nvim':
    'github:ray-x/lsp_signature.nvim/c6aeb2f1d2538bbdfdaab1664d9d4c3c75aa9db8' (2024-03-17)
  → 'github:ray-x/lsp_signature.nvim/aed5d1162b0f07bb3af34bedcc5f70a2b6466ed8' (2024-05-10)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/9b2c33c7fa0287db93868d955e7b3d0da3837a57' (2024-05-03)
  → 'github:nix-community/neovim-nightly-overlay/2b11e4433355b57784dd002d34cf810874fa044d' (2024-05-10)
• Updated input 'neovim-nightly-overlay/neovim-flake':
    'github:neovim/neovim/01e4a70d668d54a7cefa3ff53ec97e39df516265?dir=contrib' (2024-05-02)
  → 'github:neovim/neovim/ca735c7554701a1191e6afdac2ea4b4f94ba6d88?dir=contrib' (2024-05-09)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/94035b482d181af0a0f8f77823a790b256b7c3cc' (2024-05-02)
  → 'github:nixos/nixpkgs/ac34158a823c7596e0106c806d0b7df47885fa73' (2024-05-09)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/8f3c541407e691af6163e2447f3af1bd6e17f9a3' (2024-04-23)
  → 'github:hrsh7th/nvim-cmp/cd2cf0c124d3de577fb5449746568ee8e601afc8' (2024-05-08)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/aa5f4f4ee10b2688fb37fa46215672441d5cd5d9' (2024-04-29)
  → 'github:neovim/nvim-lspconfig/a3d9395455f2b2e3b50a0b0f37b8b4c23683f44a' (2024-05-08)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/fbcb320d74cdc877d111a6462693059fb819df91' (2024-05-03)
  → 'github:mrcjkb/rustaceanvim/2eb8776df1aab03f514b38ddc39af57efbd8970b' (2024-05-04)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/f72e57d2ebc0cd21d208ecc245a2c6dcd4c8c2b3' (2024-04-20)
  → 'github:nvim-neorocks/neorocks/4333320b464e10e1e8ffefbf6e0b4055c79bbfd3' (2024-05-03)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:neovim/neovim/4d52b0cf670502caf81b70f2f1e6f8c548b78f58?dir=contrib' (2024-04-20)
  → 'github:neovim/neovim/cf9f002f31c8b4d9d42912a3f45f5d3db4462fd9?dir=contrib' (2024-05-03)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/d764f230634fa4f86dc8d01c6af9619c7cc5d225' (2024-04-18)
  → 'github:nixos/nixpkgs/1c74cc292b61614e74c1cf0d372f79d57fb4936b' (2024-05-01)
• Updated input 'rustacean-nvim/neorocks/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/40e6053ecb65fcbf12863338a6dcefb3f55f1bf8' (2024-04-12)
  → 'github:cachix/pre-commit-hooks.nix/2849da033884f54822af194400f8dff435ada242' (2024-04-30)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/fd16bb6d3bcca96039b11aa52038fafeb6e4f4be' (2024-04-20)
  → 'github:nixos/nixpkgs/d6f6eb2a984f2ba9a366c31e4d36d65465683450' (2024-04-27)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/40e6053ecb65fcbf12863338a6dcefb3f55f1bf8' (2024-04-12)
  → 'github:cachix/pre-commit-hooks.nix/6fb82e44254d6a0ece014ec423cb62d92435336f' (2024-04-24)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/794bba734ec95eaff9bb82fbd112473be2087283' (2024-04-29)
  → 'github:nvim-tree/nvim-web-devicons/5b9067899ee6a2538891573500e8fd6ff008440f' (2024-05-06)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/neovim/neovim): [`4d52b0cf` ➡️ `cf9f002f`](https://github.com/neovim/neovim/compare/4d52b0cf670502caf81b70f2f1e6f8c548b78f58...cf9f002f31c8b4d9d42912a3f45f5d3db4462fd9) <sub>(2024-04-20 to 2024-05-03)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`fbcb320d` ➡️ `2eb8776d`](https://github.com/mrcjkb/rustaceanvim/compare/fbcb320d74cdc877d111a6462693059fb819df91...2eb8776df1aab03f514b38ddc39af57efbd8970b) <sub>(2024-05-03 to 2024-05-04)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`d764f230` ➡️ `1c74cc29`](https://github.com/nixos/nixpkgs/compare/d764f230634fa4f86dc8d01c6af9619c7cc5d225...1c74cc292b61614e74c1cf0d372f79d57fb4936b) <sub>(2024-04-18 to 2024-05-01)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`f72e57d2` ➡️ `4333320b`](https://github.com/nvim-neorocks/neorocks/compare/f72e57d2ebc0cd21d208ecc245a2c6dcd4c8c2b3...4333320b464e10e1e8ffefbf6e0b4055c79bbfd3) <sub>(2024-04-20 to 2024-05-03)</sub>
 - Updated input [`lsp-signature-nvim`](https://github.com/ray-x/lsp_signature.nvim): [`c6aeb2f1` ➡️ `aed5d116`](https://github.com/ray-x/lsp_signature.nvim/compare/c6aeb2f1d2538bbdfdaab1664d9d4c3c75aa9db8...aed5d1162b0f07bb3af34bedcc5f70a2b6466ed8) <sub>(2024-03-17 to 2024-05-10)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`9b2c33c7` ➡️ `2b11e443`](https://github.com/nix-community/neovim-nightly-overlay/compare/9b2c33c7fa0287db93868d955e7b3d0da3837a57...2b11e4433355b57784dd002d34cf810874fa044d) <sub>(2024-05-03 to 2024-05-10)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`aa5f4f4e` ➡️ `a3d93954`](https://github.com/neovim/nvim-lspconfig/compare/aa5f4f4ee10b2688fb37fa46215672441d5cd5d9...a3d9395455f2b2e3b50a0b0f37b8b4c23683f44a) <sub>(2024-04-29 to 2024-05-08)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`8f3c5414` ➡️ `cd2cf0c1`](https://github.com/hrsh7th/nvim-cmp/compare/8f3c541407e691af6163e2447f3af1bd6e17f9a3...cd2cf0c124d3de577fb5449746568ee8e601afc8) <sub>(2024-04-23 to 2024-05-08)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`40e6053e` ➡️ `6fb82e44`](https://github.com/cachix/pre-commit-hooks.nix/compare/40e6053ecb65fcbf12863338a6dcefb3f55f1bf8...6fb82e44254d6a0ece014ec423cb62d92435336f) <sub>(2024-04-12 to 2024-04-24)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`fd16bb6d` ➡️ `d6f6eb2a`](https://github.com/nixos/nixpkgs/compare/fd16bb6d3bcca96039b11aa52038fafeb6e4f4be...d6f6eb2a984f2ba9a366c31e4d36d65465683450) <sub>(2024-04-20 to 2024-04-27)</sub>
 - Updated input [`rustacean-nvim/neorocks/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`40e6053e` ➡️ `2849da03`](https://github.com/cachix/pre-commit-hooks.nix/compare/40e6053ecb65fcbf12863338a6dcefb3f55f1bf8...2849da033884f54822af194400f8dff435ada242) <sub>(2024-04-12 to 2024-04-30)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`9cafac31` ➡️ `805610a9`](https://github.com/lewis6991/gitsigns.nvim/compare/9cafac31a091267838e1e90fd6e083d37611f516...805610a9393fa231f2c2b49cb521bfa413fadb3d) <sub>(2024-05-01 to 2024-05-06)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`94035b48` ➡️ `ac34158a`](https://github.com/nixos/nixpkgs/compare/94035b482d181af0a0f8f77823a790b256b7c3cc...ac34158a823c7596e0106c806d0b7df47885fa73) <sub>(2024-05-02 to 2024-05-09)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-flake`](https://github.com/neovim/neovim): [`01e4a70d` ➡️ `ca735c75`](https://github.com/neovim/neovim/compare/01e4a70d668d54a7cefa3ff53ec97e39df516265...ca735c7554701a1191e6afdac2ea4b4f94ba6d88) <sub>(2024-05-02 to 2024-05-09)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`794bba73` ➡️ `5b906789`](https://github.com/nvim-tree/nvim-web-devicons/compare/794bba734ec95eaff9bb82fbd112473be2087283...5b9067899ee6a2538891573500e8fd6ff008440f) <sub>(2024-04-29 to 2024-05-06)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`9036fe9e` ➡️ `f2c5ba5e`](https://github.com/nix-community/home-manager/compare/9036fe9ef8e15a819fa76f47a8b1f287903fb848...f2c5ba5e720fd584d83f2f97399dac0d26ae60b9) <sub>(2024-05-02 to 2024-05-10)</sub>