### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "cmp-lsp-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1702205473,
-        "narHash": "sha256-/0sh9vJBD9pUuD7q3tNSQ1YLvxFMNykdg5eG+LjZAA8=",
+        "lastModified": 1715931395,
+        "narHash": "sha256-CT1+Z4XJBVsl/RqvJeGmyitD6x7So0ylXvvef5jh7I8=",
         "owner": "hrsh7th",
         "repo": "cmp-nvim-lsp",
-        "rev": "5af77f54de1b16c34b23cba810150689a3a90312",
+        "rev": "39e2eda76828d88b773cc27a3f61d2ad782c922d",
         "type": "github"
       },
       "original": {
@@ -369,11 +369,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1714601825,
-        "narHash": "sha256-0ujueJ226zEmjkFwodSukO1Zu5gMvTmx/dCtT5VBhek=",
+        "lastModified": 1715976636,
+        "narHash": "sha256-517q3oPvshwUBhXEDuB23S0RPuHvSZWK/1tr6wDhEyA=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "ce882460cf3db12e99f8bf579cbf99e331f6dd4f",
+        "rev": "5a9bd42dd8dd127779f3cd8982a0419b7ca9c7f5",
         "type": "github"
       },
       "original": {
@@ -523,11 +523,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715359697,
-        "narHash": "sha256-FJYyXqulIbCdsUCTFBTu/bIH4aN+7jzjQAn52Qc6qPg=",
+        "lastModified": 1715930644,
+        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f2c5ba5e720fd584d83f2f97399dac0d26ae60b9",
+        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
         "type": "github"
       },
       "original": {
@@ -557,11 +557,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1713780596,
-        "narHash": "sha256-DDAYNGSnrBwvVfpKx+XjkuecpoE9HiEf6JW+DBQgvm0=",
+        "lastModified": 1715621965,
+        "narHash": "sha256-S5Wzi3hhFOiCaeZqmx3zBdrv8KzaEafD5hCfY8ixz0A=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "110e6dc761d5c3d352574def3479a9c39dfc4358",
+        "rev": "46d2206858657d439792926958f52b037534de49",
         "type": "github"
       },
       "original": {
@@ -654,11 +654,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1714473569,
-        "narHash": "sha256-SK7IFQgRMAraTzmErl2ldJ62bsfUCbKFW5MesUpDXoQ=",
+        "lastModified": 1715959338,
+        "narHash": "sha256-FtXRgulUjadwYn4lzSIDpAm5eCWrCLSYhqpu86Ln4VY=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "b152822e1a4bafb6bdf11a16cc26525cbd95ee00",
+        "rev": "03c607c2bd4db0238d8f93a6393ffbd931466390",
         "type": "github"
       },
       "original": {
@@ -715,11 +715,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1715292729,
-        "narHash": "sha256-Ml5HzPmVx/fnLedNpBYQs3YG2zhSKsPga89yaCDVYlM=",
+        "lastModified": 1715815279,
+        "narHash": "sha256-Pf7ZlqPnr195NZb5ADzMVsXurPMjRZ+JMXf6JxvXArE=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "ca735c7554701a1191e6afdac2ea4b4f94ba6d88",
+        "rev": "9ca81b025990911c2a0dbda92af39ba84983bac3",
         "type": "github"
       },
       "original": {
@@ -765,11 +765,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715299512,
-        "narHash": "sha256-IYOsXQt04EIHfNhjwbDhSY/n3vQGhSiL/XHuMGnZnek=",
+        "lastModified": 1715817852,
+        "narHash": "sha256-UH5o7hT72oAavJTG2NxlpMyQe3BQMniQAsgTugWtlc4=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "2b11e4433355b57784dd002d34cf810874fa044d",
+        "rev": "7b5ca2486bba58cac80b9229209239740b67cf90",
         "type": "github"
       },
       "original": {
@@ -880,11 +880,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1715220225,
-        "narHash": "sha256-X0xvboLSjfC5s/M1yuPdSdc6yzKV8536hTTWCSKF5Xc=",
+        "lastModified": 1715867414,
+        "narHash": "sha256-cu4UEffKkBByyGR6CFs9XP6iSNsKTkq1r66DA5BkYnE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ac34158a823c7596e0106c806d0b7df47885fa73",
+        "rev": "bf446f08bff6814b569265bef8374cfdd3d8f0e0",
         "type": "github"
       },
       "original": {
@@ -977,11 +977,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1715160812,
-        "narHash": "sha256-/zTOFwCSBETBgkILpP8h82ZjN7LiMV0Uk5d2TEnQVU4=",
+        "lastModified": 1715954188,
+        "narHash": "sha256-GhXfnWqpXFVM7Yi9+qEXHfA6LIMILcMG9pP4VYXuptE=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "cd2cf0c124d3de577fb5449746568ee8e601afc8",
+        "rev": "5260e5e8ecadaf13e6b82cf867a909f54e15fd07",
         "type": "github"
       },
       "original": {
@@ -993,11 +993,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1715152811,
-        "narHash": "sha256-LMzLDbkKVmRRhwaUaroCRGUsKe/fwzgwV1gbvr/t6WQ=",
+        "lastModified": 1715938827,
+        "narHash": "sha256-usWyZNCEwdTpbPMTYGcbuc+yiMnNYiwqyF5OL9RcGNE=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "a3d9395455f2b2e3b50a0b0f37b8b4c23683f44a",
+        "rev": "a284b14b3a9c4851f900286cd7eb68e3a8f90b1c",
         "type": "github"
       },
       "original": {
@@ -1155,11 +1155,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1714829223,
-        "narHash": "sha256-d/7geM2EKyysTwqJqliZo1qbbeezH1DzpxczyKZO84w=",
+        "lastModified": 1715892036,
+        "narHash": "sha256-21SgWuc1oZfgUcYb8/CBfgJjm6e0JHWpfntCe5dgSHM=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "2eb8776df1aab03f514b38ddc39af57efbd8970b",
+        "rev": "50c09f3afa35d3b32e09ac1b155e95c53a98b8e8",
         "type": "github"
       },
       "original": {
@@ -1307,11 +1307,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1714700089,
-        "narHash": "sha256-SoEetPE7f7Y0kUa4+7dH+EOs/0WBsMDxeOkbVNuoSjE=",
+        "lastModified": 1715968939,
+        "narHash": "sha256-+h0L5vpwXFNDuzE5Dne5zWuKtZ1mquAhdplHcUxPg8w=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "fac83a556e7b710dc31433dec727361ca062dbe9",
+        "rev": "0c12735d5aff6a48ffd8111bf144dc2ff44e5975",
         "type": "github"
       },
       "original": {
@@ -1323,11 +1323,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1715028064,
-        "narHash": "sha256-DSUTxUFCesXuaJjrDNvurILUt1IrO5MI5ukbZ8D87zQ=",
+        "lastModified": 1715644375,
+        "narHash": "sha256-1trRSUVyWFl3K+7xHXQGNl/EwE0ggyigQpZ+kmRPsk8=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "5b9067899ee6a2538891573500e8fd6ff008440f",
+        "rev": "e37bb1feee9e7320c76050a55443fa843b4b6f83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'cmp-lsp-nvim':
    'github:hrsh7th/cmp-nvim-lsp/5af77f54de1b16c34b23cba810150689a3a90312' (2023-12-10)
  → 'github:hrsh7th/cmp-nvim-lsp/39e2eda76828d88b773cc27a3f61d2ad782c922d' (2024-05-17)
• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/ce882460cf3db12e99f8bf579cbf99e331f6dd4f' (2024-05-01)
  → 'github:tpope/vim-fugitive/5a9bd42dd8dd127779f3cd8982a0419b7ca9c7f5' (2024-05-17)
• Updated input 'home-manager':
    'github:nix-community/home-manager/f2c5ba5e720fd584d83f2f97399dac0d26ae60b9' (2024-05-10)
  → 'github:nix-community/home-manager/e3ad5108f54177e6520535768ddbf1e6af54b59d' (2024-05-17)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/110e6dc761d5c3d352574def3479a9c39dfc4358' (2024-04-22)
  → 'github:hyprwm/contrib/46d2206858657d439792926958f52b037534de49' (2024-05-13)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/b152822e1a4bafb6bdf11a16cc26525cbd95ee00' (2024-04-30)
  → 'github:L3MON4D3/LuaSnip/03c607c2bd4db0238d8f93a6393ffbd931466390' (2024-05-17)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/2b11e4433355b57784dd002d34cf810874fa044d' (2024-05-10)
  → 'github:nix-community/neovim-nightly-overlay/7b5ca2486bba58cac80b9229209239740b67cf90' (2024-05-16)
• Updated input 'neovim-nightly-overlay/neovim-flake':
    'github:neovim/neovim/ca735c7554701a1191e6afdac2ea4b4f94ba6d88?dir=contrib' (2024-05-09)
  → 'github:neovim/neovim/9ca81b025990911c2a0dbda92af39ba84983bac3?dir=contrib' (2024-05-15)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/ac34158a823c7596e0106c806d0b7df47885fa73' (2024-05-09)
  → 'github:nixos/nixpkgs/bf446f08bff6814b569265bef8374cfdd3d8f0e0' (2024-05-16)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/cd2cf0c124d3de577fb5449746568ee8e601afc8' (2024-05-08)
  → 'github:hrsh7th/nvim-cmp/5260e5e8ecadaf13e6b82cf867a909f54e15fd07' (2024-05-17)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/a3d9395455f2b2e3b50a0b0f37b8b4c23683f44a' (2024-05-08)
  → 'github:neovim/nvim-lspconfig/a284b14b3a9c4851f900286cd7eb68e3a8f90b1c' (2024-05-17)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/2eb8776df1aab03f514b38ddc39af57efbd8970b' (2024-05-04)
  → 'github:mrcjkb/rustaceanvim/50c09f3afa35d3b32e09ac1b155e95c53a98b8e8' (2024-05-16)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/fac83a556e7b710dc31433dec727361ca062dbe9' (2024-05-03)
  → 'github:nvim-telescope/telescope.nvim/0c12735d5aff6a48ffd8111bf144dc2ff44e5975' (2024-05-17)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/5b9067899ee6a2538891573500e8fd6ff008440f' (2024-05-06)
  → 'github:nvim-tree/nvim-web-devicons/e37bb1feee9e7320c76050a55443fa843b4b6f83' (2024-05-13)

```

</p></details>

 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`2eb8776d` ➡️ `50c09f3a`](https://github.com/mrcjkb/rustaceanvim/compare/2eb8776df1aab03f514b38ddc39af57efbd8970b...50c09f3afa35d3b32e09ac1b155e95c53a98b8e8) <sub>(2024-05-04 to 2024-05-16)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`ce882460` ➡️ `5a9bd42d`](https://github.com/tpope/vim-fugitive/compare/ce882460cf3db12e99f8bf579cbf99e331f6dd4f...5a9bd42dd8dd127779f3cd8982a0419b7ca9c7f5) <sub>(2024-05-01 to 2024-05-17)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`2b11e443` ➡️ `7b5ca248`](https://github.com/nix-community/neovim-nightly-overlay/compare/2b11e4433355b57784dd002d34cf810874fa044d...7b5ca2486bba58cac80b9229209239740b67cf90) <sub>(2024-05-10 to 2024-05-16)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`b152822e` ➡️ `03c607c2`](https://github.com/L3MON4D3/LuaSnip/compare/b152822e1a4bafb6bdf11a16cc26525cbd95ee00...03c607c2bd4db0238d8f93a6393ffbd931466390) <sub>(2024-04-30 to 2024-05-17)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`110e6dc7` ➡️ `46d22068`](https://github.com/hyprwm/contrib/compare/110e6dc761d5c3d352574def3479a9c39dfc4358...46d2206858657d439792926958f52b037534de49) <sub>(2024-04-22 to 2024-05-13)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`a3d93954` ➡️ `a284b14b`](https://github.com/neovim/nvim-lspconfig/compare/a3d9395455f2b2e3b50a0b0f37b8b4c23683f44a...a284b14b3a9c4851f900286cd7eb68e3a8f90b1c) <sub>(2024-05-08 to 2024-05-17)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`cd2cf0c1` ➡️ `5260e5e8`](https://github.com/hrsh7th/nvim-cmp/compare/cd2cf0c124d3de577fb5449746568ee8e601afc8...5260e5e8ecadaf13e6b82cf867a909f54e15fd07) <sub>(2024-05-08 to 2024-05-17)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`ac34158a` ➡️ `bf446f08`](https://github.com/nixos/nixpkgs/compare/ac34158a823c7596e0106c806d0b7df47885fa73...bf446f08bff6814b569265bef8374cfdd3d8f0e0) <sub>(2024-05-09 to 2024-05-16)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`fac83a55` ➡️ `0c12735d`](https://github.com/nvim-telescope/telescope.nvim/compare/fac83a556e7b710dc31433dec727361ca062dbe9...0c12735d5aff6a48ffd8111bf144dc2ff44e5975) <sub>(2024-05-03 to 2024-05-17)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-flake`](https://github.com/neovim/neovim): [`ca735c75` ➡️ `9ca81b02`](https://github.com/neovim/neovim/compare/ca735c7554701a1191e6afdac2ea4b4f94ba6d88...9ca81b025990911c2a0dbda92af39ba84983bac3) <sub>(2024-05-09 to 2024-05-15)</sub>
 - Updated input [`cmp-lsp-nvim`](https://github.com/hrsh7th/cmp-nvim-lsp): [`5af77f54` ➡️ `39e2eda7`](https://github.com/hrsh7th/cmp-nvim-lsp/compare/5af77f54de1b16c34b23cba810150689a3a90312...39e2eda76828d88b773cc27a3f61d2ad782c922d) <sub>(2023-12-10 to 2024-05-17)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`5b906789` ➡️ `e37bb1fe`](https://github.com/nvim-tree/nvim-web-devicons/compare/5b9067899ee6a2538891573500e8fd6ff008440f...e37bb1feee9e7320c76050a55443fa843b4b6f83) <sub>(2024-05-06 to 2024-05-13)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`f2c5ba5e` ➡️ `e3ad5108`](https://github.com/nix-community/home-manager/compare/f2c5ba5e720fd584d83f2f97399dac0d26ae60b9...e3ad5108f54177e6520535768ddbf1e6af54b59d) <sub>(2024-05-10 to 2024-05-17)</sub>