### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723056346,
-        "narHash": "sha256-YpzywjTAUHRRHcO8zz9x2gYqJ0JmZlcB9+RaUvD89qM=",
+        "lastModified": 1723202784,
+        "narHash": "sha256-qbhjc/NEGaDbyy0ucycubq4N3//gDFFH3DOmp1D3u1Q=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3c977f1c9930f54066c085305b4b2291385e7a73",
+        "rev": "c7012d0c18567c889b948781bc74a501e92275d1",
         "type": "github"
       },
       "original": {
@@ -694,11 +694,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723015306,
-        "narHash": "sha256-jQnFEtH20/OsDPpx71ntZzGdRlpXhUENSQCGTjn//NA=",
+        "lastModified": 1723399884,
+        "narHash": "sha256-97wn0ihhGqfMb8WcUgzzkM/TuAxce2Gd20A8oiruju4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b3d5ea65d88d67d4ec578ed11d4d2d51e3de525e",
+        "rev": "086f619dd991a4d355c07837448244029fc2d9ab",
         "type": "github"
       },
       "original": {
@@ -825,11 +825,11 @@
     "lualine-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1721024646,
-        "narHash": "sha256-uNDRynWs7fXDDzDFKvE31oDetv3aabiJfr/r/84z9Sg=",
+        "lastModified": 1723473562,
+        "narHash": "sha256-gCm7m96PkZyrgjmt7Efc+NMZKStAq1zr7JRCYOgGDuE=",
         "owner": "nvim-lualine",
         "repo": "lualine.nvim",
-        "rev": "544dd1583f9bb27b393f598475c89809c4d5e86b",
+        "rev": "b431d228b7bbcdaea818bdc3e25b8cdbe861f056",
         "type": "github"
       },
       "original": {
@@ -927,11 +927,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723228852,
-        "narHash": "sha256-vPk1MWy3atw4OxFWXdGpeLwqmx87Ph/qdAsGn7e1cy4=",
+        "lastModified": 1723796332,
+        "narHash": "sha256-V1eO+6leWxL4etUpgxi81kC9mOUIPo/gy4GXPqcgQ6E=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "585d8caecf1561bec33529f2f890b234d8c5dabb",
+        "rev": "b67c560eb553aa29f7e4efa729af61ff4d45c786",
         "type": "github"
       },
       "original": {
@@ -943,11 +943,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1723160721,
-        "narHash": "sha256-W1Jz/sINvHUXqZIGqCoZutW7U5fDCG2xI1IcX5UjIbI=",
+        "lastModified": 1723747612,
+        "narHash": "sha256-e7QFAYeZSjhQ1H0mk2awv2KcXlsepzXki3uYEUBXZ8Q=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "b9913191be0b4884d92db794e2eb92641523a415",
+        "rev": "fd65422b99c7cc69e5053a852244cfc9d46d7b65",
         "type": "github"
       },
       "original": {
@@ -1074,11 +1074,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1723151389,
-        "narHash": "sha256-9AVY0ReCmSGXHrlx78+1RrqcDgVSRhHUKDVV1LLBy28=",
+        "lastModified": 1723703277,
+        "narHash": "sha256-nk0RaUB5f68BwtXAYy3WAjqFhVKqIl9Z89RGycTa2vk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "13fe00cb6c75461901f072ae62b5805baef9f8b2",
+        "rev": "8b908192e64224420e2d59dfd9b2e4309e154c5d",
         "type": "github"
       },
       "original": {
@@ -1219,11 +1219,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1723024285,
-        "narHash": "sha256-qxysoQO6JpdUY81KSZ0denNFe+RX3+/VCq9xbVdGAR8=",
+        "lastModified": 1723788573,
+        "narHash": "sha256-y64E6q6bB0kzJzxHnOYWjCZW5tpBTzhAVs/lvpmOpU0=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "652386deae739e38fa1bcf2f06e3e7de9b3436ba",
+        "rev": "a89de2e049b5f89a0ee55029d5a31213bd4de6f8",
         "type": "github"
       },
       "original": {
@@ -1355,11 +1355,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1723016032,
-        "narHash": "sha256-UVF+Mb30Q4x4/yvrZxdEx4RAidHy6tgxRzfQgby0mRk=",
+        "lastModified": 1723582024,
+        "narHash": "sha256-OYfeJuo4FZUBdW9wGGCT0lZGYr/ur1uy8frcyUJMF3k=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "b3de2d10dd351756022b77aa8a305ddc1e72a5ba",
+        "rev": "7cba8e599deca98d4b44cac1bcbd720c62937d90",
         "type": "github"
       },
       "original": {
@@ -1432,11 +1432,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1722561161,
-        "narHash": "sha256-F5TGzfPSDQY+AOzaDXStswHjkGQvnLeTWW5/xdBalpo=",
+        "lastModified": 1723686624,
+        "narHash": "sha256-rNzfnORvbKoglt20i/rKmlkysPUBlB89F6dRKgB5MKU=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "3b1600d0fd5172ad9fae00987362ca0ef3d8895d",
+        "rev": "5972437de807c3bc101565175da66a1aa4f8707a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/b3d5ea65d88d67d4ec578ed11d4d2d51e3de525e' (2024-08-07)
  → 'github:nix-community/home-manager/086f619dd991a4d355c07837448244029fc2d9ab' (2024-08-11)
• Updated input 'lualine-nvim':
    'github:nvim-lualine/lualine.nvim/544dd1583f9bb27b393f598475c89809c4d5e86b' (2024-07-15)
  → 'github:nvim-lualine/lualine.nvim/b431d228b7bbcdaea818bdc3e25b8cdbe861f056' (2024-08-12)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/585d8caecf1561bec33529f2f890b234d8c5dabb' (2024-08-09)
  → 'github:nix-community/neovim-nightly-overlay/b67c560eb553aa29f7e4efa729af61ff4d45c786' (2024-08-16)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/3c977f1c9930f54066c085305b4b2291385e7a73' (2024-08-07)
  → 'github:cachix/git-hooks.nix/c7012d0c18567c889b948781bc74a501e92275d1' (2024-08-09)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/b9913191be0b4884d92db794e2eb92641523a415' (2024-08-08)
  → 'github:neovim/neovim/fd65422b99c7cc69e5053a852244cfc9d46d7b65' (2024-08-15)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/13fe00cb6c75461901f072ae62b5805baef9f8b2' (2024-08-08)
  → 'github:nixos/nixpkgs/8b908192e64224420e2d59dfd9b2e4309e154c5d' (2024-08-15)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/652386deae739e38fa1bcf2f06e3e7de9b3436ba' (2024-08-07)
  → 'github:neovim/nvim-lspconfig/a89de2e049b5f89a0ee55029d5a31213bd4de6f8' (2024-08-16)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/b3de2d10dd351756022b77aa8a305ddc1e72a5ba' (2024-08-07)
  → 'github:mrcjkb/rustaceanvim/7cba8e599deca98d4b44cac1bcbd720c62937d90' (2024-08-13)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/3b1600d0fd5172ad9fae00987362ca0ef3d8895d' (2024-08-02)
  → 'github:nvim-telescope/telescope.nvim/5972437de807c3bc101565175da66a1aa4f8707a' (2024-08-15)

```

</p></details>

 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`b3de2d10` ➡️ `7cba8e59`](https://github.com/mrcjkb/rustaceanvim/compare/b3de2d10dd351756022b77aa8a305ddc1e72a5ba...7cba8e599deca98d4b44cac1bcbd720c62937d90) <sub>(2024-08-07 to 2024-08-13)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`585d8cae` ➡️ `b67c560e`](https://github.com/nix-community/neovim-nightly-overlay/compare/585d8caecf1561bec33529f2f890b234d8c5dabb...b67c560eb553aa29f7e4efa729af61ff4d45c786) <sub>(2024-08-09 to 2024-08-16)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`652386de` ➡️ `a89de2e0`](https://github.com/neovim/nvim-lspconfig/compare/652386deae739e38fa1bcf2f06e3e7de9b3436ba...a89de2e049b5f89a0ee55029d5a31213bd4de6f8) <sub>(2024-08-07 to 2024-08-16)</sub>
 - Updated input [`lualine-nvim`](https://github.com/nvim-lualine/lualine.nvim): [`544dd158` ➡️ `b431d228`](https://github.com/nvim-lualine/lualine.nvim/compare/544dd1583f9bb27b393f598475c89809c4d5e86b...b431d228b7bbcdaea818bdc3e25b8cdbe861f056) <sub>(2024-07-15 to 2024-08-12)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`13fe00cb` ➡️ `8b908192`](https://github.com/nixos/nixpkgs/compare/13fe00cb6c75461901f072ae62b5805baef9f8b2...8b908192e64224420e2d59dfd9b2e4309e154c5d) <sub>(2024-08-08 to 2024-08-15)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`3c977f1c` ➡️ `c7012d0c`](https://github.com/cachix/git-hooks.nix/compare/3c977f1c9930f54066c085305b4b2291385e7a73...c7012d0c18567c889b948781bc74a501e92275d1) <sub>(2024-08-07 to 2024-08-09)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`3b1600d0` ➡️ `5972437d`](https://github.com/nvim-telescope/telescope.nvim/compare/3b1600d0fd5172ad9fae00987362ca0ef3d8895d...5972437de807c3bc101565175da66a1aa4f8707a) <sub>(2024-08-02 to 2024-08-15)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`b3d5ea65` ➡️ `086f619d`](https://github.com/nix-community/home-manager/compare/b3d5ea65d88d67d4ec578ed11d4d2d51e3de525e...086f619dd991a4d355c07837448244029fc2d9ab) <sub>(2024-08-07 to 2024-08-11)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`b9913191` ➡️ `fd65422b`](https://github.com/neovim/neovim/compare/b9913191be0b4884d92db794e2eb92641523a415...fd65422b99c7cc69e5053a852244cfc9d46d7b65) <sub>(2024-08-08 to 2024-08-15)</sub>