### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -367,11 +367,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1718211560,
-        "narHash": "sha256-0WYwsFdTm7TP6LP8lXeDBP0yOJqCAGSCfwgs6vpZqrU=",
+        "lastModified": 1719369274,
+        "narHash": "sha256-v0M1dzLMNyBsd+73dX5bk99AJNh4nRmCikhlb+Xpazw=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "64d6cafb9dcbacce18c26d7daf617ebb96b273f3",
+        "rev": "d0c1a437536778bcc8174b7cb2ffdf98f611e6fe",
         "type": "github"
       },
       "original": {
@@ -445,11 +445,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718879355,
-        "narHash": "sha256-RTyqP4fBX2MdhNuMP+fnR3lIwbdtXhyj7w7fwtvgspc=",
+        "lastModified": 1719259945,
+        "narHash": "sha256-F1h+XIsGKT9TkGO3omxDLEb/9jOOsI6NnzsXFsZhry4=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "8cd35b9496d21a6c55164d8547d9d5280162b07a",
+        "rev": "0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07",
         "type": "github"
       },
       "original": {
@@ -528,11 +528,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1718979684,
-        "narHash": "sha256-e0UFZJimSPAnCqUZeHQBh4heij+zYWh1tJt3Onf9+vo=",
+        "lastModified": 1719583788,
+        "narHash": "sha256-QXM13mB7Ulx7+lH43jlY7r3Q3GU1ZkaZf7nxY/aIXfU=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "8df63f2ddc615feb71fd4aee45a4cee022876df1",
+        "rev": "6b1a14eabcebbcca1b9e9163a26b2f8371364cb7",
         "type": "github"
       },
       "original": {
@@ -550,11 +550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718018037,
-        "narHash": "sha256-03rLBd/lKecgaKz0j5ESUf9lDn5R0SJatZTKLL5unWE=",
+        "lastModified": 1719226092,
+        "narHash": "sha256-YNkUMcCUCpnULp40g+svYsaH1RbSEj6s4WdZY/SHe38=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "0ab08b23ce3c3f75fe9a5598756b6fb8bcf0b414",
+        "rev": "11e4b8dc112e2f485d7c97e1cee77f9958f498f5",
         "type": "github"
       },
       "original": {
@@ -570,11 +570,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718983978,
-        "narHash": "sha256-lp6stESwTLBZUQ5GBivxwNehShmBp4jqeX/1xahM61w=",
+        "lastModified": 1719588253,
+        "narHash": "sha256-A03i8xiVgP14DCmV5P7VUv37eodCjY4e1iai0b2EuuM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c559542f0aa87971a7f4c1b3478fe33cc904b902",
+        "rev": "7e68e55d2e16d3a1e92a679430728c35a30fd24e",
         "type": "github"
       },
       "original": {
@@ -701,11 +701,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1717753191,
-        "narHash": "sha256-QgK/tI4KU+ZrVl7NFCP8lX7LWjes1pKvt2Eti/UZna8=",
+        "lastModified": 1719606247,
+        "narHash": "sha256-zjefbPMiKxwYsBzE75jQRVNFMDSnCq1hKe1cBBqMRWg=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "50fcf17db7c75af80e6b6109acfbfb4504768780",
+        "rev": "ce0a05ab4e2839e1c48d072c5236cce846a387bc",
         "type": "github"
       },
       "original": {
@@ -789,11 +789,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718935491,
-        "narHash": "sha256-Dk+ZTVu3CuVv4UPbif3GmR7eT3zAE/mQ+3UUvFHknKE=",
+        "lastModified": 1719467057,
+        "narHash": "sha256-8gQ0txwuLoBpBeIhTAkl+/7Hi/AD4KE5m4YhOn1OA3E=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "cc2d148e283e05cce751c5cc50ce38bbc0589f61",
+        "rev": "bb6bea003dc464a4248a173e71a007d368691092",
         "type": "github"
       },
       "original": {
@@ -805,11 +805,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1718890629,
-        "narHash": "sha256-TLJ8xTHKgnbsMnlmfQ7eF5+aafjo5PlFQFF3mkrIsBs=",
+        "lastModified": 1719414226,
+        "narHash": "sha256-h/qJ+1R+BtY+mX02UsqYW82hEl78mrHTGAs9yjpFEzU=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "0e3e1e6b6d8370f1fcc9887d5cb931b131450a1c",
+        "rev": "fc9b70826ec88ca2e6c0624c522b872e87aa7ac1",
         "type": "github"
       },
       "original": {
@@ -920,11 +920,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1718870667,
-        "narHash": "sha256-jab3Kpc8O1z3qxwVsCMHL4+18n5Wy/HHKyu1fcsF7gs=",
+        "lastModified": 1719468428,
+        "narHash": "sha256-vN5xJAZ4UGREEglh3lfbbkIj+MPEYMuqewMn4atZFaQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9b10b8f00cb5494795e5f51b39210fed4d2b0748",
+        "rev": "1e3deb3d8a86a870d925760db1a5adecc64d329d",
         "type": "github"
       },
       "original": {
@@ -1033,11 +1033,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1718966746,
-        "narHash": "sha256-a2J1tk/XjAHXgcpmXGp0Ls7rsA5jb9SfHnk12qwD+8o=",
+        "lastModified": 1719556895,
+        "narHash": "sha256-EjoliG6YSuZsUaGLGbkGZL+/hvDYM0RJOHjJP+lJwOI=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "f43135c38a37c588053ad5e209c7460f43f6340c",
+        "rev": "95b2fc427353e42318c974d10685d500441b821b",
         "type": "github"
       },
       "original": {
@@ -1332,11 +1332,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1718969656,
-        "narHash": "sha256-0fS3RYO/9gwmdK2H9Y/4Z/P++4aEHTHJqR2mH0vWAFY=",
+        "lastModified": 1719458873,
+        "narHash": "sha256-DuyCp6ZJYhJJSramSHjwGqa3vyindi8jieaFnsLHoUE=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "f2bfde705ac752c52544d5cfa8b0aee0a766c1ed",
+        "rev": "7bd2f9b72f8449780b79bcf351534e2cd36ec43a",
         "type": "github"
       },
       "original": {

--- a/system/nixos/profiles/desktop/default.nix
+++ b/system/nixos/profiles/desktop/default.nix
@@ -76,8 +76,6 @@ in
 
     hardware.opengl = {
       enable = true;
-      driSupport = true;
-      driSupport32Bit = true;
     };
 
     hardware.nvidia = {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/64d6cafb9dcbacce18c26d7daf617ebb96b273f3' (2024-06-12)
  → 'github:tpope/vim-fugitive/d0c1a437536778bcc8174b7cb2ffdf98f611e6fe' (2024-06-26)
• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/8df63f2ddc615feb71fd4aee45a4cee022876df1' (2024-06-21)
  → 'github:lewis6991/gitsigns.nvim/6b1a14eabcebbcca1b9e9163a26b2f8371364cb7' (2024-06-28)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c559542f0aa87971a7f4c1b3478fe33cc904b902' (2024-06-21)
  → 'github:nix-community/home-manager/7e68e55d2e16d3a1e92a679430728c35a30fd24e' (2024-06-28)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/50fcf17db7c75af80e6b6109acfbfb4504768780' (2024-06-07)
  → 'github:L3MON4D3/LuaSnip/ce0a05ab4e2839e1c48d072c5236cce846a387bc' (2024-06-28)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/cc2d148e283e05cce751c5cc50ce38bbc0589f61' (2024-06-21)
  → 'github:nix-community/neovim-nightly-overlay/bb6bea003dc464a4248a173e71a007d368691092' (2024-06-27)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/8cd35b9496d21a6c55164d8547d9d5280162b07a' (2024-06-20)
  → 'github:cachix/git-hooks.nix/0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07' (2024-06-24)
• Updated input 'neovim-nightly-overlay/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/0ab08b23ce3c3f75fe9a5598756b6fb8bcf0b414' (2024-06-10)
  → 'github:hercules-ci/hercules-ci-effects/11e4b8dc112e2f485d7c97e1cee77f9958f498f5' (2024-06-24)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/0e3e1e6b6d8370f1fcc9887d5cb931b131450a1c' (2024-06-20)
  → 'github:neovim/neovim/fc9b70826ec88ca2e6c0624c522b872e87aa7ac1' (2024-06-26)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/9b10b8f00cb5494795e5f51b39210fed4d2b0748' (2024-06-20)
  → 'github:nixos/nixpkgs/1e3deb3d8a86a870d925760db1a5adecc64d329d' (2024-06-27)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/f43135c38a37c588053ad5e209c7460f43f6340c' (2024-06-21)
  → 'github:neovim/nvim-lspconfig/95b2fc427353e42318c974d10685d500441b821b' (2024-06-28)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/f2bfde705ac752c52544d5cfa8b0aee0a766c1ed' (2024-06-21)
  → 'github:nvim-telescope/telescope.nvim/7bd2f9b72f8449780b79bcf351534e2cd36ec43a' (2024-06-27)

```

</p></details>

 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`64d6cafb` ➡️ `d0c1a437`](https://github.com/tpope/vim-fugitive/compare/64d6cafb9dcbacce18c26d7daf617ebb96b273f3...d0c1a437536778bcc8174b7cb2ffdf98f611e6fe) <sub>(2024-06-12 to 2024-06-26)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`cc2d148e` ➡️ `bb6bea00`](https://github.com/nix-community/neovim-nightly-overlay/compare/cc2d148e283e05cce751c5cc50ce38bbc0589f61...bb6bea003dc464a4248a173e71a007d368691092) <sub>(2024-06-21 to 2024-06-27)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`50fcf17d` ➡️ `ce0a05ab`](https://github.com/L3MON4D3/LuaSnip/compare/50fcf17db7c75af80e6b6109acfbfb4504768780...ce0a05ab4e2839e1c48d072c5236cce846a387bc) <sub>(2024-06-07 to 2024-06-28)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`f43135c3` ➡️ `95b2fc42`](https://github.com/neovim/nvim-lspconfig/compare/f43135c38a37c588053ad5e209c7460f43f6340c...95b2fc427353e42318c974d10685d500441b821b) <sub>(2024-06-21 to 2024-06-28)</sub>
 - Updated input [`neovim-nightly-overlay/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`0ab08b23` ➡️ `11e4b8dc`](https://github.com/hercules-ci/hercules-ci-effects/compare/0ab08b23ce3c3f75fe9a5598756b6fb8bcf0b414...11e4b8dc112e2f485d7c97e1cee77f9958f498f5) <sub>(2024-06-10 to 2024-06-24)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`8df63f2d` ➡️ `6b1a14ea`](https://github.com/lewis6991/gitsigns.nvim/compare/8df63f2ddc615feb71fd4aee45a4cee022876df1...6b1a14eabcebbcca1b9e9163a26b2f8371364cb7) <sub>(2024-06-21 to 2024-06-28)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`9b10b8f0` ➡️ `1e3deb3d`](https://github.com/nixos/nixpkgs/compare/9b10b8f00cb5494795e5f51b39210fed4d2b0748...1e3deb3d8a86a870d925760db1a5adecc64d329d) <sub>(2024-06-20 to 2024-06-27)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`8cd35b94` ➡️ `0ff4381b`](https://github.com/cachix/git-hooks.nix/compare/8cd35b9496d21a6c55164d8547d9d5280162b07a...0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07) <sub>(2024-06-20 to 2024-06-24)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`f2bfde70` ➡️ `7bd2f9b7`](https://github.com/nvim-telescope/telescope.nvim/compare/f2bfde705ac752c52544d5cfa8b0aee0a766c1ed...7bd2f9b72f8449780b79bcf351534e2cd36ec43a) <sub>(2024-06-21 to 2024-06-27)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`c559542f` ➡️ `7e68e55d`](https://github.com/nix-community/home-manager/compare/c559542f0aa87971a7f4c1b3478fe33cc904b902...7e68e55d2e16d3a1e92a679430728c35a30fd24e) <sub>(2024-06-21 to 2024-06-28)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`0e3e1e6b` ➡️ `fc9b7082`](https://github.com/neovim/neovim/compare/0e3e1e6b6d8370f1fcc9887d5cb931b131450a1c...fc9b70826ec88ca2e6c0624c522b872e87aa7ac1) <sub>(2024-06-20 to 2024-06-26)</sub>