### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -367,11 +367,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1720195443,
-        "narHash": "sha256-CfwcR1xFUJH3dBfpkyX/sncLopaUPUFPZDfe3aohTNo=",
+        "lastModified": 1721347143,
+        "narHash": "sha256-NLHaXpPrb4/QuVuTjl6YUUKA3/1r4VCOaNO48Dk9pms=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "8c8cdf4405cb8bdb70dd9812a33bb52363a87dbc",
+        "rev": "0444df68cd1cdabc7453d6bd84099458327e5513",
         "type": "github"
       },
       "original": {
@@ -445,11 +445,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720524665,
-        "narHash": "sha256-ni/87oHPZm6Gv0ECYxr1f6uxB0UKBWJ6HvS7lwLU6oY=",
+        "lastModified": 1721042469,
+        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "8d6a17d0cdf411c55f12602624df6368ad86fac1",
+        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
         "type": "github"
       },
       "original": {
@@ -528,11 +528,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1720792653,
-        "narHash": "sha256-BYNrqMnJx3fcsQAG2V5FSDPMuK9m6VNj620JenH5JOw=",
+        "lastModified": 1721142323,
+        "narHash": "sha256-iFVTd7nO4twq/S3qQpy4PZfHMpLDErJfJk63TmwL8t0=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "e9c4187c3774a46df2d086a66cf3a7e6bea4c432",
+        "rev": "f4928ba14eb6c667786ac7d69927f6aee6719f1e",
         "type": "github"
       },
       "original": {
@@ -570,11 +570,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720734513,
-        "narHash": "sha256-neWQ8eNtLTd+YMesb7WjKl1SVCbDyCm46LUgP/g/hdo=",
+        "lastModified": 1721135958,
+        "narHash": "sha256-H548rpPMsn25LDKn1PCFmPxmWlClJJGnvdzImHkqjuY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "90ae324e2c56af10f20549ab72014804a3064c7f",
+        "rev": "afd2021bedff2de92dfce0e257a3d03ae65c603d",
         "type": "github"
       },
       "original": {
@@ -701,11 +701,11 @@
     "lualine-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1720414209,
-        "narHash": "sha256-FGzK9K8yOPbq8DYK8Efu4MZ20p3JNuovbONwgnnK9J4=",
+        "lastModified": 1721024646,
+        "narHash": "sha256-uNDRynWs7fXDDzDFKvE31oDetv3aabiJfr/r/84z9Sg=",
         "owner": "nvim-lualine",
         "repo": "lualine.nvim",
-        "rev": "6a40b530539d2209f7dc0492f3681c8c126647ad",
+        "rev": "544dd1583f9bb27b393f598475c89809c4d5e86b",
         "type": "github"
       },
       "original": {
@@ -805,11 +805,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720796317,
-        "narHash": "sha256-2B4PFl75fFjQkquRCPB5PYeY0bFqF/xvsLy014c+7W4=",
+        "lastModified": 1721368131,
+        "narHash": "sha256-dvDYa+Z2qZHTibmeUbKKIpR2jONO4UPbyHiDgYhgoMQ=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "a07ca86e6922bc2a68ec4c801ab7e05e12397af0",
+        "rev": "d9fcc47baa026c7df9a9789d5e825b4f13a9239a",
         "type": "github"
       },
       "original": {
@@ -821,11 +821,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1720739431,
-        "narHash": "sha256-lEgZwuKL1eLsiFqoSiOZgq30jQCFTEYlreL79Txbxu4=",
+        "lastModified": 1721316387,
+        "narHash": "sha256-qPgppLqmnd0OnHLMo4cGPZSUyLbcw9nThWO4sJC8bWI=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "a5de650f0eb93a848831f1ba631485437a82d57b",
+        "rev": "f61efe3fe77c9a517dccb9fd5ff7f16c0660ced4",
         "type": "github"
       },
       "original": {
@@ -936,11 +936,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1720750130,
-        "narHash": "sha256-y2wc7CdK0vVSIbx7MdVoZzuMcUoLvZXm+pQf2RIr1OU=",
+        "lastModified": 1721403608,
+        "narHash": "sha256-X5+QA5K3J2KA20YEaBJ+GKDj/XIb5PutHmphgYQUszA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6794d064edc69918bb0fc0e0eda33ece324be17a",
+        "rev": "ad0111043c09f7d0f6b9f039882cbf350d4f7d49",
         "type": "github"
       },
       "original": {
@@ -1033,11 +1033,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1717829983,
-        "narHash": "sha256-7tEfEjWH5pneI10jLYpenoysRQPa2zPGLTNcbMX3x2I=",
+        "lastModified": 1721093634,
+        "narHash": "sha256-jc4fQBaAuL4XhHljVU3sdaEyQCnHbI+gwNOTnGHk0qM=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "a110e12d0b58eefcf5b771f533fc2cf3050680ac",
+        "rev": "d818fd0624205b34e14888358037fb6f5dc51234",
         "type": "github"
       },
       "original": {
@@ -1049,11 +1049,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1720781924,
-        "narHash": "sha256-eYtuIMptp4XCyneZHPcgvdt2gBVzrHjXOOrcF9IMqoA=",
+        "lastModified": 1721369277,
+        "narHash": "sha256-GscyvR1SYGUig7GGLDS5xS5weVi32WJuFOypVaZc044=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "216deb2d1b5fbf24398919228208649bbf5cbadf",
+        "rev": "e26da408cf955afa8e9ddbadd510e84ea8976cd7",
         "type": "github"
       },
       "original": {

--- a/system/nixos/profiles/desktop/default.nix
+++ b/system/nixos/profiles/desktop/default.nix
@@ -17,8 +17,6 @@ in
   };
 
   config = mkIf cfg.enable {
-    sound.enable = true;
-
     # hardware = {
     #   pulseaudio = {
     #     enable = true;


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/8c8cdf4405cb8bdb70dd9812a33bb52363a87dbc' (2024-07-05)
  → 'github:tpope/vim-fugitive/0444df68cd1cdabc7453d6bd84099458327e5513' (2024-07-18)
• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/e9c4187c3774a46df2d086a66cf3a7e6bea4c432' (2024-07-12)
  → 'github:lewis6991/gitsigns.nvim/f4928ba14eb6c667786ac7d69927f6aee6719f1e' (2024-07-16)
• Updated input 'home-manager':
    'github:nix-community/home-manager/90ae324e2c56af10f20549ab72014804a3064c7f' (2024-07-11)
  → 'github:nix-community/home-manager/afd2021bedff2de92dfce0e257a3d03ae65c603d' (2024-07-16)
• Updated input 'lualine-nvim':
    'github:nvim-lualine/lualine.nvim/6a40b530539d2209f7dc0492f3681c8c126647ad' (2024-07-08)
  → 'github:nvim-lualine/lualine.nvim/544dd1583f9bb27b393f598475c89809c4d5e86b' (2024-07-15)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/a07ca86e6922bc2a68ec4c801ab7e05e12397af0' (2024-07-12)
  → 'github:nix-community/neovim-nightly-overlay/d9fcc47baa026c7df9a9789d5e825b4f13a9239a' (2024-07-19)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/8d6a17d0cdf411c55f12602624df6368ad86fac1' (2024-07-09)
  → 'github:cachix/git-hooks.nix/f451c19376071a90d8c58ab1a953c6e9840527fd' (2024-07-15)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/a5de650f0eb93a848831f1ba631485437a82d57b' (2024-07-11)
  → 'github:neovim/neovim/f61efe3fe77c9a517dccb9fd5ff7f16c0660ced4' (2024-07-18)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/6794d064edc69918bb0fc0e0eda33ece324be17a' (2024-07-12)
  → 'github:nixos/nixpkgs/ad0111043c09f7d0f6b9f039882cbf350d4f7d49' (2024-07-19)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/a110e12d0b58eefcf5b771f533fc2cf3050680ac' (2024-06-08)
  → 'github:hrsh7th/nvim-cmp/d818fd0624205b34e14888358037fb6f5dc51234' (2024-07-16)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/216deb2d1b5fbf24398919228208649bbf5cbadf' (2024-07-12)
  → 'github:neovim/nvim-lspconfig/e26da408cf955afa8e9ddbadd510e84ea8976cd7' (2024-07-19)

```

</p></details>

 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`8c8cdf44` ➡️ `0444df68`](https://github.com/tpope/vim-fugitive/compare/8c8cdf4405cb8bdb70dd9812a33bb52363a87dbc...0444df68cd1cdabc7453d6bd84099458327e5513) <sub>(2024-07-05 to 2024-07-18)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`a07ca86e` ➡️ `d9fcc47b`](https://github.com/nix-community/neovim-nightly-overlay/compare/a07ca86e6922bc2a68ec4c801ab7e05e12397af0...d9fcc47baa026c7df9a9789d5e825b4f13a9239a) <sub>(2024-07-12 to 2024-07-19)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`216deb2d` ➡️ `e26da408`](https://github.com/neovim/nvim-lspconfig/compare/216deb2d1b5fbf24398919228208649bbf5cbadf...e26da408cf955afa8e9ddbadd510e84ea8976cd7) <sub>(2024-07-12 to 2024-07-19)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`a110e12d` ➡️ `d818fd06`](https://github.com/hrsh7th/nvim-cmp/compare/a110e12d0b58eefcf5b771f533fc2cf3050680ac...d818fd0624205b34e14888358037fb6f5dc51234) <sub>(2024-06-08 to 2024-07-16)</sub>
 - Updated input [`lualine-nvim`](https://github.com/nvim-lualine/lualine.nvim): [`6a40b530` ➡️ `544dd158`](https://github.com/nvim-lualine/lualine.nvim/compare/6a40b530539d2209f7dc0492f3681c8c126647ad...544dd1583f9bb27b393f598475c89809c4d5e86b) <sub>(2024-07-08 to 2024-07-15)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`e9c4187c` ➡️ `f4928ba1`](https://github.com/lewis6991/gitsigns.nvim/compare/e9c4187c3774a46df2d086a66cf3a7e6bea4c432...f4928ba14eb6c667786ac7d69927f6aee6719f1e) <sub>(2024-07-12 to 2024-07-16)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`6794d064` ➡️ `ad011104`](https://github.com/nixos/nixpkgs/compare/6794d064edc69918bb0fc0e0eda33ece324be17a...ad0111043c09f7d0f6b9f039882cbf350d4f7d49) <sub>(2024-07-12 to 2024-07-19)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`8d6a17d0` ➡️ `f451c193`](https://github.com/cachix/git-hooks.nix/compare/8d6a17d0cdf411c55f12602624df6368ad86fac1...f451c19376071a90d8c58ab1a953c6e9840527fd) <sub>(2024-07-09 to 2024-07-15)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`90ae324e` ➡️ `afd2021b`](https://github.com/nix-community/home-manager/compare/90ae324e2c56af10f20549ab72014804a3064c7f...afd2021bedff2de92dfce0e257a3d03ae65c603d) <sub>(2024-07-11 to 2024-07-16)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`a5de650f` ➡️ `f61efe3f`](https://github.com/neovim/neovim/compare/a5de650f0eb93a848831f1ba631485437a82d57b...f61efe3fe77c9a517dccb9fd5ff7f16c0660ced4) <sub>(2024-07-11 to 2024-07-18)</sub>