### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -431,11 +431,38 @@
         "type": "github"
       }
     },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "neovim-nightly-overlay",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "neovim-nightly-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1716213921,
+        "narHash": "sha256-xrsYFST8ij4QWaV6HEokCUNIZLjjLP1bYC60K8XiBVA=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "0e8fcc54b842ad8428c9e705cb5994eaf05c26a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
           "neovim-nightly-overlay",
-          "pre-commit-hooks",
+          "git-hooks",
           "nixpkgs"
         ]
       },
@@ -501,11 +528,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1716453598,
-        "narHash": "sha256-TTC3uvRsq4v6PBdS/3YAGpyhVt0w3/SGkPE3fu1zW94=",
+        "lastModified": 1716973248,
+        "narHash": "sha256-9sgbNwingPhzcGS2gYCiNV6WDU3tzCYDPQ10935qh5Q=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "cdfcd9d39d23c46ae9a040de2c6a8b8bf868746e",
+        "rev": "75dc649106827183547d3bedd4602442340d2f7f",
         "type": "github"
       },
       "original": {
@@ -543,11 +570,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716457508,
-        "narHash": "sha256-ZxzffLuWRyuMrkVVq7wastNUqeO0HJL9xqfY1QsYaqo=",
+        "lastModified": 1717097707,
+        "narHash": "sha256-HC5vJ3oYsjwsCaSbkIPv80e4ebJpNvFKQTBOGlHvjLs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "850cb322046ef1a268449cf1ceda5fd24d930b05",
+        "rev": "0eb314b4f0ba337e88123e0b1e57ef58346aafd9",
         "type": "github"
       },
       "original": {
@@ -626,11 +653,11 @@
     "lsp-signature-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1716506401,
-        "narHash": "sha256-YNkRZGHbgfK/8POjtAGASiDMr9GeU61DNhti+K8iWUk=",
+        "lastModified": 1716637798,
+        "narHash": "sha256-4Abo4HGwzZtqEHcS9lsQdw+Dsn7tkQoeq5QyfTEEwnA=",
         "owner": "ray-x",
         "repo": "lsp_signature.nvim",
-        "rev": "43729353dec224fa620a877639b8b0744112b286",
+        "rev": "529e8861d0410389f0163a5e5c2199d4a4ef5bf6",
         "type": "github"
       },
       "original": {
@@ -709,7 +736,7 @@
         "flake-utils": "flake-utils_4",
         "neovim-nightly": "neovim-nightly",
         "nixpkgs": "nixpkgs_5",
-        "pre-commit-hooks": "pre-commit-hooks_2"
+        "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
         "lastModified": 1714773380,
@@ -754,19 +781,19 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
+        "git-hooks": "git-hooks",
         "hercules-ci-effects": "hercules-ci-effects",
         "neovim-src": "neovim-src",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "pre-commit-hooks": "pre-commit-hooks"
+        ]
       },
       "locked": {
-        "lastModified": 1716747123,
-        "narHash": "sha256-XZFVa21Vpn39Y7fCmGAb8CxKJlX0YKKUyUfArvhXNjo=",
+        "lastModified": 1717171539,
+        "narHash": "sha256-Sr7x7scl6VGOD/+74wyZaKF2asiidkG/9+Me5vmEy84=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "491c6d2a3f239754a2e6aa110d47899a38d94c45",
+        "rev": "8d9517ad34e62b04744f1586838d4565939172b4",
         "type": "github"
       },
       "original": {
@@ -778,11 +805,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1716642936,
-        "narHash": "sha256-l53vGzYIy6tI1rYBlbxW502sDgpmZ4i/uTdWWtPKPtM=",
+        "lastModified": 1717058786,
+        "narHash": "sha256-IuoPQ4AMGvSzo8IT4vFVO5rz6l4GMYxO6nLE0CjClzQ=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "52389e724366ebb2fb58f08c657f580900dd09ee",
+        "rev": "5c33815448e11b514678f39cecc74e68131d4628",
         "type": "github"
       },
       "original": {
@@ -893,11 +920,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1716451822,
-        "narHash": "sha256-0lT5RVelqN+dgXWWneXvV5ufSksW0r0TDQi8O6U2+o8=",
+        "lastModified": 1717112898,
+        "narHash": "sha256-7R2ZvOnvd9h8fDd65p0JnB7wXfUvreox3xFdYWd1BnY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3305b2b25e4ae4baee872346eae133cf6f611783",
+        "rev": "6132b0f6e344ce2fe34fc051b72fb46e34f668e0",
         "type": "github"
       },
       "original": {
@@ -1006,11 +1033,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1716498901,
-        "narHash": "sha256-PMMqPDnq4Q8gWeKQ2WPE+pOf1R1G61wJ+bAWkHpQlzE=",
+        "lastModified": 1717134215,
+        "narHash": "sha256-tFrMMEkQfJEDfZGAxIuCQyMgRuYsQ32MiFQNjtB7QOQ=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "b972e7154bc94ab4ecdbb38c8edbccac36f83996",
+        "rev": "b124ef3bd4435a6db7ff03ea2f5a23e1e0487552",
         "type": "github"
       },
       "original": {
@@ -1059,33 +1086,6 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "neovim-nightly-overlay",
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "neovim-nightly-overlay",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1716213921,
-        "narHash": "sha256-xrsYFST8ij4QWaV6HEokCUNIZLjjLP1bYC60K8XiBVA=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "0e8fcc54b842ad8428c9e705cb5994eaf05c26a0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks_2": {
-      "inputs": {
         "flake-compat": "flake-compat_4",
         "flake-utils": "flake-utils_6",
         "gitignore": "gitignore_2",
@@ -1110,7 +1110,7 @@
         "type": "github"
       }
     },
-    "pre-commit-hooks_3": {
+    "pre-commit-hooks_2": {
       "inputs": {
         "flake-compat": "flake-compat_5",
         "flake-utils": "flake-utils_7",
@@ -1192,14 +1192,14 @@
         "gen-luarc": "gen-luarc",
         "neorocks": "neorocks",
         "nixpkgs": "nixpkgs_6",
-        "pre-commit-hooks": "pre-commit-hooks_3"
+        "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1716536666,
-        "narHash": "sha256-TwYkEdCV+M/pYWCvSCHBNqE2uLjmbXYnBoCnInfKOAU=",
+        "lastModified": 1717088659,
+        "narHash": "sha256-TzK152dUCxDoaJTeSIPTn+RbEPLhA8XRoeQl5JxR7T8=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "90bfbc588fef7e44d82e5aba8dfc787e8d3f5d1a",
+        "rev": "2fa45427c01ded4d3ecca72e357f8a60fd8e46d4",
         "type": "github"
       },
       "original": {
@@ -1332,11 +1332,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1716432083,
-        "narHash": "sha256-YQfhr7bmdRNVcQXSCPTHtgRNeUyOwPTjGJeUHkUAJHM=",
+        "lastModified": 1717003449,
+        "narHash": "sha256-aCH6J4I8ZW4adCKjlYoVoH2laf9wAs8OvXxegHYDIr0=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "5665d93988acfbb0747bdbf4f4cb583bcebc8930",
+        "rev": "dfa230be84a044e7f546a6c2b0a403c739732b86",
         "type": "github"
       },
       "original": {
@@ -1348,11 +1348,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1715644375,
-        "narHash": "sha256-1trRSUVyWFl3K+7xHXQGNl/EwE0ggyigQpZ+kmRPsk8=",
+        "lastModified": 1716609001,
+        "narHash": "sha256-fmbsnNVZ6nBorBILwPfEgcDDWZCkh9YZH/aC343FxP4=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "e37bb1feee9e7320c76050a55443fa843b4b6f83",
+        "rev": "b77921fdc44833c994fdb389d658ccbce5490c16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/cdfcd9d39d23c46ae9a040de2c6a8b8bf868746e' (2024-05-23)
  → 'github:lewis6991/gitsigns.nvim/75dc649106827183547d3bedd4602442340d2f7f' (2024-05-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/850cb322046ef1a268449cf1ceda5fd24d930b05' (2024-05-23)
  → 'github:nix-community/home-manager/0eb314b4f0ba337e88123e0b1e57ef58346aafd9' (2024-05-30)
• Updated input 'lsp-signature-nvim':
    'github:ray-x/lsp_signature.nvim/43729353dec224fa620a877639b8b0744112b286' (2024-05-23)
  → 'github:ray-x/lsp_signature.nvim/529e8861d0410389f0163a5e5c2199d4a4ef5bf6' (2024-05-25)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/491c6d2a3f239754a2e6aa110d47899a38d94c45' (2024-05-26)
  → 'github:nix-community/neovim-nightly-overlay/8d9517ad34e62b04744f1586838d4565939172b4' (2024-05-31)
• Added input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/0e8fcc54b842ad8428c9e705cb5994eaf05c26a0' (2024-05-20)
• Added input 'neovim-nightly-overlay/git-hooks/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
• Added input 'neovim-nightly-overlay/git-hooks/gitignore':
    'github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394' (2024-02-28)
• Added input 'neovim-nightly-overlay/git-hooks/gitignore/nixpkgs':
    follows 'neovim-nightly-overlay/git-hooks/nixpkgs'
• Added input 'neovim-nightly-overlay/git-hooks/nixpkgs':
    follows 'neovim-nightly-overlay/nixpkgs'
• Added input 'neovim-nightly-overlay/git-hooks/nixpkgs-stable':
    follows 'neovim-nightly-overlay/nixpkgs'
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/52389e724366ebb2fb58f08c657f580900dd09ee' (2024-05-25)
  → 'github:neovim/neovim/5c33815448e11b514678f39cecc74e68131d4628' (2024-05-30)
• Removed input 'neovim-nightly-overlay/pre-commit-hooks'
• Removed input 'neovim-nightly-overlay/pre-commit-hooks/flake-compat'
• Removed input 'neovim-nightly-overlay/pre-commit-hooks/gitignore'
• Removed input 'neovim-nightly-overlay/pre-commit-hooks/gitignore/nixpkgs'
• Removed input 'neovim-nightly-overlay/pre-commit-hooks/nixpkgs'
• Removed input 'neovim-nightly-overlay/pre-commit-hooks/nixpkgs-stable'
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3305b2b25e4ae4baee872346eae133cf6f611783' (2024-05-23)
  → 'github:nixos/nixpkgs/6132b0f6e344ce2fe34fc051b72fb46e34f668e0' (2024-05-30)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/b972e7154bc94ab4ecdbb38c8edbccac36f83996' (2024-05-23)
  → 'github:neovim/nvim-lspconfig/b124ef3bd4435a6db7ff03ea2f5a23e1e0487552' (2024-05-31)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/90bfbc588fef7e44d82e5aba8dfc787e8d3f5d1a' (2024-05-24)
  → 'github:mrcjkb/rustaceanvim/2fa45427c01ded4d3ecca72e357f8a60fd8e46d4' (2024-05-30)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/5665d93988acfbb0747bdbf4f4cb583bcebc8930' (2024-05-23)
  → 'github:nvim-telescope/telescope.nvim/dfa230be84a044e7f546a6c2b0a403c739732b86' (2024-05-29)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/e37bb1feee9e7320c76050a55443fa843b4b6f83' (2024-05-13)
  → 'github:nvim-tree/nvim-web-devicons/b77921fdc44833c994fdb389d658ccbce5490c16' (2024-05-25)

```

</p></details>

 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`90bfbc58` ➡️ `2fa45427`](https://github.com/mrcjkb/rustaceanvim/compare/90bfbc588fef7e44d82e5aba8dfc787e8d3f5d1a...2fa45427c01ded4d3ecca72e357f8a60fd8e46d4) <sub>(2024-05-24 to 2024-05-30)</sub>
 - Added input [`neovim-nightly-overlay/git-hooks/flake-compat`](https://github.com/edolstra/flake-compat): [github.com/edolstra/flake-compat](https://github.com/edolstra/flake-compat/tree/0f9255e01c2351cc7d116c072cb317785dd33b33/)
 - Removed input `neovim-nightly-overlay/pre-commit-hooks/gitignore/nixpkgs`.
 - Removed input `neovim-nightly-overlay/pre-commit-hooks/gitignore`.
 - Removed input `neovim-nightly-overlay/pre-commit-hooks/flake-compat`.
 - Updated input [`lsp-signature-nvim`](https://github.com/ray-x/lsp_signature.nvim): [`43729353` ➡️ `529e8861`](https://github.com/ray-x/lsp_signature.nvim/compare/43729353dec224fa620a877639b8b0744112b286...529e8861d0410389f0163a5e5c2199d4a4ef5bf6) <sub>(2024-05-23 to 2024-05-25)</sub>
 - Removed input `neovim-nightly-overlay/pre-commit-hooks/nixpkgs`.
 - Removed input `neovim-nightly-overlay/pre-commit-hooks`.
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`491c6d2a` ➡️ `8d9517ad`](https://github.com/nix-community/neovim-nightly-overlay/compare/491c6d2a3f239754a2e6aa110d47899a38d94c45...8d9517ad34e62b04744f1586838d4565939172b4) <sub>(2024-05-26 to 2024-05-31)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`b972e715` ➡️ `b124ef3b`](https://github.com/neovim/nvim-lspconfig/compare/b972e7154bc94ab4ecdbb38c8edbccac36f83996...b124ef3bd4435a6db7ff03ea2f5a23e1e0487552) <sub>(2024-05-23 to 2024-05-31)</sub>
 - Added input `neovim-nightly-overlay/git-hooks/nixpkgs`: ``
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`cdfcd9d3` ➡️ `75dc6491`](https://github.com/lewis6991/gitsigns.nvim/compare/cdfcd9d39d23c46ae9a040de2c6a8b8bf868746e...75dc649106827183547d3bedd4602442340d2f7f) <sub>(2024-05-23 to 2024-05-29)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`3305b2b2` ➡️ `6132b0f6`](https://github.com/nixos/nixpkgs/compare/3305b2b25e4ae4baee872346eae133cf6f611783...6132b0f6e344ce2fe34fc051b72fb46e34f668e0) <sub>(2024-05-23 to 2024-05-30)</sub>
 - Added input `neovim-nightly-overlay/git-hooks/nixpkgs-stable`: ``
 - Added input `neovim-nightly-overlay/git-hooks/gitignore/nixpkgs`: ``
 - Added input [`neovim-nightly-overlay/git-hooks/gitignore`](https://github.com/hercules-ci/gitignore.nix): [github.com/hercules-ci/gitignore.nix](https://github.com/hercules-ci/gitignore.nix/tree/637db329424fd7e46cf4185293b9cc8c88c95394/)
 - Added input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [github.com/cachix/git-hooks.nix](https://github.com/cachix/git-hooks.nix/tree/0e8fcc54b842ad8428c9e705cb5994eaf05c26a0/)
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`5665d939` ➡️ `dfa230be`](https://github.com/nvim-telescope/telescope.nvim/compare/5665d93988acfbb0747bdbf4f4cb583bcebc8930...dfa230be84a044e7f546a6c2b0a403c739732b86) <sub>(2024-05-23 to 2024-05-29)</sub>
 - Removed input `neovim-nightly-overlay/pre-commit-hooks/nixpkgs-stable`.
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`e37bb1fe` ➡️ `b77921fd`](https://github.com/nvim-tree/nvim-web-devicons/compare/e37bb1feee9e7320c76050a55443fa843b4b6f83...b77921fdc44833c994fdb389d658ccbce5490c16) <sub>(2024-05-13 to 2024-05-25)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`850cb322` ➡️ `0eb314b4`](https://github.com/nix-community/home-manager/compare/850cb322046ef1a268449cf1ceda5fd24d930b05...0eb314b4f0ba337e88123e0b1e57ef58346aafd9) <sub>(2024-05-23 to 2024-05-30)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`52389e72` ➡️ `5c338154`](https://github.com/neovim/neovim/compare/52389e724366ebb2fb58f08c657f580900dd09ee...5c33815448e11b514678f39cecc74e68131d4628) <sub>(2024-05-25 to 2024-05-30)</sub>