### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723202784,
-        "narHash": "sha256-qbhjc/NEGaDbyy0ucycubq4N3//gDFFH3DOmp1D3u1Q=",
+        "lastModified": 1724227338,
+        "narHash": "sha256-TuSaYdhOxeaaE9885mFO1lZHHax33GD5A9dczJrGUjw=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "c7012d0c18567c889b948781bc74a501e92275d1",
+        "rev": "6cedaa7c1b4f82a266e5d30f212273e60d62cb0d",
         "type": "github"
       },
       "original": {
@@ -694,11 +694,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723399884,
-        "narHash": "sha256-97wn0ihhGqfMb8WcUgzzkM/TuAxce2Gd20A8oiruju4=",
+        "lastModified": 1724422166,
+        "narHash": "sha256-l9zifWrZe6sRTwl/Padz+a6zwGeE9eaU+0PFWtUQl2w=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "086f619dd991a4d355c07837448244029fc2d9ab",
+        "rev": "5dc25356567119127f046b347c3060a8dd607365",
         "type": "github"
       },
       "original": {
@@ -841,11 +841,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1722979597,
-        "narHash": "sha256-9TEQUCMUgoQ19Gpfs/3lcyR38yJMpNssGJsih3F9Nw8=",
+        "lastModified": 1724185291,
+        "narHash": "sha256-zPygc/M446bMdgK9Zy05HZKLrIy2bC9KSd+Xoghy980=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "b84eeb3641b08324287587b426ec974b888390d9",
+        "rev": "7ad2eaeaca56d6ed63acacbfc114b99f1f67b982",
         "type": "github"
       },
       "original": {
@@ -927,11 +927,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723796332,
-        "narHash": "sha256-V1eO+6leWxL4etUpgxi81kC9mOUIPo/gy4GXPqcgQ6E=",
+        "lastModified": 1724391918,
+        "narHash": "sha256-cE2PmF0Ayw/flzTL3aEtiak5QkBTp0z265CDWnUKoM8=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "b67c560eb553aa29f7e4efa729af61ff4d45c786",
+        "rev": "4fb7a5de4d5024a49bb60b7ff5ddb54252fe4622",
         "type": "github"
       },
       "original": {
@@ -943,11 +943,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1723747612,
-        "narHash": "sha256-e7QFAYeZSjhQ1H0mk2awv2KcXlsepzXki3uYEUBXZ8Q=",
+        "lastModified": 1724363148,
+        "narHash": "sha256-mvxaYMDkhOM0f1LEmu43u2qMtHkY40Me4bcP2XqQ9MM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "fd65422b99c7cc69e5053a852244cfc9d46d7b65",
+        "rev": "3b32869ced32821fb58f0a7c08094105be7bdaf0",
         "type": "github"
       },
       "original": {
@@ -1074,11 +1074,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1723703277,
-        "narHash": "sha256-nk0RaUB5f68BwtXAYy3WAjqFhVKqIl9Z89RGycTa2vk=",
+        "lastModified": 1724363052,
+        "narHash": "sha256-Nf/iQWamRVAwAPFccQMfm5Qcf+rLLnU1rWG3f9orDVE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8b908192e64224420e2d59dfd9b2e4309e154c5d",
+        "rev": "5de1564aed415bf9d0f281461babc2d101dd49ff",
         "type": "github"
       },
       "original": {
@@ -1219,11 +1219,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1723788573,
-        "narHash": "sha256-y64E6q6bB0kzJzxHnOYWjCZW5tpBTzhAVs/lvpmOpU0=",
+        "lastModified": 1724394001,
+        "narHash": "sha256-HqXMMxf4/wy+X9wT7CPpRMm+JLLfxQQnjtEJglhMSm8=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "a89de2e049b5f89a0ee55029d5a31213bd4de6f8",
+        "rev": "911167921d49cd5c1c9b2436031d0da3945e787f",
         "type": "github"
       },
       "original": {
@@ -1257,11 +1257,11 @@
     "plenary-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1716230027,
-        "narHash": "sha256-5Jf2mWFVDofXBcXLbMa417mqlEPWLA+cQIZH/vNEV1g=",
+        "lastModified": 1724044857,
+        "narHash": "sha256-6Gm+4zZ80quI5iAW6qPAWTq9h1csPWkZFZ9KnFgYRM0=",
         "owner": "nvim-lua",
         "repo": "plenary.nvim",
-        "rev": "a3e3bc82a3f95c5ed0d7201546d5d2c19b20d683",
+        "rev": "ec289423a1693aeae6cd0d503bac2856af74edaa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/086f619dd991a4d355c07837448244029fc2d9ab' (2024-08-11)
  → 'github:nix-community/home-manager/5dc25356567119127f046b347c3060a8dd607365' (2024-08-23)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/b84eeb3641b08324287587b426ec974b888390d9' (2024-08-06)
  → 'github:L3MON4D3/LuaSnip/7ad2eaeaca56d6ed63acacbfc114b99f1f67b982' (2024-08-20)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/b67c560eb553aa29f7e4efa729af61ff4d45c786' (2024-08-16)
  → 'github:nix-community/neovim-nightly-overlay/4fb7a5de4d5024a49bb60b7ff5ddb54252fe4622' (2024-08-23)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/c7012d0c18567c889b948781bc74a501e92275d1' (2024-08-09)
  → 'github:cachix/git-hooks.nix/6cedaa7c1b4f82a266e5d30f212273e60d62cb0d' (2024-08-21)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/fd65422b99c7cc69e5053a852244cfc9d46d7b65' (2024-08-15)
  → 'github:neovim/neovim/3b32869ced32821fb58f0a7c08094105be7bdaf0' (2024-08-22)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/8b908192e64224420e2d59dfd9b2e4309e154c5d' (2024-08-15)
  → 'github:nixos/nixpkgs/5de1564aed415bf9d0f281461babc2d101dd49ff' (2024-08-22)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/a89de2e049b5f89a0ee55029d5a31213bd4de6f8' (2024-08-16)
  → 'github:neovim/nvim-lspconfig/911167921d49cd5c1c9b2436031d0da3945e787f' (2024-08-23)
• Updated input 'plenary-nvim':
    'github:nvim-lua/plenary.nvim/a3e3bc82a3f95c5ed0d7201546d5d2c19b20d683' (2024-05-20)
  → 'github:nvim-lua/plenary.nvim/ec289423a1693aeae6cd0d503bac2856af74edaa' (2024-08-19)

```

</p></details>

 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`b67c560e` ➡️ `4fb7a5de`](https://github.com/nix-community/neovim-nightly-overlay/compare/b67c560eb553aa29f7e4efa729af61ff4d45c786...4fb7a5de4d5024a49bb60b7ff5ddb54252fe4622) <sub>(2024-08-16 to 2024-08-23)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`b84eeb36` ➡️ `7ad2eaea`](https://github.com/L3MON4D3/LuaSnip/compare/b84eeb3641b08324287587b426ec974b888390d9...7ad2eaeaca56d6ed63acacbfc114b99f1f67b982) <sub>(2024-08-06 to 2024-08-20)</sub>
 - Updated input [`plenary-nvim`](https://github.com/nvim-lua/plenary.nvim): [`a3e3bc82` ➡️ `ec289423`](https://github.com/nvim-lua/plenary.nvim/compare/a3e3bc82a3f95c5ed0d7201546d5d2c19b20d683...ec289423a1693aeae6cd0d503bac2856af74edaa) <sub>(2024-05-20 to 2024-08-19)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`a89de2e0` ➡️ `91116792`](https://github.com/neovim/nvim-lspconfig/compare/a89de2e049b5f89a0ee55029d5a31213bd4de6f8...911167921d49cd5c1c9b2436031d0da3945e787f) <sub>(2024-08-16 to 2024-08-23)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`8b908192` ➡️ `5de1564a`](https://github.com/nixos/nixpkgs/compare/8b908192e64224420e2d59dfd9b2e4309e154c5d...5de1564aed415bf9d0f281461babc2d101dd49ff) <sub>(2024-08-15 to 2024-08-22)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`c7012d0c` ➡️ `6cedaa7c`](https://github.com/cachix/git-hooks.nix/compare/c7012d0c18567c889b948781bc74a501e92275d1...6cedaa7c1b4f82a266e5d30f212273e60d62cb0d) <sub>(2024-08-09 to 2024-08-21)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`086f619d` ➡️ `5dc25356`](https://github.com/nix-community/home-manager/compare/086f619dd991a4d355c07837448244029fc2d9ab...5dc25356567119127f046b347c3060a8dd607365) <sub>(2024-08-11 to 2024-08-23)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`fd65422b` ➡️ `3b32869c`](https://github.com/neovim/neovim/compare/fd65422b99c7cc69e5053a852244cfc9d46d7b65...3b32869ced32821fb58f0a7c08094105be7bdaf0) <sub>(2024-08-15 to 2024-08-22)</sub>