### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -445,11 +445,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717664902,
-        "narHash": "sha256-7XfBuLULizXjXfBYy/VV+SpYMHreNRHk9nKMsm1bgb4=",
+        "lastModified": 1718879355,
+        "narHash": "sha256-RTyqP4fBX2MdhNuMP+fnR3lIwbdtXhyj7w7fwtvgspc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "cc4d466cb1254af050ff7bdf47f6d404a7c646d1",
+        "rev": "8cd35b9496d21a6c55164d8547d9d5280162b07a",
         "type": "github"
       },
       "original": {
@@ -528,11 +528,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1718287407,
-        "narHash": "sha256-1EgkwEgfs3/e+nVs+gADj0xurOcG/zeLGiXZuFDetSw=",
+        "lastModified": 1718979684,
+        "narHash": "sha256-e0UFZJimSPAnCqUZeHQBh4heij+zYWh1tJt3Onf9+vo=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "47c8e3e571376b24de62408fd0c9d12f0a9fc0a3",
+        "rev": "8df63f2ddc615feb71fd4aee45a4cee022876df1",
         "type": "github"
       },
       "original": {
@@ -570,11 +570,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718243258,
-        "narHash": "sha256-abBpj2VU8p6qlRzTU8o22q68MmOaZ4v8zZ4UlYl5YRU=",
+        "lastModified": 1718983978,
+        "narHash": "sha256-lp6stESwTLBZUQ5GBivxwNehShmBp4jqeX/1xahM61w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8d5e27b4807d25308dfe369d5a923d87e7dbfda3",
+        "rev": "c559542f0aa87971a7f4c1b3478fe33cc904b902",
         "type": "github"
       },
       "original": {
@@ -604,11 +604,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1716228712,
-        "narHash": "sha256-y+LOXuSRMfkR2Vfwl5K2NVrszi1h5MJpML+msLnVS8U=",
+        "lastModified": 1718476555,
+        "narHash": "sha256-fuWpgh8KasByIJWE+xVd37Al0LV5YAn6s871T50qVY0=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "33b38358559054d316eb605ccb733980dfa7dc63",
+        "rev": "29a8374f4b9206d5c4af84aceb7fb5dff441ea60",
         "type": "github"
       },
       "original": {
@@ -653,11 +653,11 @@
     "lsp-signature-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1717205989,
-        "narHash": "sha256-ezNJvVjwGUpb3D77DshVAVnh9fDIiLW21CcPRDxlzJY=",
+        "lastModified": 1718424851,
+        "narHash": "sha256-cU6Xz1ZzRU5JM1qFiUrT3m02JcTJUQR6Grlf87j9ztw=",
         "owner": "ray-x",
         "repo": "lsp_signature.nvim",
-        "rev": "2ec2ba23882329c1302dff773b0d3620371d634f",
+        "rev": "a38da0a61c172bb59e34befc12efe48359884793",
         "type": "github"
       },
       "original": {
@@ -789,11 +789,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718298978,
-        "narHash": "sha256-7jIX4cUdn6LYP4l38S38nsSNbGMF5eXP9qKe69SR02k=",
+        "lastModified": 1718935491,
+        "narHash": "sha256-Dk+ZTVu3CuVv4UPbif3GmR7eT3zAE/mQ+3UUvFHknKE=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "84299e229226207721e142246ff8343f8a8c6e5d",
+        "rev": "cc2d148e283e05cce751c5cc50ce38bbc0589f61",
         "type": "github"
       },
       "original": {
@@ -805,11 +805,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1718209811,
-        "narHash": "sha256-hZYLBealuoS3bL3eXFeQVAoasThqf7DDwg8kW0ASTOE=",
+        "lastModified": 1718890629,
+        "narHash": "sha256-TLJ8xTHKgnbsMnlmfQ7eF5+aafjo5PlFQFF3mkrIsBs=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "53afdf360cf195c02c22865f4e63b273d1ef152e",
+        "rev": "0e3e1e6b6d8370f1fcc9887d5cb931b131450a1c",
         "type": "github"
       },
       "original": {
@@ -920,11 +920,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1718276985,
-        "narHash": "sha256-u1fA0DYQYdeG+5kDm1bOoGcHtX0rtC7qs2YA2N1X++I=",
+        "lastModified": 1718870667,
+        "narHash": "sha256-jab3Kpc8O1z3qxwVsCMHL4+18n5Wy/HHKyu1fcsF7gs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3f84a279f1a6290ce154c5531378acc827836fbb",
+        "rev": "9b10b8f00cb5494795e5f51b39210fed4d2b0748",
         "type": "github"
       },
       "original": {
@@ -1033,11 +1033,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1718348279,
-        "narHash": "sha256-Z9nN6Jss2X1IbOnANsxlyGy9nsoNB0ongDOZez9RFZw=",
+        "lastModified": 1718966746,
+        "narHash": "sha256-a2J1tk/XjAHXgcpmXGp0Ls7rsA5jb9SfHnk12qwD+8o=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "37f362ef42d1a604d332e8d3d7d47593852b4313",
+        "rev": "f43135c38a37c588053ad5e209c7460f43f6340c",
         "type": "github"
       },
       "original": {
@@ -1195,11 +1195,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1717754390,
-        "narHash": "sha256-bgx4kY6uLmQzUoMz6qnBXB1iDnniY/JE+T6FxxwLIdY=",
+        "lastModified": 1718994853,
+        "narHash": "sha256-dDtdRV9NPb/hf/yhH6X+2KItYAzzJFA0KzvIfnKXIrs=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "00a9508e8f95b8f8f9f60125a2082a53e0740987",
+        "rev": "54908384f1b7932576a92caa645681026d8b84e1",
         "type": "github"
       },
       "original": {
@@ -1332,11 +1332,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1717942246,
-        "narHash": "sha256-wiKpQZJfZ/kkZAid9PiER4RSJLHnTrZfYrfqzjPWKYs=",
+        "lastModified": 1718969656,
+        "narHash": "sha256-0fS3RYO/9gwmdK2H9Y/4Z/P++4aEHTHJqR2mH0vWAFY=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "f12b15e1b3a33524eb06a1ae7bc852fb1fd92197",
+        "rev": "f2bfde705ac752c52544d5cfa8b0aee0a766c1ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/47c8e3e571376b24de62408fd0c9d12f0a9fc0a3' (2024-06-13)
  → 'github:lewis6991/gitsigns.nvim/8df63f2ddc615feb71fd4aee45a4cee022876df1' (2024-06-21)
• Updated input 'home-manager':
    'github:nix-community/home-manager/8d5e27b4807d25308dfe369d5a923d87e7dbfda3' (2024-06-13)
  → 'github:nix-community/home-manager/c559542f0aa87971a7f4c1b3478fe33cc904b902' (2024-06-21)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/33b38358559054d316eb605ccb733980dfa7dc63' (2024-05-20)
  → 'github:hyprwm/contrib/29a8374f4b9206d5c4af84aceb7fb5dff441ea60' (2024-06-15)
• Updated input 'lsp-signature-nvim':
    'github:ray-x/lsp_signature.nvim/2ec2ba23882329c1302dff773b0d3620371d634f' (2024-06-01)
  → 'github:ray-x/lsp_signature.nvim/a38da0a61c172bb59e34befc12efe48359884793' (2024-06-15)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/84299e229226207721e142246ff8343f8a8c6e5d' (2024-06-13)
  → 'github:nix-community/neovim-nightly-overlay/cc2d148e283e05cce751c5cc50ce38bbc0589f61' (2024-06-21)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/cc4d466cb1254af050ff7bdf47f6d404a7c646d1' (2024-06-06)
  → 'github:cachix/git-hooks.nix/8cd35b9496d21a6c55164d8547d9d5280162b07a' (2024-06-20)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/53afdf360cf195c02c22865f4e63b273d1ef152e' (2024-06-12)
  → 'github:neovim/neovim/0e3e1e6b6d8370f1fcc9887d5cb931b131450a1c' (2024-06-20)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3f84a279f1a6290ce154c5531378acc827836fbb' (2024-06-13)
  → 'github:nixos/nixpkgs/9b10b8f00cb5494795e5f51b39210fed4d2b0748' (2024-06-20)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/37f362ef42d1a604d332e8d3d7d47593852b4313' (2024-06-14)
  → 'github:neovim/nvim-lspconfig/f43135c38a37c588053ad5e209c7460f43f6340c' (2024-06-21)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/00a9508e8f95b8f8f9f60125a2082a53e0740987' (2024-06-07)
  → 'github:mrcjkb/rustaceanvim/54908384f1b7932576a92caa645681026d8b84e1' (2024-06-21)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/f12b15e1b3a33524eb06a1ae7bc852fb1fd92197' (2024-06-09)
  → 'github:nvim-telescope/telescope.nvim/f2bfde705ac752c52544d5cfa8b0aee0a766c1ed' (2024-06-21)

```

</p></details>

 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`00a9508e` ➡️ `54908384`](https://github.com/mrcjkb/rustaceanvim/compare/00a9508e8f95b8f8f9f60125a2082a53e0740987...54908384f1b7932576a92caa645681026d8b84e1) <sub>(2024-06-07 to 2024-06-21)</sub>
 - Updated input [`lsp-signature-nvim`](https://github.com/ray-x/lsp_signature.nvim): [`2ec2ba23` ➡️ `a38da0a6`](https://github.com/ray-x/lsp_signature.nvim/compare/2ec2ba23882329c1302dff773b0d3620371d634f...a38da0a61c172bb59e34befc12efe48359884793) <sub>(2024-06-01 to 2024-06-15)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`84299e22` ➡️ `cc2d148e`](https://github.com/nix-community/neovim-nightly-overlay/compare/84299e229226207721e142246ff8343f8a8c6e5d...cc2d148e283e05cce751c5cc50ce38bbc0589f61) <sub>(2024-06-13 to 2024-06-21)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`33b38358` ➡️ `29a8374f`](https://github.com/hyprwm/contrib/compare/33b38358559054d316eb605ccb733980dfa7dc63...29a8374f4b9206d5c4af84aceb7fb5dff441ea60) <sub>(2024-05-20 to 2024-06-15)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`37f362ef` ➡️ `f43135c3`](https://github.com/neovim/nvim-lspconfig/compare/37f362ef42d1a604d332e8d3d7d47593852b4313...f43135c38a37c588053ad5e209c7460f43f6340c) <sub>(2024-06-14 to 2024-06-21)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`47c8e3e5` ➡️ `8df63f2d`](https://github.com/lewis6991/gitsigns.nvim/compare/47c8e3e571376b24de62408fd0c9d12f0a9fc0a3...8df63f2ddc615feb71fd4aee45a4cee022876df1) <sub>(2024-06-13 to 2024-06-21)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`3f84a279` ➡️ `9b10b8f0`](https://github.com/nixos/nixpkgs/compare/3f84a279f1a6290ce154c5531378acc827836fbb...9b10b8f00cb5494795e5f51b39210fed4d2b0748) <sub>(2024-06-13 to 2024-06-20)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`cc4d466c` ➡️ `8cd35b94`](https://github.com/cachix/git-hooks.nix/compare/cc4d466cb1254af050ff7bdf47f6d404a7c646d1...8cd35b9496d21a6c55164d8547d9d5280162b07a) <sub>(2024-06-06 to 2024-06-20)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`f12b15e1` ➡️ `f2bfde70`](https://github.com/nvim-telescope/telescope.nvim/compare/f12b15e1b3a33524eb06a1ae7bc852fb1fd92197...f2bfde705ac752c52544d5cfa8b0aee0a766c1ed) <sub>(2024-06-09 to 2024-06-21)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`8d5e27b4` ➡️ `c559542f`](https://github.com/nix-community/home-manager/compare/8d5e27b4807d25308dfe369d5a923d87e7dbfda3...c559542f0aa87971a7f4c1b3478fe33cc904b902) <sub>(2024-06-13 to 2024-06-21)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`53afdf36` ➡️ `0e3e1e6b`](https://github.com/neovim/neovim/compare/53afdf360cf195c02c22865f4e63b273d1ef152e...0e3e1e6b6d8370f1fcc9887d5cb931b131450a1c) <sub>(2024-06-12 to 2024-06-20)</sub>