### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "cmp-lsp-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1702205473,
-        "narHash": "sha256-/0sh9vJBD9pUuD7q3tNSQ1YLvxFMNykdg5eG+LjZAA8=",
+        "lastModified": 1715931395,
+        "narHash": "sha256-CT1+Z4XJBVsl/RqvJeGmyitD6x7So0ylXvvef5jh7I8=",
         "owner": "hrsh7th",
         "repo": "cmp-nvim-lsp",
-        "rev": "5af77f54de1b16c34b23cba810150689a3a90312",
+        "rev": "39e2eda76828d88b773cc27a3f61d2ad782c922d",
         "type": "github"
       },
       "original": {
@@ -144,6 +144,22 @@
         "type": "github"
       }
     },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -152,11 +168,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714641030,
-        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
+        "lastModified": 1715865404,
+        "narHash": "sha256-/GJvTdTpuDjNn84j82cU6bXztE0MSkdnTWClUCRub78=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
+        "rev": "8dc45382d5206bd292f9c2768b8058a8fd8311d9",
         "type": "github"
       },
       "original": {
@@ -245,24 +261,6 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
         "lastModified": 1694529238,
         "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
@@ -276,9 +274,9 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
+    "flake-utils_3": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1681202837,
@@ -286,6 +284,24 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -348,32 +364,14 @@
         "type": "github"
       }
     },
-    "flake-utils_8": {
-      "inputs": {
-        "systems": "systems_8"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1714601825,
-        "narHash": "sha256-0ujueJ226zEmjkFwodSukO1Zu5gMvTmx/dCtT5VBhek=",
+        "lastModified": 1716130336,
+        "narHash": "sha256-nyNtb3nsS/zFdSNRyXabcGIabAwgivJIUFB2c62vXmA=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "ce882460cf3db12e99f8bf579cbf99e331f6dd4f",
+        "rev": "4f59455d2388e113bd510e85b310d15b9228ca0d",
         "type": "github"
       },
       "original": {
@@ -436,6 +434,28 @@
     "gitignore": {
       "inputs": {
         "nixpkgs": [
+          "neovim-nightly-overlay",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
           "rustacean-nvim",
           "neorocks",
           "pre-commit-hooks",
@@ -456,7 +476,7 @@
         "type": "github"
       }
     },
-    "gitignore_2": {
+    "gitignore_3": {
       "inputs": {
         "nixpkgs": [
           "rustacean-nvim",
@@ -481,11 +501,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1715007445,
-        "narHash": "sha256-v21qTJfiv57vSUDGCJ4wM+L0Ixwh2b3pkoESFAHBrDM=",
+        "lastModified": 1716453598,
+        "narHash": "sha256-TTC3uvRsq4v6PBdS/3YAGpyhVt0w3/SGkPE3fu1zW94=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "805610a9393fa231f2c2b49cb521bfa413fadb3d",
+        "rev": "cdfcd9d39d23c46ae9a040de2c6a8b8bf868746e",
         "type": "github"
       },
       "original": {
@@ -523,11 +543,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715359697,
-        "narHash": "sha256-FJYyXqulIbCdsUCTFBTu/bIH4aN+7jzjQAn52Qc6qPg=",
+        "lastModified": 1716457508,
+        "narHash": "sha256-ZxzffLuWRyuMrkVVq7wastNUqeO0HJL9xqfY1QsYaqo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f2c5ba5e720fd584d83f2f97399dac0d26ae60b9",
+        "rev": "850cb322046ef1a268449cf1ceda5fd24d930b05",
         "type": "github"
       },
       "original": {
@@ -557,11 +577,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1713780596,
-        "narHash": "sha256-DDAYNGSnrBwvVfpKx+XjkuecpoE9HiEf6JW+DBQgvm0=",
+        "lastModified": 1716228712,
+        "narHash": "sha256-y+LOXuSRMfkR2Vfwl5K2NVrszi1h5MJpML+msLnVS8U=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "110e6dc761d5c3d352574def3479a9c39dfc4358",
+        "rev": "33b38358559054d316eb605ccb733980dfa7dc63",
         "type": "github"
       },
       "original": {
@@ -606,11 +626,11 @@
     "lsp-signature-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1715342515,
-        "narHash": "sha256-f4AuZnt2m2VA90baSbZt6+elzjXmJKPFTO28v8auoYc=",
+        "lastModified": 1716506401,
+        "narHash": "sha256-YNkRZGHbgfK/8POjtAGASiDMr9GeU61DNhti+K8iWUk=",
         "owner": "ray-x",
         "repo": "lsp_signature.nvim",
-        "rev": "aed5d1162b0f07bb3af34bedcc5f70a2b6466ed8",
+        "rev": "43729353dec224fa620a877639b8b0744112b286",
         "type": "github"
       },
       "original": {
@@ -654,11 +674,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1714473569,
-        "narHash": "sha256-SK7IFQgRMAraTzmErl2ldJ62bsfUCbKFW5MesUpDXoQ=",
+        "lastModified": 1716536093,
+        "narHash": "sha256-WP71ChUQR67GJ/hsynv3/KAfojVFqTqYRVkmUmC9aqo=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "b152822e1a4bafb6bdf11a16cc26525cbd95ee00",
+        "rev": "878ace11983444d865a72e1759dbcc331d1ace4c",
         "type": "github"
       },
       "original": {
@@ -685,11 +705,11 @@
     },
     "neorocks": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_5",
+        "flake-compat": "flake-compat_3",
+        "flake-utils": "flake-utils_4",
         "neovim-nightly": "neovim-nightly",
         "nixpkgs": "nixpkgs_5",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
         "lastModified": 1714773380,
@@ -705,33 +725,9 @@
         "type": "github"
       }
     },
-    "neovim-flake": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": [
-          "neovim-nightly-overlay",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "dir": "contrib",
-        "lastModified": 1715292729,
-        "narHash": "sha256-Ml5HzPmVx/fnLedNpBYQs3YG2zhSKsPga89yaCDVYlM=",
-        "owner": "neovim",
-        "repo": "neovim",
-        "rev": "ca735c7554701a1191e6afdac2ea4b4f94ba6d88",
-        "type": "github"
-      },
-      "original": {
-        "dir": "contrib",
-        "owner": "neovim",
-        "repo": "neovim",
-        "type": "github"
-      }
-    },
     "neovim-nightly": {
       "inputs": {
-        "flake-utils": "flake-utils_6",
+        "flake-utils": "flake-utils_5",
         "nixpkgs": [
           "rustacean-nvim",
           "neorocks",
@@ -759,22 +755,39 @@
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "hercules-ci-effects": "hercules-ci-effects",
-        "neovim-flake": "neovim-flake",
+        "neovim-src": "neovim-src",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1715299512,
-        "narHash": "sha256-IYOsXQt04EIHfNhjwbDhSY/n3vQGhSiL/XHuMGnZnek=",
+        "lastModified": 1716561825,
+        "narHash": "sha256-v9V74Xd1/n0n/1eB3gZ+LqcOCurWqTfBum5azqjWMII=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "2b11e4433355b57784dd002d34cf810874fa044d",
+        "rev": "d83afee1f19108100bd2fef1f86d87d2942d734d",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
+        "type": "github"
+      }
+    },
+    "neovim-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1716501420,
+        "narHash": "sha256-VO9RCUNwiU627oVjR5gfsyz8z6VHkuW2VFT53xth1ig=",
+        "owner": "neovim",
+        "repo": "neovim",
+        "rev": "e7859d2ad504a3e3cae1d540d5fd4f9b560d154a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "neovim",
+        "repo": "neovim",
         "type": "github"
       }
     },
@@ -880,11 +893,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1715220225,
-        "narHash": "sha256-X0xvboLSjfC5s/M1yuPdSdc6yzKV8536hTTWCSKF5Xc=",
+        "lastModified": 1716451822,
+        "narHash": "sha256-0lT5RVelqN+dgXWWneXvV5ufSksW0r0TDQi8O6U2+o8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ac34158a823c7596e0106c806d0b7df47885fa73",
+        "rev": "3305b2b25e4ae4baee872346eae133cf6f611783",
         "type": "github"
       },
       "original": {
@@ -977,11 +990,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1715160812,
-        "narHash": "sha256-/zTOFwCSBETBgkILpP8h82ZjN7LiMV0Uk5d2TEnQVU4=",
+        "lastModified": 1715954188,
+        "narHash": "sha256-GhXfnWqpXFVM7Yi9+qEXHfA6LIMILcMG9pP4VYXuptE=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "cd2cf0c124d3de577fb5449746568ee8e601afc8",
+        "rev": "5260e5e8ecadaf13e6b82cf867a909f54e15fd07",
         "type": "github"
       },
       "original": {
@@ -993,11 +1006,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1715152811,
-        "narHash": "sha256-LMzLDbkKVmRRhwaUaroCRGUsKe/fwzgwV1gbvr/t6WQ=",
+        "lastModified": 1716498901,
+        "narHash": "sha256-PMMqPDnq4Q8gWeKQ2WPE+pOf1R1G61wJ+bAWkHpQlzE=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "a3d9395455f2b2e3b50a0b0f37b8b4c23683f44a",
+        "rev": "b972e7154bc94ab4ecdbb38c8edbccac36f83996",
         "type": "github"
       },
       "original": {
@@ -1008,7 +1021,7 @@
     },
     "osh-oxy": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -1031,11 +1044,11 @@
     "plenary-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1714083960,
-        "narHash": "sha256-vy0MXEoSM4rvYpfwbc2PnilvMOA30Urv0FAxjXuvqQ8=",
+        "lastModified": 1716230027,
+        "narHash": "sha256-5Jf2mWFVDofXBcXLbMa417mqlEPWLA+cQIZH/vNEV1g=",
         "owner": "nvim-lua",
         "repo": "plenary.nvim",
-        "rev": "08e301982b9a057110ede7a735dd1b5285eb341f",
+        "rev": "a3e3bc82a3f95c5ed0d7201546d5d2c19b20d683",
         "type": "github"
       },
       "original": {
@@ -1046,9 +1059,36 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_7",
+        "flake-compat": "flake-compat_2",
         "gitignore": "gitignore",
+        "nixpkgs": [
+          "neovim-nightly-overlay",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "neovim-nightly-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1716213921,
+        "narHash": "sha256-xrsYFST8ij4QWaV6HEokCUNIZLjjLP1bYC60K8XiBVA=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "0e8fcc54b842ad8428c9e705cb5994eaf05c26a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_4",
+        "flake-utils": "flake-utils_6",
+        "gitignore": "gitignore_2",
         "nixpkgs": [
           "rustacean-nvim",
           "neorocks",
@@ -1070,11 +1110,11 @@
         "type": "github"
       }
     },
-    "pre-commit-hooks_2": {
+    "pre-commit-hooks_3": {
       "inputs": {
-        "flake-compat": "flake-compat_4",
-        "flake-utils": "flake-utils_8",
-        "gitignore": "gitignore_2",
+        "flake-compat": "flake-compat_5",
+        "flake-utils": "flake-utils_7",
+        "gitignore": "gitignore_3",
         "nixpkgs": "nixpkgs_7",
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
@@ -1129,7 +1169,7 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
@@ -1152,14 +1192,14 @@
         "gen-luarc": "gen-luarc",
         "neorocks": "neorocks",
         "nixpkgs": "nixpkgs_6",
-        "pre-commit-hooks": "pre-commit-hooks_2"
+        "pre-commit-hooks": "pre-commit-hooks_3"
       },
       "locked": {
-        "lastModified": 1714829223,
-        "narHash": "sha256-d/7geM2EKyysTwqJqliZo1qbbeezH1DzpxczyKZO84w=",
+        "lastModified": 1716536666,
+        "narHash": "sha256-TwYkEdCV+M/pYWCvSCHBNqE2uLjmbXYnBoCnInfKOAU=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "2eb8776df1aab03f514b38ddc39af57efbd8970b",
+        "rev": "90bfbc588fef7e44d82e5aba8dfc787e8d3f5d1a",
         "type": "github"
       },
       "original": {
@@ -1273,21 +1313,6 @@
         "type": "github"
       }
     },
-    "systems_8": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "telescope-fzf-native-nvim": {
       "flake": false,
       "locked": {
@@ -1307,11 +1332,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1714700089,
-        "narHash": "sha256-SoEetPE7f7Y0kUa4+7dH+EOs/0WBsMDxeOkbVNuoSjE=",
+        "lastModified": 1716432083,
+        "narHash": "sha256-YQfhr7bmdRNVcQXSCPTHtgRNeUyOwPTjGJeUHkUAJHM=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "fac83a556e7b710dc31433dec727361ca062dbe9",
+        "rev": "5665d93988acfbb0747bdbf4f4cb583bcebc8930",
         "type": "github"
       },
       "original": {
@@ -1323,11 +1348,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1715028064,
-        "narHash": "sha256-DSUTxUFCesXuaJjrDNvurILUt1IrO5MI5ukbZ8D87zQ=",
+        "lastModified": 1715644375,
+        "narHash": "sha256-1trRSUVyWFl3K+7xHXQGNl/EwE0ggyigQpZ+kmRPsk8=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "5b9067899ee6a2538891573500e8fd6ff008440f",
+        "rev": "e37bb1feee9e7320c76050a55443fa843b4b6f83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'cmp-lsp-nvim':
    'github:hrsh7th/cmp-nvim-lsp/5af77f54de1b16c34b23cba810150689a3a90312' (2023-12-10)
  → 'github:hrsh7th/cmp-nvim-lsp/39e2eda76828d88b773cc27a3f61d2ad782c922d' (2024-05-17)
• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/ce882460cf3db12e99f8bf579cbf99e331f6dd4f' (2024-05-01)
  → 'github:tpope/vim-fugitive/4f59455d2388e113bd510e85b310d15b9228ca0d' (2024-05-19)
• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/805610a9393fa231f2c2b49cb521bfa413fadb3d' (2024-05-06)
  → 'github:lewis6991/gitsigns.nvim/cdfcd9d39d23c46ae9a040de2c6a8b8bf868746e' (2024-05-23)
• Updated input 'home-manager':
    'github:nix-community/home-manager/f2c5ba5e720fd584d83f2f97399dac0d26ae60b9' (2024-05-10)
  → 'github:nix-community/home-manager/850cb322046ef1a268449cf1ceda5fd24d930b05' (2024-05-23)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/110e6dc761d5c3d352574def3479a9c39dfc4358' (2024-04-22)
  → 'github:hyprwm/contrib/33b38358559054d316eb605ccb733980dfa7dc63' (2024-05-20)
• Updated input 'lsp-signature-nvim':
    'github:ray-x/lsp_signature.nvim/aed5d1162b0f07bb3af34bedcc5f70a2b6466ed8' (2024-05-10)
  → 'github:ray-x/lsp_signature.nvim/43729353dec224fa620a877639b8b0744112b286' (2024-05-23)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/b152822e1a4bafb6bdf11a16cc26525cbd95ee00' (2024-04-30)
  → 'github:L3MON4D3/LuaSnip/878ace11983444d865a72e1759dbcc331d1ace4c' (2024-05-24)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/2b11e4433355b57784dd002d34cf810874fa044d' (2024-05-10)
  → 'github:nix-community/neovim-nightly-overlay/d83afee1f19108100bd2fef1f86d87d2942d734d' (2024-05-24)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e' (2024-05-02)
  → 'github:hercules-ci/flake-parts/8dc45382d5206bd292f9c2768b8058a8fd8311d9' (2024-05-16)
• Removed input 'neovim-nightly-overlay/neovim-flake'
• Removed input 'neovim-nightly-overlay/neovim-flake/flake-utils'
• Removed input 'neovim-nightly-overlay/neovim-flake/flake-utils/systems'
• Removed input 'neovim-nightly-overlay/neovim-flake/nixpkgs'
• Added input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/e7859d2ad504a3e3cae1d540d5fd4f9b560d154a' (2024-05-23)
• Added input 'neovim-nightly-overlay/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/0e8fcc54b842ad8428c9e705cb5994eaf05c26a0' (2024-05-20)
• Added input 'neovim-nightly-overlay/pre-commit-hooks/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
• Added input 'neovim-nightly-overlay/pre-commit-hooks/gitignore':
    'github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394' (2024-02-28)
• Added input 'neovim-nightly-overlay/pre-commit-hooks/gitignore/nixpkgs':
    follows 'neovim-nightly-overlay/pre-commit-hooks/nixpkgs'
• Added input 'neovim-nightly-overlay/pre-commit-hooks/nixpkgs':
    follows 'neovim-nightly-overlay/nixpkgs'
• Added input 'neovim-nightly-overlay/pre-commit-hooks/nixpkgs-stable':
    follows 'neovim-nightly-overlay/nixpkgs'
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/ac34158a823c7596e0106c806d0b7df47885fa73' (2024-05-09)
  → 'github:nixos/nixpkgs/3305b2b25e4ae4baee872346eae133cf6f611783' (2024-05-23)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/cd2cf0c124d3de577fb5449746568ee8e601afc8' (2024-05-08)
  → 'github:hrsh7th/nvim-cmp/5260e5e8ecadaf13e6b82cf867a909f54e15fd07' (2024-05-17)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/a3d9395455f2b2e3b50a0b0f37b8b4c23683f44a' (2024-05-08)
  → 'github:neovim/nvim-lspconfig/b972e7154bc94ab4ecdbb38c8edbccac36f83996' (2024-05-23)
• Updated input 'plenary-nvim':
    'github:nvim-lua/plenary.nvim/08e301982b9a057110ede7a735dd1b5285eb341f' (2024-04-25)
  → 'github:nvim-lua/plenary.nvim/a3e3bc82a3f95c5ed0d7201546d5d2c19b20d683' (2024-05-20)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/2eb8776df1aab03f514b38ddc39af57efbd8970b' (2024-05-04)
  → 'github:mrcjkb/rustaceanvim/90bfbc588fef7e44d82e5aba8dfc787e8d3f5d1a' (2024-05-24)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/fac83a556e7b710dc31433dec727361ca062dbe9' (2024-05-03)
  → 'github:nvim-telescope/telescope.nvim/5665d93988acfbb0747bdbf4f4cb583bcebc8930' (2024-05-23)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/5b9067899ee6a2538891573500e8fd6ff008440f' (2024-05-06)
  → 'github:nvim-tree/nvim-web-devicons/e37bb1feee9e7320c76050a55443fa843b4b6f83' (2024-05-13)

```

</p></details>

 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`2eb8776d` ➡️ `90bfbc58`](https://github.com/mrcjkb/rustaceanvim/compare/2eb8776df1aab03f514b38ddc39af57efbd8970b...90bfbc588fef7e44d82e5aba8dfc787e8d3f5d1a) <sub>(2024-05-04 to 2024-05-24)</sub>
 - Removed input `neovim-nightly-overlay/neovim-flake/flake-utils`.
 - Added input `neovim-nightly-overlay/pre-commit-hooks/gitignore/nixpkgs`: ``
 - Added input [`neovim-nightly-overlay/pre-commit-hooks/gitignore`](https://github.com/hercules-ci/gitignore.nix): [github.com/hercules-ci/gitignore.nix](https://github.com/hercules-ci/gitignore.nix/tree/637db329424fd7e46cf4185293b9cc8c88c95394/)
 - Added input [`neovim-nightly-overlay/pre-commit-hooks/flake-compat`](https://github.com/edolstra/flake-compat): [github.com/edolstra/flake-compat](https://github.com/edolstra/flake-compat/tree/0f9255e01c2351cc7d116c072cb317785dd33b33/)
 - Updated input [`lsp-signature-nvim`](https://github.com/ray-x/lsp_signature.nvim): [`aed5d116` ➡️ `43729353`](https://github.com/ray-x/lsp_signature.nvim/compare/aed5d1162b0f07bb3af34bedcc5f70a2b6466ed8...43729353dec224fa620a877639b8b0744112b286) <sub>(2024-05-10 to 2024-05-23)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`ce882460` ➡️ `4f59455d`](https://github.com/tpope/vim-fugitive/compare/ce882460cf3db12e99f8bf579cbf99e331f6dd4f...4f59455d2388e113bd510e85b310d15b9228ca0d) <sub>(2024-05-01 to 2024-05-19)</sub>
 - Added input `neovim-nightly-overlay/pre-commit-hooks/nixpkgs`: ``
 - Added input [`neovim-nightly-overlay/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [github.com/cachix/pre-commit-hooks.nix](https://github.com/cachix/pre-commit-hooks.nix/tree/0e8fcc54b842ad8428c9e705cb5994eaf05c26a0/)
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`2b11e443` ➡️ `d83afee1`](https://github.com/nix-community/neovim-nightly-overlay/compare/2b11e4433355b57784dd002d34cf810874fa044d...d83afee1f19108100bd2fef1f86d87d2942d734d) <sub>(2024-05-10 to 2024-05-24)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`b152822e` ➡️ `878ace11`](https://github.com/L3MON4D3/LuaSnip/compare/b152822e1a4bafb6bdf11a16cc26525cbd95ee00...878ace11983444d865a72e1759dbcc331d1ace4c) <sub>(2024-04-30 to 2024-05-24)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`110e6dc7` ➡️ `33b38358`](https://github.com/hyprwm/contrib/compare/110e6dc761d5c3d352574def3479a9c39dfc4358...33b38358559054d316eb605ccb733980dfa7dc63) <sub>(2024-04-22 to 2024-05-20)</sub>
 - Updated input [`plenary-nvim`](https://github.com/nvim-lua/plenary.nvim): [`08e30198` ➡️ `a3e3bc82`](https://github.com/nvim-lua/plenary.nvim/compare/08e301982b9a057110ede7a735dd1b5285eb341f...a3e3bc82a3f95c5ed0d7201546d5d2c19b20d683) <sub>(2024-04-25 to 2024-05-20)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`a3d93954` ➡️ `b972e715`](https://github.com/neovim/nvim-lspconfig/compare/a3d9395455f2b2e3b50a0b0f37b8b4c23683f44a...b972e7154bc94ab4ecdbb38c8edbccac36f83996) <sub>(2024-05-08 to 2024-05-23)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`cd2cf0c1` ➡️ `5260e5e8`](https://github.com/hrsh7th/nvim-cmp/compare/cd2cf0c124d3de577fb5449746568ee8e601afc8...5260e5e8ecadaf13e6b82cf867a909f54e15fd07) <sub>(2024-05-08 to 2024-05-17)</sub>
 - Removed input `neovim-nightly-overlay/neovim-flake/nixpkgs`.
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`805610a9` ➡️ `cdfcd9d3`](https://github.com/lewis6991/gitsigns.nvim/compare/805610a9393fa231f2c2b49cb521bfa413fadb3d...cdfcd9d39d23c46ae9a040de2c6a8b8bf868746e) <sub>(2024-05-06 to 2024-05-23)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`ac34158a` ➡️ `3305b2b2`](https://github.com/nixos/nixpkgs/compare/ac34158a823c7596e0106c806d0b7df47885fa73...3305b2b25e4ae4baee872346eae133cf6f611783) <sub>(2024-05-09 to 2024-05-23)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`fac83a55` ➡️ `5665d939`](https://github.com/nvim-telescope/telescope.nvim/compare/fac83a556e7b710dc31433dec727361ca062dbe9...5665d93988acfbb0747bdbf4f4cb583bcebc8930) <sub>(2024-05-03 to 2024-05-23)</sub>
 - Removed input `neovim-nightly-overlay/neovim-flake/flake-utils/systems`.
 - Added input `neovim-nightly-overlay/pre-commit-hooks/nixpkgs-stable`: ``
 - Removed input `neovim-nightly-overlay/neovim-flake`.
 - Updated input [`cmp-lsp-nvim`](https://github.com/hrsh7th/cmp-nvim-lsp): [`5af77f54` ➡️ `39e2eda7`](https://github.com/hrsh7th/cmp-nvim-lsp/compare/5af77f54de1b16c34b23cba810150689a3a90312...39e2eda76828d88b773cc27a3f61d2ad782c922d) <sub>(2023-12-10 to 2024-05-17)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`5b906789` ➡️ `e37bb1fe`](https://github.com/nvim-tree/nvim-web-devicons/compare/5b9067899ee6a2538891573500e8fd6ff008440f...e37bb1feee9e7320c76050a55443fa843b4b6f83) <sub>(2024-05-06 to 2024-05-13)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`f2c5ba5e` ➡️ `850cb322`](https://github.com/nix-community/home-manager/compare/f2c5ba5e720fd584d83f2f97399dac0d26ae60b9...850cb322046ef1a268449cf1ceda5fd24d930b05) <sub>(2024-05-10 to 2024-05-23)</sub>
 - Added input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [github.com/neovim/neovim](https://github.com/neovim/neovim/tree/e7859d2ad504a3e3cae1d540d5fd4f9b560d154a/)
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`e5d10a24` ➡️ `8dc45382`](https://github.com/hercules-ci/flake-parts/compare/e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e...8dc45382d5206bd292f9c2768b8058a8fd8311d9) <sub>(2024-05-02 to 2024-05-16)</sub>