### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -160,6 +160,38 @@
         "type": "github"
       }
     },
+    "flake-compat_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -207,11 +239,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
         "type": "github"
       },
       "original": {
@@ -225,17 +257,81 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1706830856,
-        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "lastModified": 1717285511,
+        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "type": "github"
+      }
+    },
+    "flake-parts_5": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_3"
+      },
+      "locked": {
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_6": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "rustacean-nvim",
+          "neorocks",
+          "neovim-nightly",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_7": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "rustacean-nvim",
+          "neorocks",
+          "neovim-nightly",
+          "hercules-ci-effects",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
       }
     },
     "flake-utils": {
@@ -284,78 +380,6 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
-      "inputs": {
-        "systems": "systems_4"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_5": {
-      "inputs": {
-        "systems": "systems_5"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_6": {
-      "inputs": {
-        "systems": "systems_6"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_7": {
-      "inputs": {
-        "systems": "systems_7"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -418,11 +442,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1710933866,
-        "narHash": "sha256-GtYTuxY6AdFxl3uwFkTkqpvOP4lQLzu2YwqnejhDs1Q=",
+        "lastModified": 1718922730,
+        "narHash": "sha256-ykhhOPqA9NzdNBr3ii+3h2DkK2+wasNqQLfMF6BXxTE=",
         "owner": "mrcjkb",
         "repo": "nix-gen-luarc-json",
-        "rev": "6e8912ea4fbfaa10797caafb1f5628fb4178b6e8",
+        "rev": "021e8078e43884c6cdc70ca753d9a0b146cd55a4",
         "type": "github"
       },
       "original": {
@@ -441,6 +465,58 @@
         ],
         "nixpkgs-stable": [
           "neovim-nightly-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1721042469,
+        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_4",
+        "gitignore": "gitignore_2",
+        "nixpkgs": "nixpkgs_5",
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1721042469,
+        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks_3": {
+      "inputs": {
+        "flake-compat": "flake-compat_6",
+        "gitignore": "gitignore_3",
+        "nixpkgs": [
+          "rustacean-nvim",
+          "neorocks",
+          "neovim-nightly",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "rustacean-nvim",
+          "neorocks",
+          "neovim-nightly",
           "nixpkgs"
         ]
       },
@@ -485,7 +561,7 @@
         "nixpkgs": [
           "rustacean-nvim",
           "neorocks",
-          "pre-commit-hooks",
+          "git-hooks",
           "nixpkgs"
         ]
       },
@@ -504,6 +580,30 @@
       }
     },
     "gitignore_3": {
+      "inputs": {
+        "nixpkgs": [
+          "rustacean-nvim",
+          "neorocks",
+          "neovim-nightly",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_4": {
       "inputs": {
         "nixpkgs": [
           "rustacean-nvim",
@@ -528,11 +628,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1721142323,
-        "narHash": "sha256-iFVTd7nO4twq/S3qQpy4PZfHMpLDErJfJk63TmwL8t0=",
+        "lastModified": 1721914876,
+        "narHash": "sha256-nHUQoYo/4J2rh494UxYz3hqrrgPSxX4IgManKxCsBR8=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "f4928ba14eb6c667786ac7d69927f6aee6719f1e",
+        "rev": "f074844b60f9e151970fbcdbeb8a2cd52b6ef25a",
         "type": "github"
       },
       "original": {
@@ -563,6 +663,30 @@
         "type": "github"
       }
     },
+    "hercules-ci-effects_2": {
+      "inputs": {
+        "flake-parts": "flake-parts_7",
+        "nixpkgs": [
+          "rustacean-nvim",
+          "neorocks",
+          "neovim-nightly",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1719226092,
+        "narHash": "sha256-YNkUMcCUCpnULp40g+svYsaH1RbSEj6s4WdZY/SHe38=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "rev": "11e4b8dc112e2f485d7c97e1cee77f9958f498f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -570,11 +694,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721135958,
-        "narHash": "sha256-H548rpPMsn25LDKn1PCFmPxmWlClJJGnvdzImHkqjuY=",
+        "lastModified": 1721996913,
+        "narHash": "sha256-eqbhEBObarS6WsI0J1PVACQ8fXeq9OmSS0+iXBegoOI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "afd2021bedff2de92dfce0e257a3d03ae65c603d",
+        "rev": "bc2b96acda50229bc99925dde5c8e561e90b0b00",
         "type": "github"
       },
       "original": {
@@ -685,11 +809,11 @@
     "lspkind-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1704982040,
-        "narHash": "sha256-/QLdBU/Zwmkw1NGuLBD48tvrmIP9d9WHhgcLEQgRTWo=",
+        "lastModified": 1721915252,
+        "narHash": "sha256-1KK6JhQUtA5mxwRSKU5e3pTQzZwaoAjzycBLx5X/xlA=",
         "owner": "onsails",
         "repo": "lspkind.nvim",
-        "rev": "1735dd5a5054c1fb7feaf8e8658dbab925f4f0cf",
+        "rev": "cff4ae321a91ee3473a92ea1a8c637e3a9510aec",
         "type": "github"
       },
       "original": {
@@ -749,17 +873,17 @@
     "neorocks": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_4",
+        "flake-parts": "flake-parts_5",
+        "git-hooks": "git-hooks_2",
         "neovim-nightly": "neovim-nightly",
-        "nixpkgs": "nixpkgs_5",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1714773380,
-        "narHash": "sha256-UyBGSuwwbDCAXDm0AII7Xmld1n7mqziQaqQJ/SSI6mI=",
+        "lastModified": 1721971601,
+        "narHash": "sha256-mvMOjRSSGEKkGEPrSgPC8xluMJYKqTtr0ik++jwAtXQ=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "4333320b464e10e1e8ffefbf6e0b4055c79bbfd3",
+        "rev": "2868f35af48fd893615a60b3c19f4f1131e2edcd",
         "type": "github"
       },
       "original": {
@@ -770,26 +894,24 @@
     },
     "neovim-nightly": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
-        "nixpkgs": [
-          "rustacean-nvim",
-          "neorocks",
-          "nixpkgs"
-        ]
+        "flake-compat": "flake-compat_5",
+        "flake-parts": "flake-parts_6",
+        "git-hooks": "git-hooks_3",
+        "hercules-ci-effects": "hercules-ci-effects_2",
+        "neovim-src": "neovim-src_2",
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "dir": "contrib",
-        "lastModified": 1714703732,
-        "narHash": "sha256-RZymn1F/tWGKv/SjQc/Os5GOWpfUPnRvTRdZUHhEqq8=",
-        "owner": "neovim",
-        "repo": "neovim",
-        "rev": "cf9f002f31c8b4d9d42912a3f45f5d3db4462fd9",
+        "lastModified": 1721885903,
+        "narHash": "sha256-5tQKxRP67m4qIXUzO/R2nJgWpAhBUPUTGKDWW1zzr8g=",
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "rev": "9d4c7b114a00f0c9ec4145e5674fc28af04e6489",
         "type": "github"
       },
       "original": {
-        "dir": "contrib",
-        "owner": "neovim",
-        "repo": "neovim",
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
         "type": "github"
       }
     },
@@ -805,11 +927,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721368131,
-        "narHash": "sha256-dvDYa+Z2qZHTibmeUbKKIpR2jONO4UPbyHiDgYhgoMQ=",
+        "lastModified": 1721973148,
+        "narHash": "sha256-5pTLdRp8QLZyiqJ/AxAfChxZw0MP72IIGPBT+8MpIOI=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "d9fcc47baa026c7df9a9789d5e825b4f13a9239a",
+        "rev": "814a0d204eb9dab10d524137ab2e0392b9a1d70d",
         "type": "github"
       },
       "original": {
@@ -821,11 +943,27 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1721316387,
-        "narHash": "sha256-qPgppLqmnd0OnHLMo4cGPZSUyLbcw9nThWO4sJC8bWI=",
+        "lastModified": 1721959272,
+        "narHash": "sha256-0oAFj06adCMeyqNN7cbAU4dMCc/lKa438d/ECxMLmjM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "f61efe3fe77c9a517dccb9fd5ff7f16c0660ced4",
+        "rev": "0dfcf3fe12ace3116bdffbbfc6875c67023eb8f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "neovim",
+        "repo": "neovim",
+        "type": "github"
+      }
+    },
+    "neovim-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1721830906,
+        "narHash": "sha256-Wa12HERoF7fCuAWta4X3HPveuxBjtRNMYasNE2QKmCY=",
+        "owner": "neovim",
+        "repo": "neovim",
+        "rev": "b4b4cf46a7a2b6d7b4e997179166444b0e338ac8",
         "type": "github"
       },
       "original": {
@@ -837,11 +975,11 @@
     "nightfox-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1714329621,
-        "narHash": "sha256-ly9yavagB6A8t2plHZyNJt5tqCBq+ExEtYGKR4+9qHQ=",
+        "lastModified": 1721661222,
+        "narHash": "sha256-2efugsL7pbQ78XxwWRybnfxhuqe7LSUgpTlwcJJTAX0=",
         "owner": "EdenEast",
         "repo": "nightfox.nvim",
-        "rev": "df75a6a94910ae47854341d6b5a6fd483192c0eb",
+        "rev": "d3e8b1acc095baf57af81bb5e89fe7c4359eb619",
         "type": "github"
       },
       "original": {
@@ -868,79 +1006,79 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
-        "type": "github"
+        "lastModified": 1719876945,
+        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       }
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1706550542,
-        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
-        "type": "github"
+        "lastModified": 1717284937,
+        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+      }
+    },
+    "nixpkgs-lib_3": {
+      "locked": {
+        "lastModified": 1719876945,
+        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       }
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1710695816,
-        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1710695816,
-        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1721403608,
-        "narHash": "sha256-X5+QA5K3J2KA20YEaBJ+GKDj/XIb5PutHmphgYQUszA=",
+        "lastModified": 1721970117,
+        "narHash": "sha256-Hwm46lggqtihMaRuxbNaC1ACcU2a0jO/HXqrdjMatXk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ad0111043c09f7d0f6b9f039882cbf350d4f7d49",
+        "rev": "733453ac54a40997a6a690b60f3942d79560247c",
         "type": "github"
       },
       "original": {
@@ -968,11 +1106,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1708475490,
-        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
+        "lastModified": 1718714799,
+        "narHash": "sha256-FUZpz9rg3gL8NVPKbqU8ei1VkPLsTIfAJ2fdAf5qjak=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
+        "rev": "c00d587b1a1afbf200b1d8f0b0e4ba9deb1c7f0e",
         "type": "github"
       },
       "original": {
@@ -984,15 +1122,15 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1714594348,
-        "narHash": "sha256-fL6twwN/npU94mvumU5ho/uhM/fwePCRQ9lwamm2lds=",
-        "owner": "nixos",
+        "lastModified": 1719082008,
+        "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1c74cc292b61614e74c1cf0d372f79d57fb4936b",
+        "rev": "9693852a2070b398ee123a329e68f0dab5526681",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -1000,11 +1138,27 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1714213793,
-        "narHash": "sha256-Yg5D5LhyAZvd3DZrQQfJAVK8K3TkUYKooFtH1ulM0mw=",
+        "lastModified": 1721782431,
+        "narHash": "sha256-UNDpwjYxNXQet/g3mgRLsQ9zxrbm9j2JEvP4ijF3AWs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4f02464258baaf54992debfd010a7a3662a25536",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1721933792,
+        "narHash": "sha256-zYVwABlQnxpbaHMfX6Wt9jhyQstFYwN2XjleOJV3VVg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d6f6eb2a984f2ba9a366c31e4d36d65465683450",
+        "rev": "2122a9b35b35719ad9a395fe783eabb092df01b1",
         "type": "github"
       },
       "original": {
@@ -1014,13 +1168,29 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_8": {
       "locked": {
-        "lastModified": 1710765496,
-        "narHash": "sha256-p7ryWEeQfMwTB6E0wIUd5V2cFTgq+DRRBz2hYGnJZyA=",
+        "lastModified": 1721933792,
+        "narHash": "sha256-zYVwABlQnxpbaHMfX6Wt9jhyQstFYwN2XjleOJV3VVg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2122a9b35b35719ad9a395fe783eabb092df01b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1719082008,
+        "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e367f7a1fb93137af22a3908f00b9a35e2d286a7",
+        "rev": "9693852a2070b398ee123a329e68f0dab5526681",
         "type": "github"
       },
       "original": {
@@ -1049,11 +1219,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1721369277,
-        "narHash": "sha256-GscyvR1SYGUig7GGLDS5xS5weVi32WJuFOypVaZc044=",
+        "lastModified": 1721997333,
+        "narHash": "sha256-kBxo5oHCyPLrQaPJBoOPVhw47mA3RInnO49nvEnQI0E=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "e26da408cf955afa8e9ddbadd510e84ea8976cd7",
+        "rev": "f95d371c1a274f60392edfd8ea5121b42dca736e",
         "type": "github"
       },
       "original": {
@@ -1102,44 +1272,17 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_4",
-        "flake-utils": "flake-utils_6",
-        "gitignore": "gitignore_2",
-        "nixpkgs": [
-          "rustacean-nvim",
-          "neorocks",
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
-      },
-      "locked": {
-        "lastModified": 1714478972,
-        "narHash": "sha256-q//cgb52vv81uOuwz1LaXElp3XAe1TqrABXODAEF6Sk=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "2849da033884f54822af194400f8dff435ada242",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks_2": {
-      "inputs": {
-        "flake-compat": "flake-compat_5",
-        "flake-utils": "flake-utils_7",
-        "gitignore": "gitignore_3",
-        "nixpkgs": "nixpkgs_7",
+        "flake-compat": "flake-compat_7",
+        "gitignore": "gitignore_4",
+        "nixpkgs": "nixpkgs_9",
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1713954846,
-        "narHash": "sha256-RWFafuSb5nkWGu8dDbW7gVb8FOQOPqmX/9MlxUUDguw=",
+        "lastModified": 1721042469,
+        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "6fb82e44254d6a0ece014ec423cb62d92435336f",
+        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
         "type": "github"
       },
       "original": {
@@ -1208,15 +1351,15 @@
         "flake-parts": "flake-parts_3",
         "gen-luarc": "gen-luarc",
         "neorocks": "neorocks",
-        "nixpkgs": "nixpkgs_6",
-        "pre-commit-hooks": "pre-commit-hooks_2"
+        "nixpkgs": "nixpkgs_8",
+        "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1720595685,
-        "narHash": "sha256-Mx8pB9ECjFpbfmZPuXfpwoE5pUZ363M53f27ht7MBmA=",
+        "lastModified": 1722010822,
+        "narHash": "sha256-Mmu7u41/CI1EIj/Ed2xvywoBrMoWN11ilISI/5GKiCw=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "047f9c9d8cd2861745eb9de6c1570ee0875aa795",
+        "rev": "db175e48401793f5e1c9fee82e3d375258cb1578",
         "type": "github"
       },
       "original": {
@@ -1270,66 +1413,6 @@
         "type": "github"
       }
     },
-    "systems_4": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_5": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_6": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_7": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "telescope-fzf-native-nvim": {
       "flake": false,
       "locked": {
@@ -1349,11 +1432,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1719860810,
-        "narHash": "sha256-U6fgii9FlJy+bHAtYVnZEOyiUAqlBHTvMFc4mo+xS/s=",
+        "lastModified": 1721964597,
+        "narHash": "sha256-7xz6JhWqiIo6aFsVzt2CDb7pWLG4YTiVPaiWzda330Q=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "bfcc7d5c6f12209139f175e6123a7b7de6d9c18a",
+        "rev": "10b8a82b042caf50b78e619d92caf0910211973d",
         "type": "github"
       },
       "original": {
@@ -1365,11 +1448,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1717894639,
-        "narHash": "sha256-j/B/E1VltJ/QpVFtDKAdVC4+KZ5Mz8dQP5kd8HIHjLs=",
+        "lastModified": 1721447625,
+        "narHash": "sha256-sa4Jlj0mn1xs3sI1VOeqLmPvigeNTZY44vBfxkinBc8=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "c0cfc1738361b5da1cd0a962dd6f774cc444f856",
+        "rev": "e612de3d3a41a6b7be47f51e956dddabcbf419d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/f4928ba14eb6c667786ac7d69927f6aee6719f1e' (2024-07-16)
  → 'github:lewis6991/gitsigns.nvim/f074844b60f9e151970fbcdbeb8a2cd52b6ef25a' (2024-07-25)
• Updated input 'home-manager':
    'github:nix-community/home-manager/afd2021bedff2de92dfce0e257a3d03ae65c603d' (2024-07-16)
  → 'github:nix-community/home-manager/bc2b96acda50229bc99925dde5c8e561e90b0b00' (2024-07-26)
• Updated input 'lspkind-nvim':
    'github:onsails/lspkind.nvim/1735dd5a5054c1fb7feaf8e8658dbab925f4f0cf' (2024-01-11)
  → 'github:onsails/lspkind.nvim/cff4ae321a91ee3473a92ea1a8c637e3a9510aec' (2024-07-25)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/d9fcc47baa026c7df9a9789d5e825b4f13a9239a' (2024-07-19)
  → 'github:nix-community/neovim-nightly-overlay/814a0d204eb9dab10d524137ab2e0392b9a1d70d' (2024-07-26)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/f61efe3fe77c9a517dccb9fd5ff7f16c0660ced4' (2024-07-18)
  → 'github:neovim/neovim/0dfcf3fe12ace3116bdffbbfc6875c67023eb8f2' (2024-07-26)
• Updated input 'nightfox-nvim':
    'github:EdenEast/nightfox.nvim/df75a6a94910ae47854341d6b5a6fd483192c0eb' (2024-04-28)
  → 'github:EdenEast/nightfox.nvim/d3e8b1acc095baf57af81bb5e89fe7c4359eb619' (2024-07-22)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/ad0111043c09f7d0f6b9f039882cbf350d4f7d49' (2024-07-19)
  → 'github:nixos/nixpkgs/733453ac54a40997a6a690b60f3942d79560247c' (2024-07-26)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/e26da408cf955afa8e9ddbadd510e84ea8976cd7' (2024-07-19)
  → 'github:neovim/nvim-lspconfig/f95d371c1a274f60392edfd8ea5121b42dca736e' (2024-07-26)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/047f9c9d8cd2861745eb9de6c1570ee0875aa795' (2024-07-10)
  → 'github:mrcjkb/rustaceanvim/db175e48401793f5e1c9fee82e3d375258cb1578' (2024-07-26)
• Updated input 'rustacean-nvim/flake-parts':
    'github:hercules-ci/flake-parts/9126214d0a59633752a136528f5f3b9aa8565b7d' (2024-04-01)
  → 'github:hercules-ci/flake-parts/9227223f6d922fee3c7b190b2cc238a99527bbb7' (2024-07-03)
• Updated input 'rustacean-nvim/flake-parts/nixpkgs-lib':
    'github:NixOS/nixpkgs/d8fe5e6c92d0d190646fb9f1056741a229980089?dir=lib' (2024-03-29)
  → 'https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz?narHash=sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI%3D' (2024-07-01)
• Updated input 'rustacean-nvim/gen-luarc':
    'github:mrcjkb/nix-gen-luarc-json/6e8912ea4fbfaa10797caafb1f5628fb4178b6e8' (2024-03-20)
  → 'github:mrcjkb/nix-gen-luarc-json/021e8078e43884c6cdc70ca753d9a0b146cd55a4' (2024-06-20)
• Updated input 'rustacean-nvim/gen-luarc/flake-parts':
    'github:hercules-ci/flake-parts/b253292d9c0a5ead9bc98c4e9a26c6312e27d69f' (2024-02-01)
  → 'github:hercules-ci/flake-parts/2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8' (2024-06-01)
• Updated input 'rustacean-nvim/gen-luarc/flake-parts/nixpkgs-lib':
    'github:NixOS/nixpkgs/97b17f32362e475016f942bbdfda4a4a72a8a652?dir=lib' (2024-01-29)
  → 'https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz?narHash=sha256-lIbdfCsf8LMFloheeE6N31%2BBMIeixqyQWbSr2vk79EQ%3D' (2024-06-01)
• Updated input 'rustacean-nvim/gen-luarc/nixpkgs':
    'github:nixos/nixpkgs/0e74ca98a74bc7270d28838369593635a5db3260' (2024-02-21)
  → 'github:nixos/nixpkgs/c00d587b1a1afbf200b1d8f0b0e4ba9deb1c7f0e' (2024-06-18)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/4333320b464e10e1e8ffefbf6e0b4055c79bbfd3' (2024-05-03)
  → 'github:nvim-neorocks/neorocks/2868f35af48fd893615a60b3c19f4f1131e2edcd' (2024-07-26)
• Added input 'rustacean-nvim/neorocks/flake-parts':
    'github:hercules-ci/flake-parts/9227223f6d922fee3c7b190b2cc238a99527bbb7' (2024-07-03)
• Added input 'rustacean-nvim/neorocks/flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz?narHash=sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI%3D' (2024-07-01)
• Removed input 'rustacean-nvim/neorocks/flake-utils'
• Removed input 'rustacean-nvim/neorocks/flake-utils/systems'
• Added input 'rustacean-nvim/neorocks/git-hooks':
    'github:cachix/git-hooks.nix/f451c19376071a90d8c58ab1a953c6e9840527fd' (2024-07-15)
• Added input 'rustacean-nvim/neorocks/git-hooks/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
• Added input 'rustacean-nvim/neorocks/git-hooks/gitignore':
    'github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394' (2024-02-28)
• Added input 'rustacean-nvim/neorocks/git-hooks/gitignore/nixpkgs':
    follows 'rustacean-nvim/neorocks/git-hooks/nixpkgs'
• Added input 'rustacean-nvim/neorocks/git-hooks/nixpkgs':
    'github:NixOS/nixpkgs/9693852a2070b398ee123a329e68f0dab5526681' (2024-06-22)
• Added input 'rustacean-nvim/neorocks/git-hooks/nixpkgs-stable':
    'github:NixOS/nixpkgs/194846768975b7ad2c4988bdb82572c00222c0d7' (2024-07-07)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:neovim/neovim/cf9f002f31c8b4d9d42912a3f45f5d3db4462fd9?dir=contrib' (2024-05-03)
  → 'github:nix-community/neovim-nightly-overlay/9d4c7b114a00f0c9ec4145e5674fc28af04e6489' (2024-07-25)
• Added input 'rustacean-nvim/neorocks/neovim-nightly/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
• Added input 'rustacean-nvim/neorocks/neovim-nightly/flake-parts':
    'github:hercules-ci/flake-parts/9227223f6d922fee3c7b190b2cc238a99527bbb7' (2024-07-03)
• Added input 'rustacean-nvim/neorocks/neovim-nightly/flake-parts/nixpkgs-lib':
    follows 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs'
• Removed input 'rustacean-nvim/neorocks/neovim-nightly/flake-utils'
• Removed input 'rustacean-nvim/neorocks/neovim-nightly/flake-utils/systems'
• Added input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks':
    'github:cachix/git-hooks.nix/f451c19376071a90d8c58ab1a953c6e9840527fd' (2024-07-15)
• Added input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
• Added input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks/gitignore':
    'github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394' (2024-02-28)
• Added input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks/gitignore/nixpkgs':
    follows 'rustacean-nvim/neorocks/neovim-nightly/git-hooks/nixpkgs'
• Added input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks/nixpkgs':
    follows 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs'
• Added input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks/nixpkgs-stable':
    follows 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs'
• Added input 'rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/11e4b8dc112e2f485d7c97e1cee77f9958f498f5' (2024-06-24)
• Added input 'rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects/flake-parts':
    'github:hercules-ci/flake-parts/9126214d0a59633752a136528f5f3b9aa8565b7d' (2024-04-01)
• Added input 'rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects/flake-parts/nixpkgs-lib':
    follows 'rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects/nixpkgs'
• Added input 'rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects/nixpkgs':
    follows 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs'
• Added input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/b4b4cf46a7a2b6d7b4e997179166444b0e338ac8' (2024-07-24)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    follows 'rustacean-nvim/neorocks/nixpkgs'
  → 'github:NixOS/nixpkgs/4f02464258baaf54992debfd010a7a3662a25536' (2024-07-24)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/1c74cc292b61614e74c1cf0d372f79d57fb4936b' (2024-05-01)
  → 'github:nixos/nixpkgs/2122a9b35b35719ad9a395fe783eabb092df01b1' (2024-07-25)
• Removed input 'rustacean-nvim/neorocks/pre-commit-hooks'
• Removed input 'rustacean-nvim/neorocks/pre-commit-hooks/flake-compat'
• Removed input 'rustacean-nvim/neorocks/pre-commit-hooks/flake-utils'
• Removed input 'rustacean-nvim/neorocks/pre-commit-hooks/flake-utils/systems'
• Removed input 'rustacean-nvim/neorocks/pre-commit-hooks/gitignore'
• Removed input 'rustacean-nvim/neorocks/pre-commit-hooks/gitignore/nixpkgs'
• Removed input 'rustacean-nvim/neorocks/pre-commit-hooks/nixpkgs'
• Removed input 'rustacean-nvim/neorocks/pre-commit-hooks/nixpkgs-stable'
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/d6f6eb2a984f2ba9a366c31e4d36d65465683450' (2024-04-27)
  → 'github:nixos/nixpkgs/2122a9b35b35719ad9a395fe783eabb092df01b1' (2024-07-25)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/6fb82e44254d6a0ece014ec423cb62d92435336f' (2024-04-24)
  → 'github:cachix/pre-commit-hooks.nix/f451c19376071a90d8c58ab1a953c6e9840527fd' (2024-07-15)
• Removed input 'rustacean-nvim/pre-commit-hooks/flake-utils'
• Removed input 'rustacean-nvim/pre-commit-hooks/flake-utils/systems'
• Updated input 'rustacean-nvim/pre-commit-hooks/nixpkgs':
    'github:NixOS/nixpkgs/e367f7a1fb93137af22a3908f00b9a35e2d286a7' (2024-03-18)
  → 'github:NixOS/nixpkgs/9693852a2070b398ee123a329e68f0dab5526681' (2024-06-22)
• Updated input 'rustacean-nvim/pre-commit-hooks/nixpkgs-stable':
    'github:NixOS/nixpkgs/614b4613980a522ba49f0d194531beddbb7220d3' (2024-03-17)
  → 'github:NixOS/nixpkgs/194846768975b7ad2c4988bdb82572c00222c0d7' (2024-07-07)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/bfcc7d5c6f12209139f175e6123a7b7de6d9c18a' (2024-07-01)
  → 'github:nvim-telescope/telescope.nvim/10b8a82b042caf50b78e619d92caf0910211973d' (2024-07-26)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/c0cfc1738361b5da1cd0a962dd6f774cc444f856' (2024-06-09)
  → 'github:nvim-tree/nvim-web-devicons/e612de3d3a41a6b7be47f51e956dddabcbf419d9' (2024-07-20)

```

</p></details>

 - Removed input `rustacean-nvim/pre-commit-hooks/flake-utils/systems`.
 - Removed input `rustacean-nvim/neorocks/pre-commit-hooks/flake-compat`.
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`1c74cc29` ➡️ `2122a9b3`](https://github.com/nixos/nixpkgs/compare/1c74cc292b61614e74c1cf0d372f79d57fb4936b...2122a9b35b35719ad9a395fe783eabb092df01b1) <sub>(2024-05-01 to 2024-07-25)</sub>
 - Updated input [`nightfox-nvim`](https://github.com/EdenEast/nightfox.nvim): [`df75a6a9` ➡️ `d3e8b1ac`](https://github.com/EdenEast/nightfox.nvim/compare/df75a6a94910ae47854341d6b5a6fd483192c0eb...d3e8b1acc095baf57af81bb5e89fe7c4359eb619) <sub>(2024-04-28 to 2024-07-22)</sub>
 - Added input `rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects/flake-parts/nixpkgs-lib`: ``
 - Removed input `rustacean-nvim/neorocks/flake-utils/systems`.
 - Added input `rustacean-nvim/neorocks/neovim-nightly/git-hooks/nixpkgs-stable`: ``
 - Updated input [`rustacean-nvim/flake-parts`](https://github.com/hercules-ci/flake-parts): [`9126214d` ➡️ `9227223f`](https://github.com/hercules-ci/flake-parts/compare/9126214d0a59633752a136528f5f3b9aa8565b7d...9227223f6d922fee3c7b190b2cc238a99527bbb7) <sub>(2024-04-01 to 2024-07-03)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`` ➡️ `4f024642`](https://github.com/NixOS/nixpkgs/compare/...4f02464258baaf54992debfd010a7a3662a25536) <sub>( to 2024-07-24)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks/nixpkgs-stable`](https://github.com/NixOS/nixpkgs): [`614b4613` ➡️ `19484676`](https://github.com/NixOS/nixpkgs/compare/614b4613980a522ba49f0d194531beddbb7220d3...194846768975b7ad2c4988bdb82572c00222c0d7) <sub>(2024-03-17 to 2024-07-07)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`f61efe3f` ➡️ `0dfcf3fe`](https://github.com/neovim/neovim/compare/f61efe3fe77c9a517dccb9fd5ff7f16c0660ced4...0dfcf3fe12ace3116bdffbbfc6875c67023eb8f2) <sub>(2024-07-18 to 2024-07-26)</sub>
 - Added input [`rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [github.com/hercules-ci/hercules-ci-effects](https://github.com/hercules-ci/hercules-ci-effects/tree/11e4b8dc112e2f485d7c97e1cee77f9958f498f5/)
 - Updated input [`rustacean-nvim/gen-luarc/flake-parts`](https://github.com/hercules-ci/flake-parts): [`b253292d` ➡️ `2a55567f`](https://github.com/hercules-ci/flake-parts/compare/b253292d9c0a5ead9bc98c4e9a26c6312e27d69f...2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8) <sub>(2024-02-01 to 2024-06-01)</sub>
 - Updated input [`lspkind-nvim`](https://github.com/onsails/lspkind.nvim): [`1735dd5a` ➡️ `cff4ae32`](https://github.com/onsails/lspkind.nvim/compare/1735dd5a5054c1fb7feaf8e8658dbab925f4f0cf...cff4ae321a91ee3473a92ea1a8c637e3a9510aec) <sub>(2024-01-11 to 2024-07-25)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`cf9f002f` ➡️ `9d4c7b11`](https://github.com/nix-community/neovim-nightly-overlay/compare/cf9f002f31c8b4d9d42912a3f45f5d3db4462fd9...9d4c7b114a00f0c9ec4145e5674fc28af04e6489) <sub>(2024-05-03 to 2024-07-25)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`f4928ba1` ➡️ `f074844b`](https://github.com/lewis6991/gitsigns.nvim/compare/f4928ba14eb6c667786ac7d69927f6aee6719f1e...f074844b60f9e151970fbcdbeb8a2cd52b6ef25a) <sub>(2024-07-16 to 2024-07-25)</sub>
 - Added input [`rustacean-nvim/neorocks/git-hooks/nixpkgs`](https://github.com/NixOS/nixpkgs): [github.com/NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/tree/9693852a2070b398ee123a329e68f0dab5526681/)
 - Added input [`rustacean-nvim/neorocks/git-hooks/flake-compat`](https://github.com/edolstra/flake-compat): [github.com/edolstra/flake-compat](https://github.com/edolstra/flake-compat/tree/0f9255e01c2351cc7d116c072cb317785dd33b33/)
 - Added input [`rustacean-nvim/neorocks/neovim-nightly/flake-parts`](https://github.com/hercules-ci/flake-parts): [github.com/hercules-ci/flake-parts](https://github.com/hercules-ci/flake-parts/tree/9227223f6d922fee3c7b190b2cc238a99527bbb7/)
 - Added input [`rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects/flake-parts`](https://github.com/hercules-ci/flake-parts): [github.com/hercules-ci/flake-parts](https://github.com/hercules-ci/flake-parts/tree/9126214d0a59633752a136528f5f3b9aa8565b7d/)
 - Added input [`rustacean-nvim/neorocks/git-hooks/gitignore`](https://github.com/hercules-ci/gitignore.nix): [github.com/hercules-ci/gitignore.nix](https://github.com/hercules-ci/gitignore.nix/tree/637db329424fd7e46cf4185293b9cc8c88c95394/)
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`4333320b` ➡️ `2868f35a`](https://github.com/nvim-neorocks/neorocks/compare/4333320b464e10e1e8ffefbf6e0b4055c79bbfd3...2868f35af48fd893615a60b3c19f4f1131e2edcd) <sub>(2024-05-03 to 2024-07-26)</sub>
 - Added input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks/flake-compat`](https://github.com/edolstra/flake-compat): [github.com/edolstra/flake-compat](https://github.com/edolstra/flake-compat/tree/0f9255e01c2351cc7d116c072cb317785dd33b33/)
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`bfcc7d5c` ➡️ `10b8a82b`](https://github.com/nvim-telescope/telescope.nvim/compare/bfcc7d5c6f12209139f175e6123a7b7de6d9c18a...10b8a82b042caf50b78e619d92caf0910211973d) <sub>(2024-07-01 to 2024-07-26)</sub>
 - Added input `rustacean-nvim/neorocks/neovim-nightly/git-hooks/gitignore/nixpkgs`: ``
 - Added input [`rustacean-nvim/neorocks/git-hooks/nixpkgs-stable`](https://github.com/NixOS/nixpkgs): [github.com/NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/tree/194846768975b7ad2c4988bdb82572c00222c0d7/)
 - Added input `rustacean-nvim/neorocks/flake-parts/nixpkgs-lib`: `https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz?narHash=sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI%3D`
 - Added input `rustacean-nvim/neorocks/neovim-nightly/git-hooks/nixpkgs`: ``
 - Added input `rustacean-nvim/neorocks/git-hooks/gitignore/nixpkgs`: ``
 - Removed input `rustacean-nvim/neorocks/neovim-nightly/flake-utils`.
 - Removed input `rustacean-nvim/neorocks/pre-commit-hooks/gitignore`.
 - Updated input `rustacean-nvim/gen-luarc/flake-parts/nixpkgs-lib`: `97b17f32` ➡️ `eb9ceca1` <sub>(2024-01-29 to 2024-06-01)</sub>
 - Added input [`rustacean-nvim/neorocks/neovim-nightly/flake-compat`](https://github.com/edolstra/flake-compat): [github.com/edolstra/flake-compat](https://github.com/edolstra/flake-compat/tree/0f9255e01c2351cc7d116c072cb317785dd33b33/)
 - Updated input [`rustacean-nvim/pre-commit-hooks/nixpkgs`](https://github.com/NixOS/nixpkgs): [`e367f7a1` ➡️ `9693852a`](https://github.com/NixOS/nixpkgs/compare/e367f7a1fb93137af22a3908f00b9a35e2d286a7...9693852a2070b398ee123a329e68f0dab5526681) <sub>(2024-03-18 to 2024-06-22)</sub>
 - Added input `rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects/nixpkgs`: ``
 - Updated input `rustacean-nvim/flake-parts/nixpkgs-lib`: `d8fe5e6c` ➡️ `5daf0514` <sub>(2024-03-29 to 2024-07-01)</sub>
 - Removed input `rustacean-nvim/neorocks/neovim-nightly/flake-utils/systems`.
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`047f9c9d` ➡️ `db175e48`](https://github.com/mrcjkb/rustaceanvim/compare/047f9c9d8cd2861745eb9de6c1570ee0875aa795...db175e48401793f5e1c9fee82e3d375258cb1578) <sub>(2024-07-10 to 2024-07-26)</sub>
 - Removed input `rustacean-nvim/neorocks/pre-commit-hooks/flake-utils/systems`.
 - Added input [`rustacean-nvim/neorocks/flake-parts`](https://github.com/hercules-ci/flake-parts): [github.com/hercules-ci/flake-parts](https://github.com/hercules-ci/flake-parts/tree/9227223f6d922fee3c7b190b2cc238a99527bbb7/)
 - Removed input `rustacean-nvim/neorocks/flake-utils`.
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`afd2021b` ➡️ `bc2b96ac`](https://github.com/nix-community/home-manager/compare/afd2021bedff2de92dfce0e257a3d03ae65c603d...bc2b96acda50229bc99925dde5c8e561e90b0b00) <sub>(2024-07-16 to 2024-07-26)</sub>
 - Removed input `rustacean-nvim/neorocks/pre-commit-hooks/gitignore/nixpkgs`.
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`c0cfc173` ➡️ `e612de3d`](https://github.com/nvim-tree/nvim-web-devicons/compare/c0cfc1738361b5da1cd0a962dd6f774cc444f856...e612de3d3a41a6b7be47f51e956dddabcbf419d9) <sub>(2024-06-09 to 2024-07-20)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`d9fcc47b` ➡️ `814a0d20`](https://github.com/nix-community/neovim-nightly-overlay/compare/d9fcc47baa026c7df9a9789d5e825b4f13a9239a...814a0d204eb9dab10d524137ab2e0392b9a1d70d) <sub>(2024-07-19 to 2024-07-26)</sub>
 - Added input `rustacean-nvim/neorocks/neovim-nightly/flake-parts/nixpkgs-lib`: ``
 - Removed input `rustacean-nvim/neorocks/pre-commit-hooks/nixpkgs`.
 - Removed input `rustacean-nvim/neorocks/pre-commit-hooks/flake-utils`.
 - Added input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [github.com/neovim/neovim](https://github.com/neovim/neovim/tree/b4b4cf46a7a2b6d7b4e997179166444b0e338ac8/)
 - Added input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks/gitignore`](https://github.com/hercules-ci/gitignore.nix): [github.com/hercules-ci/gitignore.nix](https://github.com/hercules-ci/gitignore.nix/tree/637db329424fd7e46cf4185293b9cc8c88c95394/)
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`d6f6eb2a` ➡️ `2122a9b3`](https://github.com/nixos/nixpkgs/compare/d6f6eb2a984f2ba9a366c31e4d36d65465683450...2122a9b35b35719ad9a395fe783eabb092df01b1) <sub>(2024-04-27 to 2024-07-25)</sub>
 - Updated input [`rustacean-nvim/gen-luarc/nixpkgs`](https://github.com/nixos/nixpkgs): [`0e74ca98` ➡️ `c00d587b`](https://github.com/nixos/nixpkgs/compare/0e74ca98a74bc7270d28838369593635a5db3260...c00d587b1a1afbf200b1d8f0b0e4ba9deb1c7f0e) <sub>(2024-02-21 to 2024-06-18)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`6fb82e44` ➡️ `f451c193`](https://github.com/cachix/pre-commit-hooks.nix/compare/6fb82e44254d6a0ece014ec423cb62d92435336f...f451c19376071a90d8c58ab1a953c6e9840527fd) <sub>(2024-04-24 to 2024-07-15)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`ad011104` ➡️ `733453ac`](https://github.com/nixos/nixpkgs/compare/ad0111043c09f7d0f6b9f039882cbf350d4f7d49...733453ac54a40997a6a690b60f3942d79560247c) <sub>(2024-07-19 to 2024-07-26)</sub>
 - Removed input `rustacean-nvim/pre-commit-hooks/flake-utils`.
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`e26da408` ➡️ `f95d371c`](https://github.com/neovim/nvim-lspconfig/compare/e26da408cf955afa8e9ddbadd510e84ea8976cd7...f95d371c1a274f60392edfd8ea5121b42dca736e) <sub>(2024-07-19 to 2024-07-26)</sub>
 - Removed input `rustacean-nvim/neorocks/pre-commit-hooks`.
 - Updated input [`rustacean-nvim/gen-luarc`](https://github.com/mrcjkb/nix-gen-luarc-json): [`6e8912ea` ➡️ `021e8078`](https://github.com/mrcjkb/nix-gen-luarc-json/compare/6e8912ea4fbfaa10797caafb1f5628fb4178b6e8...021e8078e43884c6cdc70ca753d9a0b146cd55a4) <sub>(2024-03-20 to 2024-06-20)</sub>
 - Added input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks`](https://github.com/cachix/git-hooks.nix): [github.com/cachix/git-hooks.nix](https://github.com/cachix/git-hooks.nix/tree/f451c19376071a90d8c58ab1a953c6e9840527fd/)
 - Added input [`rustacean-nvim/neorocks/git-hooks`](https://github.com/cachix/git-hooks.nix): [github.com/cachix/git-hooks.nix](https://github.com/cachix/git-hooks.nix/tree/f451c19376071a90d8c58ab1a953c6e9840527fd/)
 - Removed input `rustacean-nvim/neorocks/pre-commit-hooks/nixpkgs-stable`.