### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715865404,
-        "narHash": "sha256-/GJvTdTpuDjNn84j82cU6bXztE0MSkdnTWClUCRub78=",
+        "lastModified": 1717285511,
+        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8dc45382d5206bd292f9c2768b8058a8fd8311d9",
+        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
         "type": "github"
       },
       "original": {
@@ -445,11 +445,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716213921,
-        "narHash": "sha256-xrsYFST8ij4QWaV6HEokCUNIZLjjLP1bYC60K8XiBVA=",
+        "lastModified": 1717664902,
+        "narHash": "sha256-7XfBuLULizXjXfBYy/VV+SpYMHreNRHk9nKMsm1bgb4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "0e8fcc54b842ad8428c9e705cb5994eaf05c26a0",
+        "rev": "cc4d466cb1254af050ff7bdf47f6d404a7c646d1",
         "type": "github"
       },
       "original": {
@@ -528,11 +528,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1716973248,
-        "narHash": "sha256-9sgbNwingPhzcGS2gYCiNV6WDU3tzCYDPQ10935qh5Q=",
+        "lastModified": 1717763051,
+        "narHash": "sha256-FWcjFwprIeDRMKhurJtGqCfI4mP4fQNQY8szjnjuOCc=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "75dc649106827183547d3bedd4602442340d2f7f",
+        "rev": "4a143f13e122ab91abdc88f89eefbe70a4858a56",
         "type": "github"
       },
       "original": {
@@ -570,11 +570,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717097707,
-        "narHash": "sha256-HC5vJ3oYsjwsCaSbkIPv80e4ebJpNvFKQTBOGlHvjLs=",
+        "lastModified": 1717525419,
+        "narHash": "sha256-5z2422pzWnPXHgq2ms8lcCfttM0dz+hg+x1pCcNkAws=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0eb314b4f0ba337e88123e0b1e57ef58346aafd9",
+        "rev": "a7117efb3725e6197dd95424136f79147aa35e5b",
         "type": "github"
       },
       "original": {
@@ -653,11 +653,11 @@
     "lsp-signature-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1716637798,
-        "narHash": "sha256-4Abo4HGwzZtqEHcS9lsQdw+Dsn7tkQoeq5QyfTEEwnA=",
+        "lastModified": 1717205989,
+        "narHash": "sha256-ezNJvVjwGUpb3D77DshVAVnh9fDIiLW21CcPRDxlzJY=",
         "owner": "ray-x",
         "repo": "lsp_signature.nvim",
-        "rev": "529e8861d0410389f0163a5e5c2199d4a4ef5bf6",
+        "rev": "2ec2ba23882329c1302dff773b0d3620371d634f",
         "type": "github"
       },
       "original": {
@@ -701,11 +701,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1716536093,
-        "narHash": "sha256-WP71ChUQR67GJ/hsynv3/KAfojVFqTqYRVkmUmC9aqo=",
+        "lastModified": 1717753191,
+        "narHash": "sha256-QgK/tI4KU+ZrVl7NFCP8lX7LWjes1pKvt2Eti/UZna8=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "878ace11983444d865a72e1759dbcc331d1ace4c",
+        "rev": "50fcf17db7c75af80e6b6109acfbfb4504768780",
         "type": "github"
       },
       "original": {
@@ -717,11 +717,11 @@
     "neodev-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1711715247,
-        "narHash": "sha256-mAJOMVN7/xO7ykVNAeTeX+z2A/7yB8zdqlEKHL6Pb74=",
+        "lastModified": 1717490891,
+        "narHash": "sha256-vkgy2w6NvzOPlo23WKweGybEqqk4wiwdgXU1LjYkWW0=",
         "owner": "folke",
         "repo": "neodev.nvim",
-        "rev": "ce9a2e8eaba5649b553529c5498acb43a6c317cd",
+        "rev": "02893eeb9d6e8503817bd52385e111cba9a90500",
         "type": "github"
       },
       "original": {
@@ -789,11 +789,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717171539,
-        "narHash": "sha256-Sr7x7scl6VGOD/+74wyZaKF2asiidkG/9+Me5vmEy84=",
+        "lastModified": 1717737574,
+        "narHash": "sha256-Oc1xZW7pc/cCr+2FpgbFuNz/yBh4ZqjsbmSH7pVADiE=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "8d9517ad34e62b04744f1586838d4565939172b4",
+        "rev": "da7e7da75fab002c8e6c695ddce45c825fbe6444",
         "type": "github"
       },
       "original": {
@@ -805,11 +805,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1717058786,
-        "narHash": "sha256-IuoPQ4AMGvSzo8IT4vFVO5rz6l4GMYxO6nLE0CjClzQ=",
+        "lastModified": 1717712276,
+        "narHash": "sha256-r9mtD17PiNYVKWs+Cc9uIv/vmkRtiwGrG42QRd1K6Os=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "5c33815448e11b514678f39cecc74e68131d4628",
+        "rev": "d490a7bc5b9d731828f5da16b35a86b4e1270624",
         "type": "github"
       },
       "original": {
@@ -920,11 +920,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1717112898,
-        "narHash": "sha256-7R2ZvOnvd9h8fDd65p0JnB7wXfUvreox3xFdYWd1BnY=",
+        "lastModified": 1717681334,
+        "narHash": "sha256-HlvsMH8BNgdmQCwbBDmWp5/DfkEQYhXZHagJQCgbJU0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6132b0f6e344ce2fe34fc051b72fb46e34f668e0",
+        "rev": "31f40991012489e858517ec20102f033e4653afb",
         "type": "github"
       },
       "original": {
@@ -1033,11 +1033,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1717134215,
-        "narHash": "sha256-tFrMMEkQfJEDfZGAxIuCQyMgRuYsQ32MiFQNjtB7QOQ=",
+        "lastModified": 1717681643,
+        "narHash": "sha256-QlgLZx9Dp5ijSOxeicNcqm4G8YcF5aOZFJSiBclWuIY=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "b124ef3bd4435a6db7ff03ea2f5a23e1e0487552",
+        "rev": "92166b89ab4b3d60f24e58170cac53b7141fd032",
         "type": "github"
       },
       "original": {
@@ -1195,11 +1195,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1717088659,
-        "narHash": "sha256-TzK152dUCxDoaJTeSIPTn+RbEPLhA8XRoeQl5JxR7T8=",
+        "lastModified": 1717754390,
+        "narHash": "sha256-bgx4kY6uLmQzUoMz6qnBXB1iDnniY/JE+T6FxxwLIdY=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "2fa45427c01ded4d3ecca72e357f8a60fd8e46d4",
+        "rev": "00a9508e8f95b8f8f9f60125a2082a53e0740987",
         "type": "github"
       },
       "original": {
@@ -1348,11 +1348,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1716609001,
-        "narHash": "sha256-fmbsnNVZ6nBorBILwPfEgcDDWZCkh9YZH/aC343FxP4=",
+        "lastModified": 1717733505,
+        "narHash": "sha256-bpC7xeYhUKUDa7cm4qEYRpc3m1ItukMM0XZNSHI0HV0=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "b77921fdc44833c994fdb389d658ccbce5490c16",
+        "rev": "b4b302d6ae229f67df7a87ef69fa79473fe788a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/75dc649106827183547d3bedd4602442340d2f7f' (2024-05-29)
  → 'github:lewis6991/gitsigns.nvim/4a143f13e122ab91abdc88f89eefbe70a4858a56' (2024-06-07)
• Updated input 'home-manager':
    'github:nix-community/home-manager/0eb314b4f0ba337e88123e0b1e57ef58346aafd9' (2024-05-30)
  → 'github:nix-community/home-manager/a7117efb3725e6197dd95424136f79147aa35e5b' (2024-06-04)
• Updated input 'lsp-signature-nvim':
    'github:ray-x/lsp_signature.nvim/529e8861d0410389f0163a5e5c2199d4a4ef5bf6' (2024-05-25)
  → 'github:ray-x/lsp_signature.nvim/2ec2ba23882329c1302dff773b0d3620371d634f' (2024-06-01)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/878ace11983444d865a72e1759dbcc331d1ace4c' (2024-05-24)
  → 'github:L3MON4D3/LuaSnip/50fcf17db7c75af80e6b6109acfbfb4504768780' (2024-06-07)
• Updated input 'neodev-nvim':
    'github:folke/neodev.nvim/ce9a2e8eaba5649b553529c5498acb43a6c317cd' (2024-03-29)
  → 'github:folke/neodev.nvim/02893eeb9d6e8503817bd52385e111cba9a90500' (2024-06-04)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/8d9517ad34e62b04744f1586838d4565939172b4' (2024-05-31)
  → 'github:nix-community/neovim-nightly-overlay/da7e7da75fab002c8e6c695ddce45c825fbe6444' (2024-06-07)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/8dc45382d5206bd292f9c2768b8058a8fd8311d9' (2024-05-16)
  → 'github:hercules-ci/flake-parts/2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8' (2024-06-01)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/0e8fcc54b842ad8428c9e705cb5994eaf05c26a0' (2024-05-20)
  → 'github:cachix/git-hooks.nix/cc4d466cb1254af050ff7bdf47f6d404a7c646d1' (2024-06-06)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/5c33815448e11b514678f39cecc74e68131d4628' (2024-05-30)
  → 'github:neovim/neovim/d490a7bc5b9d731828f5da16b35a86b4e1270624' (2024-06-06)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/6132b0f6e344ce2fe34fc051b72fb46e34f668e0' (2024-05-30)
  → 'github:nixos/nixpkgs/31f40991012489e858517ec20102f033e4653afb' (2024-06-06)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/b124ef3bd4435a6db7ff03ea2f5a23e1e0487552' (2024-05-31)
  → 'github:neovim/nvim-lspconfig/92166b89ab4b3d60f24e58170cac53b7141fd032' (2024-06-06)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/2fa45427c01ded4d3ecca72e357f8a60fd8e46d4' (2024-05-30)
  → 'github:mrcjkb/rustaceanvim/00a9508e8f95b8f8f9f60125a2082a53e0740987' (2024-06-07)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/b77921fdc44833c994fdb389d658ccbce5490c16' (2024-05-25)
  → 'github:nvim-tree/nvim-web-devicons/b4b302d6ae229f67df7a87ef69fa79473fe788a9' (2024-06-07)

```

</p></details>

 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`2fa45427` ➡️ `00a9508e`](https://github.com/mrcjkb/rustaceanvim/compare/2fa45427c01ded4d3ecca72e357f8a60fd8e46d4...00a9508e8f95b8f8f9f60125a2082a53e0740987) <sub>(2024-05-30 to 2024-06-07)</sub>
 - Updated input [`neodev-nvim`](https://github.com/folke/neodev.nvim): [`ce9a2e8e` ➡️ `02893eeb`](https://github.com/folke/neodev.nvim/compare/ce9a2e8eaba5649b553529c5498acb43a6c317cd...02893eeb9d6e8503817bd52385e111cba9a90500) <sub>(2024-03-29 to 2024-06-04)</sub>
 - Updated input [`lsp-signature-nvim`](https://github.com/ray-x/lsp_signature.nvim): [`529e8861` ➡️ `2ec2ba23`](https://github.com/ray-x/lsp_signature.nvim/compare/529e8861d0410389f0163a5e5c2199d4a4ef5bf6...2ec2ba23882329c1302dff773b0d3620371d634f) <sub>(2024-05-25 to 2024-06-01)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`8d9517ad` ➡️ `da7e7da7`](https://github.com/nix-community/neovim-nightly-overlay/compare/8d9517ad34e62b04744f1586838d4565939172b4...da7e7da75fab002c8e6c695ddce45c825fbe6444) <sub>(2024-05-31 to 2024-06-07)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`878ace11` ➡️ `50fcf17d`](https://github.com/L3MON4D3/LuaSnip/compare/878ace11983444d865a72e1759dbcc331d1ace4c...50fcf17db7c75af80e6b6109acfbfb4504768780) <sub>(2024-05-24 to 2024-06-07)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`b124ef3b` ➡️ `92166b89`](https://github.com/neovim/nvim-lspconfig/compare/b124ef3bd4435a6db7ff03ea2f5a23e1e0487552...92166b89ab4b3d60f24e58170cac53b7141fd032) <sub>(2024-05-31 to 2024-06-06)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`75dc6491` ➡️ `4a143f13`](https://github.com/lewis6991/gitsigns.nvim/compare/75dc649106827183547d3bedd4602442340d2f7f...4a143f13e122ab91abdc88f89eefbe70a4858a56) <sub>(2024-05-29 to 2024-06-07)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`6132b0f6` ➡️ `31f40991`](https://github.com/nixos/nixpkgs/compare/6132b0f6e344ce2fe34fc051b72fb46e34f668e0...31f40991012489e858517ec20102f033e4653afb) <sub>(2024-05-30 to 2024-06-06)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`0e8fcc54` ➡️ `cc4d466c`](https://github.com/cachix/git-hooks.nix/compare/0e8fcc54b842ad8428c9e705cb5994eaf05c26a0...cc4d466cb1254af050ff7bdf47f6d404a7c646d1) <sub>(2024-05-20 to 2024-06-06)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`b77921fd` ➡️ `b4b302d6`](https://github.com/nvim-tree/nvim-web-devicons/compare/b77921fdc44833c994fdb389d658ccbce5490c16...b4b302d6ae229f67df7a87ef69fa79473fe788a9) <sub>(2024-05-25 to 2024-06-07)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`0eb314b4` ➡️ `a7117efb`](https://github.com/nix-community/home-manager/compare/0eb314b4f0ba337e88123e0b1e57ef58346aafd9...a7117efb3725e6197dd95424136f79147aa35e5b) <sub>(2024-05-30 to 2024-06-04)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`5c338154` ➡️ `d490a7bc`](https://github.com/neovim/neovim/compare/5c33815448e11b514678f39cecc74e68131d4628...d490a7bc5b9d731828f5da16b35a86b4e1270624) <sub>(2024-05-30 to 2024-06-06)</sub>
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`8dc45382` ➡️ `2a55567f`](https://github.com/hercules-ci/flake-parts/compare/8dc45382d5206bd292f9c2768b8058a8fd8311d9...2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8) <sub>(2024-05-16 to 2024-06-01)</sub>