### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717285511,
-        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
         "type": "github"
       },
       "original": {
@@ -367,11 +367,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1719369274,
-        "narHash": "sha256-v0M1dzLMNyBsd+73dX5bk99AJNh4nRmCikhlb+Xpazw=",
+        "lastModified": 1720195443,
+        "narHash": "sha256-CfwcR1xFUJH3dBfpkyX/sncLopaUPUFPZDfe3aohTNo=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "d0c1a437536778bcc8174b7cb2ffdf98f611e6fe",
+        "rev": "8c8cdf4405cb8bdb70dd9812a33bb52363a87dbc",
         "type": "github"
       },
       "original": {
@@ -528,11 +528,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1719583788,
-        "narHash": "sha256-QXM13mB7Ulx7+lH43jlY7r3Q3GU1ZkaZf7nxY/aIXfU=",
+        "lastModified": 1720011088,
+        "narHash": "sha256-6Bukof+xnUULmTRF+bewSzSQP+tJoNxERv6aueOALCk=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "6b1a14eabcebbcca1b9e9163a26b2f8371364cb7",
+        "rev": "39b5b6f48bde0595ce68007ffce408c5d7ac1f79",
         "type": "github"
       },
       "original": {
@@ -570,11 +570,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719588253,
-        "narHash": "sha256-A03i8xiVgP14DCmV5P7VUv37eodCjY4e1iai0b2EuuM=",
+        "lastModified": 1720167120,
+        "narHash": "sha256-K9JYdlPiyaXp33JRg7CT8rMwH56e4ncXSsXW/YKnNXc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7e68e55d2e16d3a1e92a679430728c35a30fd24e",
+        "rev": "bbe6e94737289c8cb92d4d8f9199fbfe4f11c0ba",
         "type": "github"
       },
       "original": {
@@ -789,11 +789,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719467057,
-        "narHash": "sha256-8gQ0txwuLoBpBeIhTAkl+/7Hi/AD4KE5m4YhOn1OA3E=",
+        "lastModified": 1720161606,
+        "narHash": "sha256-B0n9ZIrXGPN0oS1DKBYZu2P1fTsnYMmXQkFtj/6mEQ8=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "bb6bea003dc464a4248a173e71a007d368691092",
+        "rev": "9e1740926b3910db38a8864e0220d012e14f7e8e",
         "type": "github"
       },
       "original": {
@@ -805,11 +805,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1719414226,
-        "narHash": "sha256-h/qJ+1R+BtY+mX02UsqYW82hEl78mrHTGAs9yjpFEzU=",
+        "lastModified": 1720137094,
+        "narHash": "sha256-K3iDLJy3K/ivR0uTlu2EXT+zrwMYNRn+CBGo+0kxxoc=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "fc9b70826ec88ca2e6c0624c522b872e87aa7ac1",
+        "rev": "3e6cec0befd41d37ee36cb4f602e84c58c5f0d27",
         "type": "github"
       },
       "original": {
@@ -920,11 +920,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1719468428,
-        "narHash": "sha256-vN5xJAZ4UGREEglh3lfbbkIj+MPEYMuqewMn4atZFaQ=",
+        "lastModified": 1720149507,
+        "narHash": "sha256-OFJoD1jjxzFlY1tAsehEWVA88DbU5smzDPQuu9SmnXY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1e3deb3d8a86a870d925760db1a5adecc64d329d",
+        "rev": "d9c0b9d611277e42e6db055636ba0409c59db6d2",
         "type": "github"
       },
       "original": {
@@ -1033,11 +1033,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1719556895,
-        "narHash": "sha256-EjoliG6YSuZsUaGLGbkGZL+/hvDYM0RJOHjJP+lJwOI=",
+        "lastModified": 1719990081,
+        "narHash": "sha256-Ms3GgwbzOU22hwqE2TgmccZzsXvoE4xYuCioAxRnRu8=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "95b2fc427353e42318c974d10685d500441b821b",
+        "rev": "cf97d2485fc3f6d4df1b79a3ea183e24c272215e",
         "type": "github"
       },
       "original": {
@@ -1195,11 +1195,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1718994853,
-        "narHash": "sha256-dDtdRV9NPb/hf/yhH6X+2KItYAzzJFA0KzvIfnKXIrs=",
+        "lastModified": 1719658629,
+        "narHash": "sha256-W8cSTcF+xapvpBUZYccwkPmkNkdK3wlbzC5rpbv6HZI=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "54908384f1b7932576a92caa645681026d8b84e1",
+        "rev": "af4de6a35d128ce71c75a9a7846bf089aea76f50",
         "type": "github"
       },
       "original": {
@@ -1316,11 +1316,11 @@
     "telescope-fzf-native-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1709647247,
-        "narHash": "sha256-rycebls3g0JCHM2+aG7xlJnX7ZPowqviaLbQrFSdflM=",
+        "lastModified": 1719928246,
+        "narHash": "sha256-GEhPf1f0jkEuDlHNuxVko0ChvuF/zoQroLNUlk8N5EA=",
         "owner": "nvim-telescope",
         "repo": "telescope-fzf-native.nvim",
-        "rev": "9ef21b2e6bb6ebeaf349a0781745549bbb870d27",
+        "rev": "cf48d4dfce44e0b9a2e19a008d6ec6ea6f01a83b",
         "type": "github"
       },
       "original": {
@@ -1332,11 +1332,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1719458873,
-        "narHash": "sha256-DuyCp6ZJYhJJSramSHjwGqa3vyindi8jieaFnsLHoUE=",
+        "lastModified": 1719860810,
+        "narHash": "sha256-U6fgii9FlJy+bHAtYVnZEOyiUAqlBHTvMFc4mo+xS/s=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "7bd2f9b72f8449780b79bcf351534e2cd36ec43a",
+        "rev": "bfcc7d5c6f12209139f175e6123a7b7de6d9c18a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/d0c1a437536778bcc8174b7cb2ffdf98f611e6fe' (2024-06-26)
  → 'github:tpope/vim-fugitive/8c8cdf4405cb8bdb70dd9812a33bb52363a87dbc' (2024-07-05)
• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/6b1a14eabcebbcca1b9e9163a26b2f8371364cb7' (2024-06-28)
  → 'github:lewis6991/gitsigns.nvim/39b5b6f48bde0595ce68007ffce408c5d7ac1f79' (2024-07-03)
• Updated input 'home-manager':
    'github:nix-community/home-manager/7e68e55d2e16d3a1e92a679430728c35a30fd24e' (2024-06-28)
  → 'github:nix-community/home-manager/bbe6e94737289c8cb92d4d8f9199fbfe4f11c0ba' (2024-07-05)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/bb6bea003dc464a4248a173e71a007d368691092' (2024-06-27)
  → 'github:nix-community/neovim-nightly-overlay/9e1740926b3910db38a8864e0220d012e14f7e8e' (2024-07-05)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8' (2024-06-01)
  → 'github:hercules-ci/flake-parts/9227223f6d922fee3c7b190b2cc238a99527bbb7' (2024-07-03)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/fc9b70826ec88ca2e6c0624c522b872e87aa7ac1' (2024-06-26)
  → 'github:neovim/neovim/3e6cec0befd41d37ee36cb4f602e84c58c5f0d27' (2024-07-04)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/1e3deb3d8a86a870d925760db1a5adecc64d329d' (2024-06-27)
  → 'github:nixos/nixpkgs/d9c0b9d611277e42e6db055636ba0409c59db6d2' (2024-07-05)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/95b2fc427353e42318c974d10685d500441b821b' (2024-06-28)
  → 'github:neovim/nvim-lspconfig/cf97d2485fc3f6d4df1b79a3ea183e24c272215e' (2024-07-03)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/54908384f1b7932576a92caa645681026d8b84e1' (2024-06-21)
  → 'github:mrcjkb/rustaceanvim/af4de6a35d128ce71c75a9a7846bf089aea76f50' (2024-06-29)
• Updated input 'telescope-fzf-native-nvim':
    'github:nvim-telescope/telescope-fzf-native.nvim/9ef21b2e6bb6ebeaf349a0781745549bbb870d27' (2024-03-05)
  → 'github:nvim-telescope/telescope-fzf-native.nvim/cf48d4dfce44e0b9a2e19a008d6ec6ea6f01a83b' (2024-07-02)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/7bd2f9b72f8449780b79bcf351534e2cd36ec43a' (2024-06-27)
  → 'github:nvim-telescope/telescope.nvim/bfcc7d5c6f12209139f175e6123a7b7de6d9c18a' (2024-07-01)

```

</p></details>

 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`54908384` ➡️ `af4de6a3`](https://github.com/mrcjkb/rustaceanvim/compare/54908384f1b7932576a92caa645681026d8b84e1...af4de6a35d128ce71c75a9a7846bf089aea76f50) <sub>(2024-06-21 to 2024-06-29)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`d0c1a437` ➡️ `8c8cdf44`](https://github.com/tpope/vim-fugitive/compare/d0c1a437536778bcc8174b7cb2ffdf98f611e6fe...8c8cdf4405cb8bdb70dd9812a33bb52363a87dbc) <sub>(2024-06-26 to 2024-07-05)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`bb6bea00` ➡️ `9e174092`](https://github.com/nix-community/neovim-nightly-overlay/compare/bb6bea003dc464a4248a173e71a007d368691092...9e1740926b3910db38a8864e0220d012e14f7e8e) <sub>(2024-06-27 to 2024-07-05)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`95b2fc42` ➡️ `cf97d248`](https://github.com/neovim/nvim-lspconfig/compare/95b2fc427353e42318c974d10685d500441b821b...cf97d2485fc3f6d4df1b79a3ea183e24c272215e) <sub>(2024-06-28 to 2024-07-03)</sub>
 - Updated input [`telescope-fzf-native-nvim`](https://github.com/nvim-telescope/telescope-fzf-native.nvim): [`9ef21b2e` ➡️ `cf48d4df`](https://github.com/nvim-telescope/telescope-fzf-native.nvim/compare/9ef21b2e6bb6ebeaf349a0781745549bbb870d27...cf48d4dfce44e0b9a2e19a008d6ec6ea6f01a83b) <sub>(2024-03-05 to 2024-07-02)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`6b1a14ea` ➡️ `39b5b6f4`](https://github.com/lewis6991/gitsigns.nvim/compare/6b1a14eabcebbcca1b9e9163a26b2f8371364cb7...39b5b6f48bde0595ce68007ffce408c5d7ac1f79) <sub>(2024-06-28 to 2024-07-03)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`1e3deb3d` ➡️ `d9c0b9d6`](https://github.com/nixos/nixpkgs/compare/1e3deb3d8a86a870d925760db1a5adecc64d329d...d9c0b9d611277e42e6db055636ba0409c59db6d2) <sub>(2024-06-27 to 2024-07-05)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`7bd2f9b7` ➡️ `bfcc7d5c`](https://github.com/nvim-telescope/telescope.nvim/compare/7bd2f9b72f8449780b79bcf351534e2cd36ec43a...bfcc7d5c6f12209139f175e6123a7b7de6d9c18a) <sub>(2024-06-27 to 2024-07-01)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`7e68e55d` ➡️ `bbe6e947`](https://github.com/nix-community/home-manager/compare/7e68e55d2e16d3a1e92a679430728c35a30fd24e...bbe6e94737289c8cb92d4d8f9199fbfe4f11c0ba) <sub>(2024-06-28 to 2024-07-05)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`fc9b7082` ➡️ `3e6cec0b`](https://github.com/neovim/neovim/compare/fc9b70826ec88ca2e6c0624c522b872e87aa7ac1...3e6cec0befd41d37ee36cb4f602e84c58c5f0d27) <sub>(2024-06-26 to 2024-07-04)</sub>
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`2a55567f` ➡️ `9227223f`](https://github.com/hercules-ci/flake-parts/compare/2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8...9227223f6d922fee3c7b190b2cc238a99527bbb7) <sub>(2024-06-01 to 2024-07-03)</sub>