### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -200,11 +200,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
         "type": "github"
       },
       "original": {
@@ -628,11 +628,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1721142323,
-        "narHash": "sha256-iFVTd7nO4twq/S3qQpy4PZfHMpLDErJfJk63TmwL8t0=",
+        "lastModified": 1722587187,
+        "narHash": "sha256-2hK2synCl6rpw++w5K94n7JDLlV4vAvOq8W0RxL04IE=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "f4928ba14eb6c667786ac7d69927f6aee6719f1e",
+        "rev": "0ed466953fe5885166e0d60799172a8b1f752d16",
         "type": "github"
       },
       "original": {
@@ -694,11 +694,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721135958,
-        "narHash": "sha256-H548rpPMsn25LDKn1PCFmPxmWlClJJGnvdzImHkqjuY=",
+        "lastModified": 1722630065,
+        "narHash": "sha256-QfM/9BMRkCmgWzrPDK+KbgJOUlSJnfX4OvsUupEUZvA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "afd2021bedff2de92dfce0e257a3d03ae65c603d",
+        "rev": "afc892db74d65042031a093adb6010c4c3378422",
         "type": "github"
       },
       "original": {
@@ -809,11 +809,11 @@
     "lspkind-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1704982040,
-        "narHash": "sha256-/QLdBU/Zwmkw1NGuLBD48tvrmIP9d9WHhgcLEQgRTWo=",
+        "lastModified": 1721915252,
+        "narHash": "sha256-1KK6JhQUtA5mxwRSKU5e3pTQzZwaoAjzycBLx5X/xlA=",
         "owner": "onsails",
         "repo": "lspkind.nvim",
-        "rev": "1735dd5a5054c1fb7feaf8e8658dbab925f4f0cf",
+        "rev": "cff4ae321a91ee3473a92ea1a8c637e3a9510aec",
         "type": "github"
       },
       "original": {
@@ -841,11 +841,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1719606247,
-        "narHash": "sha256-zjefbPMiKxwYsBzE75jQRVNFMDSnCq1hKe1cBBqMRWg=",
+        "lastModified": 1722506184,
+        "narHash": "sha256-I/VpvAspE6oPNjwTs5kLY9pTw6XjViGNi8lqMYNPf5Y=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "ce0a05ab4e2839e1c48d072c5236cce846a387bc",
+        "rev": "7552e6504ee95a9c8cfc6db53e389122ded46cd4",
         "type": "github"
       },
       "original": {
@@ -927,11 +927,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721368131,
-        "narHash": "sha256-dvDYa+Z2qZHTibmeUbKKIpR2jONO4UPbyHiDgYhgoMQ=",
+        "lastModified": 1722618800,
+        "narHash": "sha256-RP57a/NFk4uDnDWgTiDdJ+HteT8hTnkKz2dxd+kqL3M=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "d9fcc47baa026c7df9a9789d5e825b4f13a9239a",
+        "rev": "0dfaa8c68db4cd0e7c0f500242f24932b3abdb85",
         "type": "github"
       },
       "original": {
@@ -943,11 +943,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1721316387,
-        "narHash": "sha256-qPgppLqmnd0OnHLMo4cGPZSUyLbcw9nThWO4sJC8bWI=",
+        "lastModified": 1722556329,
+        "narHash": "sha256-biqiNshPEE3pndvrDQ2LqSe4YWi0PhHsAfhXGdoV+ic=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "f61efe3fe77c9a517dccb9fd5ff7f16c0660ced4",
+        "rev": "b782a37cf58b5ae5e47fd15fb2a5096639c64a23",
         "type": "github"
       },
       "original": {
@@ -975,11 +975,11 @@
     "nightfox-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1714329621,
-        "narHash": "sha256-ly9yavagB6A8t2plHZyNJt5tqCBq+ExEtYGKR4+9qHQ=",
+        "lastModified": 1721661222,
+        "narHash": "sha256-2efugsL7pbQ78XxwWRybnfxhuqe7LSUgpTlwcJJTAX0=",
         "owner": "EdenEast",
         "repo": "nightfox.nvim",
-        "rev": "df75a6a94910ae47854341d6b5a6fd483192c0eb",
+        "rev": "d3e8b1acc095baf57af81bb5e89fe7c4359eb619",
         "type": "github"
       },
       "original": {
@@ -1074,11 +1074,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1722040881,
-        "narHash": "sha256-NMDotPxtCNvmRnUo/YuxNOpN8+UMONBlNBnRFsGHADQ=",
+        "lastModified": 1722415718,
+        "narHash": "sha256-5US0/pgxbMksF92k1+eOa8arJTJiPvsdZj9Dl+vJkM4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "48bacf585a51d953def8bff32087970f273052e2",
+        "rev": "c3392ad349a5227f4a3464dce87bcc5046692fce",
         "type": "github"
       },
       "original": {
@@ -1203,11 +1203,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1721093634,
-        "narHash": "sha256-jc4fQBaAuL4XhHljVU3sdaEyQCnHbI+gwNOTnGHk0qM=",
+        "lastModified": 1722509464,
+        "narHash": "sha256-NcodgUp8obTsjgc+5j2dKr0f3FelYikQTJngfZXRZzo=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "d818fd0624205b34e14888358037fb6f5dc51234",
+        "rev": "ae644feb7b67bf1ce4260c231d1d4300b19c6f30",
         "type": "github"
       },
       "original": {
@@ -1219,11 +1219,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1721369277,
-        "narHash": "sha256-GscyvR1SYGUig7GGLDS5xS5weVi32WJuFOypVaZc044=",
+        "lastModified": 1722602479,
+        "narHash": "sha256-AzqGB5RKVFn3c6m31rS0mc6KdAgHfAFziBBUs2cglyw=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "e26da408cf955afa8e9ddbadd510e84ea8976cd7",
+        "rev": "e6528f4613c8db2e04be908eb2b5886d63f62a98",
         "type": "github"
       },
       "original": {
@@ -1355,11 +1355,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1722061921,
-        "narHash": "sha256-fOQHvblEX4Oz2M2Git0ZFQKHF+FbeHmNu+BEL4lrtTs=",
+        "lastModified": 1722622895,
+        "narHash": "sha256-wjB7LGvaEt1zTeEy7S1aywabSvCbj4SZyZ754l7/8p0=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "7a0ab500457fac239c31ea9a8050918369d67130",
+        "rev": "1b2d4cf2e0c6def0bdee168d84224f5e076f2a26",
         "type": "github"
       },
       "original": {
@@ -1432,11 +1432,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1719860810,
-        "narHash": "sha256-U6fgii9FlJy+bHAtYVnZEOyiUAqlBHTvMFc4mo+xS/s=",
+        "lastModified": 1722561161,
+        "narHash": "sha256-F5TGzfPSDQY+AOzaDXStswHjkGQvnLeTWW5/xdBalpo=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "bfcc7d5c6f12209139f175e6123a7b7de6d9c18a",
+        "rev": "3b1600d0fd5172ad9fae00987362ca0ef3d8895d",
         "type": "github"
       },
       "original": {
@@ -1448,11 +1448,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1717894639,
-        "narHash": "sha256-j/B/E1VltJ/QpVFtDKAdVC4+KZ5Mz8dQP5kd8HIHjLs=",
+        "lastModified": 1722135444,
+        "narHash": "sha256-GFVhR1ML7r/YsbUP0MigTyYt7cfy5PjHPBkYK5JX5Tc=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "c0cfc1738361b5da1cd0a962dd6f774cc444f856",
+        "rev": "5be6c4e685618b99c3210a69375b38a1202369b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/f4928ba14eb6c667786ac7d69927f6aee6719f1e' (2024-07-16)
  → 'github:lewis6991/gitsigns.nvim/0ed466953fe5885166e0d60799172a8b1f752d16' (2024-08-02)
• Updated input 'home-manager':
    'github:nix-community/home-manager/afd2021bedff2de92dfce0e257a3d03ae65c603d' (2024-07-16)
  → 'github:nix-community/home-manager/afc892db74d65042031a093adb6010c4c3378422' (2024-08-02)
• Updated input 'lspkind-nvim':
    'github:onsails/lspkind.nvim/1735dd5a5054c1fb7feaf8e8658dbab925f4f0cf' (2024-01-11)
  → 'github:onsails/lspkind.nvim/cff4ae321a91ee3473a92ea1a8c637e3a9510aec' (2024-07-25)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/ce0a05ab4e2839e1c48d072c5236cce846a387bc' (2024-06-28)
  → 'github:L3MON4D3/LuaSnip/7552e6504ee95a9c8cfc6db53e389122ded46cd4' (2024-08-01)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/d9fcc47baa026c7df9a9789d5e825b4f13a9239a' (2024-07-19)
  → 'github:nix-community/neovim-nightly-overlay/0dfaa8c68db4cd0e7c0f500242f24932b3abdb85' (2024-08-02)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/9227223f6d922fee3c7b190b2cc238a99527bbb7' (2024-07-03)
  → 'github:hercules-ci/flake-parts/8471fe90ad337a8074e957b69ca4d0089218391d' (2024-08-01)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/f61efe3fe77c9a517dccb9fd5ff7f16c0660ced4' (2024-07-18)
  → 'github:neovim/neovim/b782a37cf58b5ae5e47fd15fb2a5096639c64a23' (2024-08-01)
• Updated input 'nightfox-nvim':
    'github:EdenEast/nightfox.nvim/df75a6a94910ae47854341d6b5a6fd483192c0eb' (2024-04-28)
  → 'github:EdenEast/nightfox.nvim/d3e8b1acc095baf57af81bb5e89fe7c4359eb619' (2024-07-22)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/48bacf585a51d953def8bff32087970f273052e2' (2024-07-27)
  → 'github:nixos/nixpkgs/c3392ad349a5227f4a3464dce87bcc5046692fce' (2024-07-31)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/d818fd0624205b34e14888358037fb6f5dc51234' (2024-07-16)
  → 'github:hrsh7th/nvim-cmp/ae644feb7b67bf1ce4260c231d1d4300b19c6f30' (2024-08-01)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/e26da408cf955afa8e9ddbadd510e84ea8976cd7' (2024-07-19)
  → 'github:neovim/nvim-lspconfig/e6528f4613c8db2e04be908eb2b5886d63f62a98' (2024-08-02)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/7a0ab500457fac239c31ea9a8050918369d67130' (2024-07-27)
  → 'github:mrcjkb/rustaceanvim/1b2d4cf2e0c6def0bdee168d84224f5e076f2a26' (2024-08-02)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/bfcc7d5c6f12209139f175e6123a7b7de6d9c18a' (2024-07-01)
  → 'github:nvim-telescope/telescope.nvim/3b1600d0fd5172ad9fae00987362ca0ef3d8895d' (2024-08-02)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/c0cfc1738361b5da1cd0a962dd6f774cc444f856' (2024-06-09)
  → 'github:nvim-tree/nvim-web-devicons/5be6c4e685618b99c3210a69375b38a1202369b4' (2024-07-28)

```

</p></details>

 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`7a0ab500` ➡️ `1b2d4cf2`](https://github.com/mrcjkb/rustaceanvim/compare/7a0ab500457fac239c31ea9a8050918369d67130...1b2d4cf2e0c6def0bdee168d84224f5e076f2a26) <sub>(2024-07-27 to 2024-08-02)</sub>
 - Updated input [`nightfox-nvim`](https://github.com/EdenEast/nightfox.nvim): [`df75a6a9` ➡️ `d3e8b1ac`](https://github.com/EdenEast/nightfox.nvim/compare/df75a6a94910ae47854341d6b5a6fd483192c0eb...d3e8b1acc095baf57af81bb5e89fe7c4359eb619) <sub>(2024-04-28 to 2024-07-22)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`d9fcc47b` ➡️ `0dfaa8c6`](https://github.com/nix-community/neovim-nightly-overlay/compare/d9fcc47baa026c7df9a9789d5e825b4f13a9239a...0dfaa8c68db4cd0e7c0f500242f24932b3abdb85) <sub>(2024-07-19 to 2024-08-02)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`ce0a05ab` ➡️ `7552e650`](https://github.com/L3MON4D3/LuaSnip/compare/ce0a05ab4e2839e1c48d072c5236cce846a387bc...7552e6504ee95a9c8cfc6db53e389122ded46cd4) <sub>(2024-06-28 to 2024-08-01)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`e26da408` ➡️ `e6528f46`](https://github.com/neovim/nvim-lspconfig/compare/e26da408cf955afa8e9ddbadd510e84ea8976cd7...e6528f4613c8db2e04be908eb2b5886d63f62a98) <sub>(2024-07-19 to 2024-08-02)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`d818fd06` ➡️ `ae644feb`](https://github.com/hrsh7th/nvim-cmp/compare/d818fd0624205b34e14888358037fb6f5dc51234...ae644feb7b67bf1ce4260c231d1d4300b19c6f30) <sub>(2024-07-16 to 2024-08-01)</sub>
 - Updated input [`lspkind-nvim`](https://github.com/onsails/lspkind.nvim): [`1735dd5a` ➡️ `cff4ae32`](https://github.com/onsails/lspkind.nvim/compare/1735dd5a5054c1fb7feaf8e8658dbab925f4f0cf...cff4ae321a91ee3473a92ea1a8c637e3a9510aec) <sub>(2024-01-11 to 2024-07-25)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`f4928ba1` ➡️ `0ed46695`](https://github.com/lewis6991/gitsigns.nvim/compare/f4928ba14eb6c667786ac7d69927f6aee6719f1e...0ed466953fe5885166e0d60799172a8b1f752d16) <sub>(2024-07-16 to 2024-08-02)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`48bacf58` ➡️ `c3392ad3`](https://github.com/nixos/nixpkgs/compare/48bacf585a51d953def8bff32087970f273052e2...c3392ad349a5227f4a3464dce87bcc5046692fce) <sub>(2024-07-27 to 2024-07-31)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`bfcc7d5c` ➡️ `3b1600d0`](https://github.com/nvim-telescope/telescope.nvim/compare/bfcc7d5c6f12209139f175e6123a7b7de6d9c18a...3b1600d0fd5172ad9fae00987362ca0ef3d8895d) <sub>(2024-07-01 to 2024-08-02)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`c0cfc173` ➡️ `5be6c4e6`](https://github.com/nvim-tree/nvim-web-devicons/compare/c0cfc1738361b5da1cd0a962dd6f774cc444f856...5be6c4e685618b99c3210a69375b38a1202369b4) <sub>(2024-06-09 to 2024-07-28)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`afd2021b` ➡️ `afc892db`](https://github.com/nix-community/home-manager/compare/afd2021bedff2de92dfce0e257a3d03ae65c603d...afc892db74d65042031a093adb6010c4c3378422) <sub>(2024-07-16 to 2024-08-02)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`f61efe3f` ➡️ `b782a37c`](https://github.com/neovim/neovim/compare/f61efe3fe77c9a517dccb9fd5ff7f16c0660ced4...b782a37cf58b5ae5e47fd15fb2a5096639c64a23) <sub>(2024-07-18 to 2024-08-01)</sub>
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`9227223f` ➡️ `8471fe90`](https://github.com/hercules-ci/flake-parts/compare/9227223f6d922fee3c7b190b2cc238a99527bbb7...8471fe90ad337a8074e957b69ca4d0089218391d) <sub>(2024-07-03 to 2024-08-01)</sub>