### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -67,11 +67,11 @@
     "comment-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1691409559,
-        "narHash": "sha256-+dF1ZombrlO6nQggufSb0igXW5zwU++o0W/5ZA07cdc=",
+        "lastModified": 1717957420,
+        "narHash": "sha256-h0kPue5Eqd5aeu4VoLH45pF0DmWWo1d8SnLICSQ63zc=",
         "owner": "numToStr",
         "repo": "Comment.nvim",
-        "rev": "0236521ea582747b58869cb72f70ccfa967d2e89",
+        "rev": "e30b7f2008e52442154b66f7c519bfd2f1e32acb",
         "type": "github"
       },
       "original": {
@@ -367,11 +367,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1716130336,
-        "narHash": "sha256-nyNtb3nsS/zFdSNRyXabcGIabAwgivJIUFB2c62vXmA=",
+        "lastModified": 1718211560,
+        "narHash": "sha256-0WYwsFdTm7TP6LP8lXeDBP0yOJqCAGSCfwgs6vpZqrU=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "4f59455d2388e113bd510e85b310d15b9228ca0d",
+        "rev": "64d6cafb9dcbacce18c26d7daf617ebb96b273f3",
         "type": "github"
       },
       "original": {
@@ -528,11 +528,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1717763051,
-        "narHash": "sha256-FWcjFwprIeDRMKhurJtGqCfI4mP4fQNQY8szjnjuOCc=",
+        "lastModified": 1718287407,
+        "narHash": "sha256-1EgkwEgfs3/e+nVs+gADj0xurOcG/zeLGiXZuFDetSw=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "4a143f13e122ab91abdc88f89eefbe70a4858a56",
+        "rev": "47c8e3e571376b24de62408fd0c9d12f0a9fc0a3",
         "type": "github"
       },
       "original": {
@@ -550,11 +550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713898448,
-        "narHash": "sha256-6q6ojsp/Z9P2goqnxyfCSzFOD92T3Uobmj8oVAicUOs=",
+        "lastModified": 1718018037,
+        "narHash": "sha256-03rLBd/lKecgaKz0j5ESUf9lDn5R0SJatZTKLL5unWE=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "c0302ec12d569532a6b6bd218f698bc402e93adc",
+        "rev": "0ab08b23ce3c3f75fe9a5598756b6fb8bcf0b414",
         "type": "github"
       },
       "original": {
@@ -570,11 +570,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717525419,
-        "narHash": "sha256-5z2422pzWnPXHgq2ms8lcCfttM0dz+hg+x1pCcNkAws=",
+        "lastModified": 1718243258,
+        "narHash": "sha256-abBpj2VU8p6qlRzTU8o22q68MmOaZ4v8zZ4UlYl5YRU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a7117efb3725e6197dd95424136f79147aa35e5b",
+        "rev": "8d5e27b4807d25308dfe369d5a923d87e7dbfda3",
         "type": "github"
       },
       "original": {
@@ -789,11 +789,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717737574,
-        "narHash": "sha256-Oc1xZW7pc/cCr+2FpgbFuNz/yBh4ZqjsbmSH7pVADiE=",
+        "lastModified": 1718298978,
+        "narHash": "sha256-7jIX4cUdn6LYP4l38S38nsSNbGMF5eXP9qKe69SR02k=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "da7e7da75fab002c8e6c695ddce45c825fbe6444",
+        "rev": "84299e229226207721e142246ff8343f8a8c6e5d",
         "type": "github"
       },
       "original": {
@@ -805,11 +805,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1717712276,
-        "narHash": "sha256-r9mtD17PiNYVKWs+Cc9uIv/vmkRtiwGrG42QRd1K6Os=",
+        "lastModified": 1718209811,
+        "narHash": "sha256-hZYLBealuoS3bL3eXFeQVAoasThqf7DDwg8kW0ASTOE=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "d490a7bc5b9d731828f5da16b35a86b4e1270624",
+        "rev": "53afdf360cf195c02c22865f4e63b273d1ef152e",
         "type": "github"
       },
       "original": {
@@ -920,11 +920,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1717681334,
-        "narHash": "sha256-HlvsMH8BNgdmQCwbBDmWp5/DfkEQYhXZHagJQCgbJU0=",
+        "lastModified": 1718276985,
+        "narHash": "sha256-u1fA0DYQYdeG+5kDm1bOoGcHtX0rtC7qs2YA2N1X++I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "31f40991012489e858517ec20102f033e4653afb",
+        "rev": "3f84a279f1a6290ce154c5531378acc827836fbb",
         "type": "github"
       },
       "original": {
@@ -1017,11 +1017,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1715954188,
-        "narHash": "sha256-GhXfnWqpXFVM7Yi9+qEXHfA6LIMILcMG9pP4VYXuptE=",
+        "lastModified": 1717829983,
+        "narHash": "sha256-7tEfEjWH5pneI10jLYpenoysRQPa2zPGLTNcbMX3x2I=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "5260e5e8ecadaf13e6b82cf867a909f54e15fd07",
+        "rev": "a110e12d0b58eefcf5b771f533fc2cf3050680ac",
         "type": "github"
       },
       "original": {
@@ -1033,11 +1033,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1717681643,
-        "narHash": "sha256-QlgLZx9Dp5ijSOxeicNcqm4G8YcF5aOZFJSiBclWuIY=",
+        "lastModified": 1718348279,
+        "narHash": "sha256-Z9nN6Jss2X1IbOnANsxlyGy9nsoNB0ongDOZez9RFZw=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "92166b89ab4b3d60f24e58170cac53b7141fd032",
+        "rev": "37f362ef42d1a604d332e8d3d7d47593852b4313",
         "type": "github"
       },
       "original": {
@@ -1332,11 +1332,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1717003449,
-        "narHash": "sha256-aCH6J4I8ZW4adCKjlYoVoH2laf9wAs8OvXxegHYDIr0=",
+        "lastModified": 1717942246,
+        "narHash": "sha256-wiKpQZJfZ/kkZAid9PiER4RSJLHnTrZfYrfqzjPWKYs=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "dfa230be84a044e7f546a6c2b0a403c739732b86",
+        "rev": "f12b15e1b3a33524eb06a1ae7bc852fb1fd92197",
         "type": "github"
       },
       "original": {
@@ -1348,11 +1348,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1717733505,
-        "narHash": "sha256-bpC7xeYhUKUDa7cm4qEYRpc3m1ItukMM0XZNSHI0HV0=",
+        "lastModified": 1717894639,
+        "narHash": "sha256-j/B/E1VltJ/QpVFtDKAdVC4+KZ5Mz8dQP5kd8HIHjLs=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "b4b302d6ae229f67df7a87ef69fa79473fe788a9",
+        "rev": "c0cfc1738361b5da1cd0a962dd6f774cc444f856",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'comment-nvim':
    'github:numToStr/Comment.nvim/0236521ea582747b58869cb72f70ccfa967d2e89' (2023-08-07)
  → 'github:numToStr/Comment.nvim/e30b7f2008e52442154b66f7c519bfd2f1e32acb' (2024-06-09)
• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/4f59455d2388e113bd510e85b310d15b9228ca0d' (2024-05-19)
  → 'github:tpope/vim-fugitive/64d6cafb9dcbacce18c26d7daf617ebb96b273f3' (2024-06-12)
• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/4a143f13e122ab91abdc88f89eefbe70a4858a56' (2024-06-07)
  → 'github:lewis6991/gitsigns.nvim/47c8e3e571376b24de62408fd0c9d12f0a9fc0a3' (2024-06-13)
• Updated input 'home-manager':
    'github:nix-community/home-manager/a7117efb3725e6197dd95424136f79147aa35e5b' (2024-06-04)
  → 'github:nix-community/home-manager/8d5e27b4807d25308dfe369d5a923d87e7dbfda3' (2024-06-13)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/da7e7da75fab002c8e6c695ddce45c825fbe6444' (2024-06-07)
  → 'github:nix-community/neovim-nightly-overlay/84299e229226207721e142246ff8343f8a8c6e5d' (2024-06-13)
• Updated input 'neovim-nightly-overlay/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/c0302ec12d569532a6b6bd218f698bc402e93adc' (2024-04-23)
  → 'github:hercules-ci/hercules-ci-effects/0ab08b23ce3c3f75fe9a5598756b6fb8bcf0b414' (2024-06-10)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/d490a7bc5b9d731828f5da16b35a86b4e1270624' (2024-06-06)
  → 'github:neovim/neovim/53afdf360cf195c02c22865f4e63b273d1ef152e' (2024-06-12)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/31f40991012489e858517ec20102f033e4653afb' (2024-06-06)
  → 'github:nixos/nixpkgs/3f84a279f1a6290ce154c5531378acc827836fbb' (2024-06-13)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/5260e5e8ecadaf13e6b82cf867a909f54e15fd07' (2024-05-17)
  → 'github:hrsh7th/nvim-cmp/a110e12d0b58eefcf5b771f533fc2cf3050680ac' (2024-06-08)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/92166b89ab4b3d60f24e58170cac53b7141fd032' (2024-06-06)
  → 'github:neovim/nvim-lspconfig/37f362ef42d1a604d332e8d3d7d47593852b4313' (2024-06-14)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/dfa230be84a044e7f546a6c2b0a403c739732b86' (2024-05-29)
  → 'github:nvim-telescope/telescope.nvim/f12b15e1b3a33524eb06a1ae7bc852fb1fd92197' (2024-06-09)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/b4b302d6ae229f67df7a87ef69fa79473fe788a9' (2024-06-07)
  → 'github:nvim-tree/nvim-web-devicons/c0cfc1738361b5da1cd0a962dd6f774cc444f856' (2024-06-09)

```

</p></details>

 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`4f59455d` ➡️ `64d6cafb`](https://github.com/tpope/vim-fugitive/compare/4f59455d2388e113bd510e85b310d15b9228ca0d...64d6cafb9dcbacce18c26d7daf617ebb96b273f3) <sub>(2024-05-19 to 2024-06-12)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`da7e7da7` ➡️ `84299e22`](https://github.com/nix-community/neovim-nightly-overlay/compare/da7e7da75fab002c8e6c695ddce45c825fbe6444...84299e229226207721e142246ff8343f8a8c6e5d) <sub>(2024-06-07 to 2024-06-13)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`92166b89` ➡️ `37f362ef`](https://github.com/neovim/nvim-lspconfig/compare/92166b89ab4b3d60f24e58170cac53b7141fd032...37f362ef42d1a604d332e8d3d7d47593852b4313) <sub>(2024-06-06 to 2024-06-14)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`5260e5e8` ➡️ `a110e12d`](https://github.com/hrsh7th/nvim-cmp/compare/5260e5e8ecadaf13e6b82cf867a909f54e15fd07...a110e12d0b58eefcf5b771f533fc2cf3050680ac) <sub>(2024-05-17 to 2024-06-08)</sub>
 - Updated input [`comment-nvim`](https://github.com/numToStr/Comment.nvim): [`0236521e` ➡️ `e30b7f20`](https://github.com/numToStr/Comment.nvim/compare/0236521ea582747b58869cb72f70ccfa967d2e89...e30b7f2008e52442154b66f7c519bfd2f1e32acb) <sub>(2023-08-07 to 2024-06-09)</sub>
 - Updated input [`neovim-nightly-overlay/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`c0302ec1` ➡️ `0ab08b23`](https://github.com/hercules-ci/hercules-ci-effects/compare/c0302ec12d569532a6b6bd218f698bc402e93adc...0ab08b23ce3c3f75fe9a5598756b6fb8bcf0b414) <sub>(2024-04-23 to 2024-06-10)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`4a143f13` ➡️ `47c8e3e5`](https://github.com/lewis6991/gitsigns.nvim/compare/4a143f13e122ab91abdc88f89eefbe70a4858a56...47c8e3e571376b24de62408fd0c9d12f0a9fc0a3) <sub>(2024-06-07 to 2024-06-13)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`31f40991` ➡️ `3f84a279`](https://github.com/nixos/nixpkgs/compare/31f40991012489e858517ec20102f033e4653afb...3f84a279f1a6290ce154c5531378acc827836fbb) <sub>(2024-06-06 to 2024-06-13)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`dfa230be` ➡️ `f12b15e1`](https://github.com/nvim-telescope/telescope.nvim/compare/dfa230be84a044e7f546a6c2b0a403c739732b86...f12b15e1b3a33524eb06a1ae7bc852fb1fd92197) <sub>(2024-05-29 to 2024-06-09)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`b4b302d6` ➡️ `c0cfc173`](https://github.com/nvim-tree/nvim-web-devicons/compare/b4b302d6ae229f67df7a87ef69fa79473fe788a9...c0cfc1738361b5da1cd0a962dd6f774cc444f856) <sub>(2024-06-07 to 2024-06-09)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`a7117efb` ➡️ `8d5e27b4`](https://github.com/nix-community/home-manager/compare/a7117efb3725e6197dd95424136f79147aa35e5b...8d5e27b4807d25308dfe369d5a923d87e7dbfda3) <sub>(2024-06-04 to 2024-06-13)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`d490a7bc` ➡️ `53afdf36`](https://github.com/neovim/neovim/compare/d490a7bc5b9d731828f5da16b35a86b4e1270624...53afdf360cf195c02c22865f4e63b273d1ef152e) <sub>(2024-06-06 to 2024-06-12)</sub>