### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -445,11 +445,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719259945,
-        "narHash": "sha256-F1h+XIsGKT9TkGO3omxDLEb/9jOOsI6NnzsXFsZhry4=",
+        "lastModified": 1720524665,
+        "narHash": "sha256-ni/87oHPZm6Gv0ECYxr1f6uxB0UKBWJ6HvS7lwLU6oY=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07",
+        "rev": "8d6a17d0cdf411c55f12602624df6368ad86fac1",
         "type": "github"
       },
       "original": {
@@ -528,11 +528,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1720011088,
-        "narHash": "sha256-6Bukof+xnUULmTRF+bewSzSQP+tJoNxERv6aueOALCk=",
+        "lastModified": 1720792653,
+        "narHash": "sha256-BYNrqMnJx3fcsQAG2V5FSDPMuK9m6VNj620JenH5JOw=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "39b5b6f48bde0595ce68007ffce408c5d7ac1f79",
+        "rev": "e9c4187c3774a46df2d086a66cf3a7e6bea4c432",
         "type": "github"
       },
       "original": {
@@ -570,11 +570,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720167120,
-        "narHash": "sha256-K9JYdlPiyaXp33JRg7CT8rMwH56e4ncXSsXW/YKnNXc=",
+        "lastModified": 1720734513,
+        "narHash": "sha256-neWQ8eNtLTd+YMesb7WjKl1SVCbDyCm46LUgP/g/hdo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bbe6e94737289c8cb92d4d8f9199fbfe4f11c0ba",
+        "rev": "90ae324e2c56af10f20549ab72014804a3064c7f",
         "type": "github"
       },
       "original": {
@@ -604,11 +604,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1718476555,
-        "narHash": "sha256-fuWpgh8KasByIJWE+xVd37Al0LV5YAn6s871T50qVY0=",
+        "lastModified": 1720709712,
+        "narHash": "sha256-78j/cY+AXoMIqqiNc1vWx237EPfpERAcYsb57ABUbwQ=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "29a8374f4b9206d5c4af84aceb7fb5dff441ea60",
+        "rev": "65d42dcbfde2229a75ccdb195c318dfe241f9ade",
         "type": "github"
       },
       "original": {
@@ -685,11 +685,11 @@
     "lualine-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1712310396,
-        "narHash": "sha256-WcH2dWdRDgMkwBQhcgT+Z/ArMdm+VbRhmQftx4t2kNI=",
+        "lastModified": 1720414209,
+        "narHash": "sha256-FGzK9K8yOPbq8DYK8Efu4MZ20p3JNuovbONwgnnK9J4=",
         "owner": "nvim-lualine",
         "repo": "lualine.nvim",
-        "rev": "0a5a66803c7407767b799067986b4dc3036e1983",
+        "rev": "6a40b530539d2209f7dc0492f3681c8c126647ad",
         "type": "github"
       },
       "original": {
@@ -717,11 +717,11 @@
     "neodev-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1717490891,
-        "narHash": "sha256-vkgy2w6NvzOPlo23WKweGybEqqk4wiwdgXU1LjYkWW0=",
+        "lastModified": 1720260306,
+        "narHash": "sha256-hOjzlo/IqmV8tYjGwfmcCPEmHYsWnEIwtHZdhpwA1kM=",
         "owner": "folke",
         "repo": "neodev.nvim",
-        "rev": "02893eeb9d6e8503817bd52385e111cba9a90500",
+        "rev": "46aa467dca16cf3dfe27098042402066d2ae242d",
         "type": "github"
       },
       "original": {
@@ -789,11 +789,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720161606,
-        "narHash": "sha256-B0n9ZIrXGPN0oS1DKBYZu2P1fTsnYMmXQkFtj/6mEQ8=",
+        "lastModified": 1720796317,
+        "narHash": "sha256-2B4PFl75fFjQkquRCPB5PYeY0bFqF/xvsLy014c+7W4=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "9e1740926b3910db38a8864e0220d012e14f7e8e",
+        "rev": "a07ca86e6922bc2a68ec4c801ab7e05e12397af0",
         "type": "github"
       },
       "original": {
@@ -805,11 +805,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1720137094,
-        "narHash": "sha256-K3iDLJy3K/ivR0uTlu2EXT+zrwMYNRn+CBGo+0kxxoc=",
+        "lastModified": 1720739431,
+        "narHash": "sha256-lEgZwuKL1eLsiFqoSiOZgq30jQCFTEYlreL79Txbxu4=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "3e6cec0befd41d37ee36cb4f602e84c58c5f0d27",
+        "rev": "a5de650f0eb93a848831f1ba631485437a82d57b",
         "type": "github"
       },
       "original": {
@@ -920,11 +920,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1720149507,
-        "narHash": "sha256-OFJoD1jjxzFlY1tAsehEWVA88DbU5smzDPQuu9SmnXY=",
+        "lastModified": 1720750130,
+        "narHash": "sha256-y2wc7CdK0vVSIbx7MdVoZzuMcUoLvZXm+pQf2RIr1OU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d9c0b9d611277e42e6db055636ba0409c59db6d2",
+        "rev": "6794d064edc69918bb0fc0e0eda33ece324be17a",
         "type": "github"
       },
       "original": {
@@ -1033,11 +1033,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1719990081,
-        "narHash": "sha256-Ms3GgwbzOU22hwqE2TgmccZzsXvoE4xYuCioAxRnRu8=",
+        "lastModified": 1720781924,
+        "narHash": "sha256-eYtuIMptp4XCyneZHPcgvdt2gBVzrHjXOOrcF9IMqoA=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "cf97d2485fc3f6d4df1b79a3ea183e24c272215e",
+        "rev": "216deb2d1b5fbf24398919228208649bbf5cbadf",
         "type": "github"
       },
       "original": {
@@ -1195,11 +1195,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1719658629,
-        "narHash": "sha256-W8cSTcF+xapvpBUZYccwkPmkNkdK3wlbzC5rpbv6HZI=",
+        "lastModified": 1720595685,
+        "narHash": "sha256-Mx8pB9ECjFpbfmZPuXfpwoE5pUZ363M53f27ht7MBmA=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "af4de6a35d128ce71c75a9a7846bf089aea76f50",
+        "rev": "047f9c9d8cd2861745eb9de6c1570ee0875aa795",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/39b5b6f48bde0595ce68007ffce408c5d7ac1f79' (2024-07-03)
  → 'github:lewis6991/gitsigns.nvim/e9c4187c3774a46df2d086a66cf3a7e6bea4c432' (2024-07-12)
• Updated input 'home-manager':
    'github:nix-community/home-manager/bbe6e94737289c8cb92d4d8f9199fbfe4f11c0ba' (2024-07-05)
  → 'github:nix-community/home-manager/90ae324e2c56af10f20549ab72014804a3064c7f' (2024-07-11)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/29a8374f4b9206d5c4af84aceb7fb5dff441ea60' (2024-06-15)
  → 'github:hyprwm/contrib/65d42dcbfde2229a75ccdb195c318dfe241f9ade' (2024-07-11)
• Updated input 'lualine-nvim':
    'github:nvim-lualine/lualine.nvim/0a5a66803c7407767b799067986b4dc3036e1983' (2024-04-05)
  → 'github:nvim-lualine/lualine.nvim/6a40b530539d2209f7dc0492f3681c8c126647ad' (2024-07-08)
• Updated input 'neodev-nvim':
    'github:folke/neodev.nvim/02893eeb9d6e8503817bd52385e111cba9a90500' (2024-06-04)
  → 'github:folke/neodev.nvim/46aa467dca16cf3dfe27098042402066d2ae242d' (2024-07-06)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/9e1740926b3910db38a8864e0220d012e14f7e8e' (2024-07-05)
  → 'github:nix-community/neovim-nightly-overlay/a07ca86e6922bc2a68ec4c801ab7e05e12397af0' (2024-07-12)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07' (2024-06-24)
  → 'github:cachix/git-hooks.nix/8d6a17d0cdf411c55f12602624df6368ad86fac1' (2024-07-09)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/3e6cec0befd41d37ee36cb4f602e84c58c5f0d27' (2024-07-04)
  → 'github:neovim/neovim/a5de650f0eb93a848831f1ba631485437a82d57b' (2024-07-11)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d9c0b9d611277e42e6db055636ba0409c59db6d2' (2024-07-05)
  → 'github:nixos/nixpkgs/6794d064edc69918bb0fc0e0eda33ece324be17a' (2024-07-12)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/cf97d2485fc3f6d4df1b79a3ea183e24c272215e' (2024-07-03)
  → 'github:neovim/nvim-lspconfig/216deb2d1b5fbf24398919228208649bbf5cbadf' (2024-07-12)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/af4de6a35d128ce71c75a9a7846bf089aea76f50' (2024-06-29)
  → 'github:mrcjkb/rustaceanvim/047f9c9d8cd2861745eb9de6c1570ee0875aa795' (2024-07-10)

```

</p></details>

 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`af4de6a3` ➡️ `047f9c9d`](https://github.com/mrcjkb/rustaceanvim/compare/af4de6a35d128ce71c75a9a7846bf089aea76f50...047f9c9d8cd2861745eb9de6c1570ee0875aa795) <sub>(2024-06-29 to 2024-07-10)</sub>
 - Updated input [`neodev-nvim`](https://github.com/folke/neodev.nvim): [`02893eeb` ➡️ `46aa467d`](https://github.com/folke/neodev.nvim/compare/02893eeb9d6e8503817bd52385e111cba9a90500...46aa467dca16cf3dfe27098042402066d2ae242d) <sub>(2024-06-04 to 2024-07-06)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`9e174092` ➡️ `a07ca86e`](https://github.com/nix-community/neovim-nightly-overlay/compare/9e1740926b3910db38a8864e0220d012e14f7e8e...a07ca86e6922bc2a68ec4c801ab7e05e12397af0) <sub>(2024-07-05 to 2024-07-12)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`29a8374f` ➡️ `65d42dcb`](https://github.com/hyprwm/contrib/compare/29a8374f4b9206d5c4af84aceb7fb5dff441ea60...65d42dcbfde2229a75ccdb195c318dfe241f9ade) <sub>(2024-06-15 to 2024-07-11)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`cf97d248` ➡️ `216deb2d`](https://github.com/neovim/nvim-lspconfig/compare/cf97d2485fc3f6d4df1b79a3ea183e24c272215e...216deb2d1b5fbf24398919228208649bbf5cbadf) <sub>(2024-07-03 to 2024-07-12)</sub>
 - Updated input [`lualine-nvim`](https://github.com/nvim-lualine/lualine.nvim): [`0a5a6680` ➡️ `6a40b530`](https://github.com/nvim-lualine/lualine.nvim/compare/0a5a66803c7407767b799067986b4dc3036e1983...6a40b530539d2209f7dc0492f3681c8c126647ad) <sub>(2024-04-05 to 2024-07-08)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`39b5b6f4` ➡️ `e9c4187c`](https://github.com/lewis6991/gitsigns.nvim/compare/39b5b6f48bde0595ce68007ffce408c5d7ac1f79...e9c4187c3774a46df2d086a66cf3a7e6bea4c432) <sub>(2024-07-03 to 2024-07-12)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`d9c0b9d6` ➡️ `6794d064`](https://github.com/nixos/nixpkgs/compare/d9c0b9d611277e42e6db055636ba0409c59db6d2...6794d064edc69918bb0fc0e0eda33ece324be17a) <sub>(2024-07-05 to 2024-07-12)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`0ff4381b` ➡️ `8d6a17d0`](https://github.com/cachix/git-hooks.nix/compare/0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07...8d6a17d0cdf411c55f12602624df6368ad86fac1) <sub>(2024-06-24 to 2024-07-09)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`bbe6e947` ➡️ `90ae324e`](https://github.com/nix-community/home-manager/compare/bbe6e94737289c8cb92d4d8f9199fbfe4f11c0ba...90ae324e2c56af10f20549ab72014804a3064c7f) <sub>(2024-07-05 to 2024-07-11)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`3e6cec0b` ➡️ `a5de650f`](https://github.com/neovim/neovim/compare/3e6cec0befd41d37ee36cb4f602e84c58c5f0d27...a5de650f0eb93a848831f1ba631485437a82d57b) <sub>(2024-07-04 to 2024-07-11)</sub>