### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721042469,
-        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
+        "lastModified": 1723056346,
+        "narHash": "sha256-YpzywjTAUHRRHcO8zz9x2gYqJ0JmZlcB9+RaUvD89qM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
+        "rev": "3c977f1c9930f54066c085305b4b2291385e7a73",
         "type": "github"
       },
       "original": {
@@ -628,11 +628,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1722587187,
-        "narHash": "sha256-2hK2synCl6rpw++w5K94n7JDLlV4vAvOq8W0RxL04IE=",
+        "lastModified": 1723029377,
+        "narHash": "sha256-NNoqXn24Fzkopx1/Xwcv41EpqHwpcMPrQWLfXcPtha4=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "0ed466953fe5885166e0d60799172a8b1f752d16",
+        "rev": "562dc47189ad3c8696dbf460d38603a74d544849",
         "type": "github"
       },
       "original": {
@@ -694,11 +694,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722630065,
-        "narHash": "sha256-QfM/9BMRkCmgWzrPDK+KbgJOUlSJnfX4OvsUupEUZvA=",
+        "lastModified": 1723015306,
+        "narHash": "sha256-jQnFEtH20/OsDPpx71ntZzGdRlpXhUENSQCGTjn//NA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "afc892db74d65042031a093adb6010c4c3378422",
+        "rev": "b3d5ea65d88d67d4ec578ed11d4d2d51e3de525e",
         "type": "github"
       },
       "original": {
@@ -728,11 +728,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1720709712,
-        "narHash": "sha256-78j/cY+AXoMIqqiNc1vWx237EPfpERAcYsb57ABUbwQ=",
+        "lastModified": 1722636442,
+        "narHash": "sha256-+7IS0n3/F0I5j6ZbrVlLcIIPHY3o+/vLAqg/G48sG+w=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "65d42dcbfde2229a75ccdb195c318dfe241f9ade",
+        "rev": "9d67858b437d4a1299be496d371b66fc0d3e01f6",
         "type": "github"
       },
       "original": {
@@ -841,11 +841,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1722506184,
-        "narHash": "sha256-I/VpvAspE6oPNjwTs5kLY9pTw6XjViGNi8lqMYNPf5Y=",
+        "lastModified": 1722979597,
+        "narHash": "sha256-9TEQUCMUgoQ19Gpfs/3lcyR38yJMpNssGJsih3F9Nw8=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "7552e6504ee95a9c8cfc6db53e389122ded46cd4",
+        "rev": "b84eeb3641b08324287587b426ec974b888390d9",
         "type": "github"
       },
       "original": {
@@ -927,11 +927,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722618800,
-        "narHash": "sha256-RP57a/NFk4uDnDWgTiDdJ+HteT8hTnkKz2dxd+kqL3M=",
+        "lastModified": 1723228852,
+        "narHash": "sha256-vPk1MWy3atw4OxFWXdGpeLwqmx87Ph/qdAsGn7e1cy4=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "0dfaa8c68db4cd0e7c0f500242f24932b3abdb85",
+        "rev": "585d8caecf1561bec33529f2f890b234d8c5dabb",
         "type": "github"
       },
       "original": {
@@ -943,11 +943,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1722556329,
-        "narHash": "sha256-biqiNshPEE3pndvrDQ2LqSe4YWi0PhHsAfhXGdoV+ic=",
+        "lastModified": 1723160721,
+        "narHash": "sha256-W1Jz/sINvHUXqZIGqCoZutW7U5fDCG2xI1IcX5UjIbI=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "b782a37cf58b5ae5e47fd15fb2a5096639c64a23",
+        "rev": "b9913191be0b4884d92db794e2eb92641523a415",
         "type": "github"
       },
       "original": {
@@ -1074,11 +1074,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1722415718,
-        "narHash": "sha256-5US0/pgxbMksF92k1+eOa8arJTJiPvsdZj9Dl+vJkM4=",
+        "lastModified": 1723151389,
+        "narHash": "sha256-9AVY0ReCmSGXHrlx78+1RrqcDgVSRhHUKDVV1LLBy28=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c3392ad349a5227f4a3464dce87bcc5046692fce",
+        "rev": "13fe00cb6c75461901f072ae62b5805baef9f8b2",
         "type": "github"
       },
       "original": {
@@ -1219,11 +1219,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1722602479,
-        "narHash": "sha256-AzqGB5RKVFn3c6m31rS0mc6KdAgHfAFziBBUs2cglyw=",
+        "lastModified": 1723024285,
+        "narHash": "sha256-qxysoQO6JpdUY81KSZ0denNFe+RX3+/VCq9xbVdGAR8=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "e6528f4613c8db2e04be908eb2b5886d63f62a98",
+        "rev": "652386deae739e38fa1bcf2f06e3e7de9b3436ba",
         "type": "github"
       },
       "original": {
@@ -1355,11 +1355,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1722622895,
-        "narHash": "sha256-wjB7LGvaEt1zTeEy7S1aywabSvCbj4SZyZ754l7/8p0=",
+        "lastModified": 1723016032,
+        "narHash": "sha256-UVF+Mb30Q4x4/yvrZxdEx4RAidHy6tgxRzfQgby0mRk=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "1b2d4cf2e0c6def0bdee168d84224f5e076f2a26",
+        "rev": "b3de2d10dd351756022b77aa8a305ddc1e72a5ba",
         "type": "github"
       },
       "original": {
@@ -1448,11 +1448,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1722135444,
-        "narHash": "sha256-GFVhR1ML7r/YsbUP0MigTyYt7cfy5PjHPBkYK5JX5Tc=",
+        "lastModified": 1722734411,
+        "narHash": "sha256-TeWMlfNTA5+tiPq6D2TVWjdfJVr3FOwpqUDU8kfFZ8E=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "5be6c4e685618b99c3210a69375b38a1202369b4",
+        "rev": "3722e3d1fb5fe1896a104eb489e8f8651260b520",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/0ed466953fe5885166e0d60799172a8b1f752d16' (2024-08-02)
  → 'github:lewis6991/gitsigns.nvim/562dc47189ad3c8696dbf460d38603a74d544849' (2024-08-07)
• Updated input 'home-manager':
    'github:nix-community/home-manager/afc892db74d65042031a093adb6010c4c3378422' (2024-08-02)
  → 'github:nix-community/home-manager/b3d5ea65d88d67d4ec578ed11d4d2d51e3de525e' (2024-08-07)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/65d42dcbfde2229a75ccdb195c318dfe241f9ade' (2024-07-11)
  → 'github:hyprwm/contrib/9d67858b437d4a1299be496d371b66fc0d3e01f6' (2024-08-02)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/7552e6504ee95a9c8cfc6db53e389122ded46cd4' (2024-08-01)
  → 'github:L3MON4D3/LuaSnip/b84eeb3641b08324287587b426ec974b888390d9' (2024-08-06)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/0dfaa8c68db4cd0e7c0f500242f24932b3abdb85' (2024-08-02)
  → 'github:nix-community/neovim-nightly-overlay/585d8caecf1561bec33529f2f890b234d8c5dabb' (2024-08-09)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/f451c19376071a90d8c58ab1a953c6e9840527fd' (2024-07-15)
  → 'github:cachix/git-hooks.nix/3c977f1c9930f54066c085305b4b2291385e7a73' (2024-08-07)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/b782a37cf58b5ae5e47fd15fb2a5096639c64a23' (2024-08-01)
  → 'github:neovim/neovim/b9913191be0b4884d92db794e2eb92641523a415' (2024-08-08)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/c3392ad349a5227f4a3464dce87bcc5046692fce' (2024-07-31)
  → 'github:nixos/nixpkgs/13fe00cb6c75461901f072ae62b5805baef9f8b2' (2024-08-08)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/e6528f4613c8db2e04be908eb2b5886d63f62a98' (2024-08-02)
  → 'github:neovim/nvim-lspconfig/652386deae739e38fa1bcf2f06e3e7de9b3436ba' (2024-08-07)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/1b2d4cf2e0c6def0bdee168d84224f5e076f2a26' (2024-08-02)
  → 'github:mrcjkb/rustaceanvim/b3de2d10dd351756022b77aa8a305ddc1e72a5ba' (2024-08-07)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/5be6c4e685618b99c3210a69375b38a1202369b4' (2024-07-28)
  → 'github:nvim-tree/nvim-web-devicons/3722e3d1fb5fe1896a104eb489e8f8651260b520' (2024-08-04)

```

</p></details>

 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`1b2d4cf2` ➡️ `b3de2d10`](https://github.com/mrcjkb/rustaceanvim/compare/1b2d4cf2e0c6def0bdee168d84224f5e076f2a26...b3de2d10dd351756022b77aa8a305ddc1e72a5ba) <sub>(2024-08-02 to 2024-08-07)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`0dfaa8c6` ➡️ `585d8cae`](https://github.com/nix-community/neovim-nightly-overlay/compare/0dfaa8c68db4cd0e7c0f500242f24932b3abdb85...585d8caecf1561bec33529f2f890b234d8c5dabb) <sub>(2024-08-02 to 2024-08-09)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`7552e650` ➡️ `b84eeb36`](https://github.com/L3MON4D3/LuaSnip/compare/7552e6504ee95a9c8cfc6db53e389122ded46cd4...b84eeb3641b08324287587b426ec974b888390d9) <sub>(2024-08-01 to 2024-08-06)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`65d42dcb` ➡️ `9d67858b`](https://github.com/hyprwm/contrib/compare/65d42dcbfde2229a75ccdb195c318dfe241f9ade...9d67858b437d4a1299be496d371b66fc0d3e01f6) <sub>(2024-07-11 to 2024-08-02)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`e6528f46` ➡️ `652386de`](https://github.com/neovim/nvim-lspconfig/compare/e6528f4613c8db2e04be908eb2b5886d63f62a98...652386deae739e38fa1bcf2f06e3e7de9b3436ba) <sub>(2024-08-02 to 2024-08-07)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`0ed46695` ➡️ `562dc471`](https://github.com/lewis6991/gitsigns.nvim/compare/0ed466953fe5885166e0d60799172a8b1f752d16...562dc47189ad3c8696dbf460d38603a74d544849) <sub>(2024-08-02 to 2024-08-07)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`c3392ad3` ➡️ `13fe00cb`](https://github.com/nixos/nixpkgs/compare/c3392ad349a5227f4a3464dce87bcc5046692fce...13fe00cb6c75461901f072ae62b5805baef9f8b2) <sub>(2024-07-31 to 2024-08-08)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`f451c193` ➡️ `3c977f1c`](https://github.com/cachix/git-hooks.nix/compare/f451c19376071a90d8c58ab1a953c6e9840527fd...3c977f1c9930f54066c085305b4b2291385e7a73) <sub>(2024-07-15 to 2024-08-07)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`5be6c4e6` ➡️ `3722e3d1`](https://github.com/nvim-tree/nvim-web-devicons/compare/5be6c4e685618b99c3210a69375b38a1202369b4...3722e3d1fb5fe1896a104eb489e8f8651260b520) <sub>(2024-07-28 to 2024-08-04)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`afc892db` ➡️ `b3d5ea65`](https://github.com/nix-community/home-manager/compare/afc892db74d65042031a093adb6010c4c3378422...b3d5ea65d88d67d4ec578ed11d4d2d51e3de525e) <sub>(2024-08-02 to 2024-08-07)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`b782a37c` ➡️ `b9913191`](https://github.com/neovim/neovim/compare/b782a37cf58b5ae5e47fd15fb2a5096639c64a23...b9913191be0b4884d92db794e2eb92641523a415) <sub>(2024-08-01 to 2024-08-08)</sub>