### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -192,6 +192,22 @@
         "type": "github"
       }
     },
+    "flake-compat_8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -239,11 +255,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
         "type": "github"
       },
       "original": {
@@ -275,11 +291,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
         "type": "github"
       },
       "original": {
@@ -298,11 +314,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719994518,
-        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
         "type": "github"
       },
       "original": {
@@ -332,6 +348,24 @@
       "original": {
         "id": "flake-parts",
         "type": "indirect"
+      }
+    },
+    "flake-parts_8": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_4"
+      },
+      "locked": {
+        "lastModified": 1696343447,
+        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
       }
     },
     "flake-utils": {
@@ -439,14 +473,16 @@
     "gen-luarc": {
       "inputs": {
         "flake-parts": "flake-parts_4",
+        "git-hooks": "git-hooks_2",
+        "luvit-meta": "luvit-meta",
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1718922730,
-        "narHash": "sha256-ykhhOPqA9NzdNBr3ii+3h2DkK2+wasNqQLfMF6BXxTE=",
+        "lastModified": 1724097937,
+        "narHash": "sha256-Q4tgm8ZHAQUdvsNft86MqIbHQAm7OF7RT/wwYWXqSdY=",
         "owner": "mrcjkb",
         "repo": "nix-gen-luarc-json",
-        "rev": "021e8078e43884c6cdc70ca753d9a0b146cd55a4",
+        "rev": "b36b69c4ded9f31b079523bc452e23458734cf00",
         "type": "github"
       },
       "original": {
@@ -469,11 +505,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724227338,
-        "narHash": "sha256-TuSaYdhOxeaaE9885mFO1lZHHax33GD5A9dczJrGUjw=",
+        "lastModified": 1724857454,
+        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "6cedaa7c1b4f82a266e5d30f212273e60d62cb0d",
+        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
         "type": "github"
       },
       "original": {
@@ -484,17 +520,21 @@
     },
     "git-hooks_2": {
       "inputs": {
-        "flake-compat": "flake-compat_4",
+        "flake-compat": "flake-compat_3",
         "gitignore": "gitignore_2",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": [
+          "rustacean-nvim",
+          "gen-luarc",
+          "nixpkgs"
+        ],
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1721042469,
-        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
+        "lastModified": 1723803910,
+        "narHash": "sha256-yezvUuFiEnCFbGuwj/bQcqg7RykIEqudOy/RBrId0pc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
+        "rev": "bfef0ada09e2c8ac55bbcd0831bd0c9d42e651ba",
         "type": "github"
       },
       "original": {
@@ -505,8 +545,29 @@
     },
     "git-hooks_3": {
       "inputs": {
-        "flake-compat": "flake-compat_6",
+        "flake-compat": "flake-compat_5",
         "gitignore": "gitignore_3",
+        "nixpkgs": "nixpkgs_5",
+        "nixpkgs-stable": "nixpkgs-stable_2"
+      },
+      "locked": {
+        "lastModified": 1724440431,
+        "narHash": "sha256-9etXEOUtzeMgqg1u0wp+EdwG7RpmrAZ2yX516bMj2aE=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "c8a54057aae480c56e28ef3e14e4960628ac495b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks_4": {
+      "inputs": {
+        "flake-compat": "flake-compat_7",
+        "gitignore": "gitignore_4",
         "nixpkgs": [
           "rustacean-nvim",
           "neorocks",
@@ -521,11 +582,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721042469,
-        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
+        "lastModified": 1724227338,
+        "narHash": "sha256-TuSaYdhOxeaaE9885mFO1lZHHax33GD5A9dczJrGUjw=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
+        "rev": "6cedaa7c1b4f82a266e5d30f212273e60d62cb0d",
         "type": "github"
       },
       "original": {
@@ -560,7 +621,7 @@
       "inputs": {
         "nixpkgs": [
           "rustacean-nvim",
-          "neorocks",
+          "gen-luarc",
           "git-hooks",
           "nixpkgs"
         ]
@@ -584,7 +645,6 @@
         "nixpkgs": [
           "rustacean-nvim",
           "neorocks",
-          "neovim-nightly",
           "git-hooks",
           "nixpkgs"
         ]
@@ -604,6 +664,30 @@
       }
     },
     "gitignore_4": {
+      "inputs": {
+        "nixpkgs": [
+          "rustacean-nvim",
+          "neorocks",
+          "neovim-nightly",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_5": {
       "inputs": {
         "nixpkgs": [
           "rustacean-nvim",
@@ -628,11 +712,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1723029377,
-        "narHash": "sha256-NNoqXn24Fzkopx1/Xwcv41EpqHwpcMPrQWLfXcPtha4=",
+        "lastModified": 1724836172,
+        "narHash": "sha256-dy5Hc2yQMZ150G4mRyfSJe9nCMlW+4l548IQfzgoGUM=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "562dc47189ad3c8696dbf460d38603a74d544849",
+        "rev": "899e993850084ea33d001ec229d237bc020c19ae",
         "type": "github"
       },
       "original": {
@@ -650,11 +734,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719226092,
-        "narHash": "sha256-YNkUMcCUCpnULp40g+svYsaH1RbSEj6s4WdZY/SHe38=",
+        "lastModified": 1724947644,
+        "narHash": "sha256-MHHrHasTngp7EYQOObHJ1a/IsRF+wodHqOckhH6uZbk=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "11e4b8dc112e2f485d7c97e1cee77f9958f498f5",
+        "rev": "dba4367b9a9d9615456c430a6d6af716f6e84cef",
         "type": "github"
       },
       "original": {
@@ -694,11 +778,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724422166,
-        "narHash": "sha256-l9zifWrZe6sRTwl/Padz+a6zwGeE9eaU+0PFWtUQl2w=",
+        "lastModified": 1724435763,
+        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5dc25356567119127f046b347c3060a8dd607365",
+        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
         "type": "github"
       },
       "original": {
@@ -841,16 +925,32 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1724185291,
-        "narHash": "sha256-zPygc/M446bMdgK9Zy05HZKLrIy2bC9KSd+Xoghy980=",
+        "lastModified": 1724868934,
+        "narHash": "sha256-1b9hT6+wUoH31JUjWHaBOJMg2juMxoA1vPfme3zBEYg=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "7ad2eaeaca56d6ed63acacbfc114b99f1f67b982",
+        "rev": "45db5addf8d0a201e1cf247cae4cdce605ad3768",
         "type": "github"
       },
       "original": {
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
+        "type": "github"
+      }
+    },
+    "luvit-meta": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705776742,
+        "narHash": "sha256-zAAptV/oLuLAAsa2zSB/6fxlElk4+jNZd/cPr9oxFig=",
+        "owner": "Bilal2453",
+        "repo": "luvit-meta",
+        "rev": "ce76f6f6cdc9201523a5875a4471dcfe0186eb60",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Bilal2453",
+        "repo": "luvit-meta",
         "type": "github"
       }
     },
@@ -872,18 +972,18 @@
     },
     "neorocks": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
+        "flake-compat": "flake-compat_4",
         "flake-parts": "flake-parts_5",
-        "git-hooks": "git-hooks_2",
+        "git-hooks": "git-hooks_3",
         "neovim-nightly": "neovim-nightly",
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1721971601,
-        "narHash": "sha256-mvMOjRSSGEKkGEPrSgPC8xluMJYKqTtr0ik++jwAtXQ=",
+        "lastModified": 1724477135,
+        "narHash": "sha256-uoHYEefxVLWtAvWw41t11R8l7oQG7MgwvnA0FYVsY2s=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "2868f35af48fd893615a60b3c19f4f1131e2edcd",
+        "rev": "960271da8c15fced6314deecfd7ef6f77787326c",
         "type": "github"
       },
       "original": {
@@ -894,19 +994,19 @@
     },
     "neovim-nightly": {
       "inputs": {
-        "flake-compat": "flake-compat_5",
+        "flake-compat": "flake-compat_6",
         "flake-parts": "flake-parts_6",
-        "git-hooks": "git-hooks_3",
+        "git-hooks": "git-hooks_4",
         "hercules-ci-effects": "hercules-ci-effects_2",
         "neovim-src": "neovim-src_2",
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1721885903,
-        "narHash": "sha256-5tQKxRP67m4qIXUzO/R2nJgWpAhBUPUTGKDWW1zzr8g=",
+        "lastModified": 1724391918,
+        "narHash": "sha256-cE2PmF0Ayw/flzTL3aEtiak5QkBTp0z265CDWnUKoM8=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "9d4c7b114a00f0c9ec4145e5674fc28af04e6489",
+        "rev": "4fb7a5de4d5024a49bb60b7ff5ddb54252fe4622",
         "type": "github"
       },
       "original": {
@@ -927,11 +1027,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724391918,
-        "narHash": "sha256-cE2PmF0Ayw/flzTL3aEtiak5QkBTp0z265CDWnUKoM8=",
+        "lastModified": 1724996444,
+        "narHash": "sha256-bgDfNsVPleUyx6vNr5INJTLfkLycNmL3yvSBv1OguLs=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "4fb7a5de4d5024a49bb60b7ff5ddb54252fe4622",
+        "rev": "d0f68c980e3a0a3a8e63ccca93a01f87fb77937e",
         "type": "github"
       },
       "original": {
@@ -943,11 +1043,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1724363148,
-        "narHash": "sha256-mvxaYMDkhOM0f1LEmu43u2qMtHkY40Me4bcP2XqQ9MM=",
+        "lastModified": 1724970905,
+        "narHash": "sha256-6HqoxweeX3tQbchJpjUNiBKj/2P3oiQBR42B/QuB+a0=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "3b32869ced32821fb58f0a7c08094105be7bdaf0",
+        "rev": "4353996d0fa8e5872a334d68196d8088391960cf",
         "type": "github"
       },
       "original": {
@@ -959,11 +1059,11 @@
     "neovim-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1721830906,
-        "narHash": "sha256-Wa12HERoF7fCuAWta4X3HPveuxBjtRNMYasNE2QKmCY=",
+        "lastModified": 1724363148,
+        "narHash": "sha256-mvxaYMDkhOM0f1LEmu43u2qMtHkY40Me4bcP2XqQ9MM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "b4b4cf46a7a2b6d7b4e997179166444b0e338ac8",
+        "rev": "3b32869ced32821fb58f0a7c08094105be7bdaf0",
         "type": "github"
       },
       "original": {
@@ -1006,14 +1106,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1719876945,
-        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "lastModified": 1722555339,
+        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
       }
     },
     "nixpkgs-lib_2": {
@@ -1030,14 +1130,32 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1719876945,
-        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "lastModified": 1722555339,
+        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+      }
+    },
+    "nixpkgs-lib_4": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1696019113,
+        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-stable": {
@@ -1072,13 +1190,45 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable_3": {
+      "locked": {
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_10": {
+      "locked": {
+        "lastModified": 1697379843,
+        "narHash": "sha256-RcnGuJgC2K/UpTy+d32piEoBXq2M+nVFzM3ah/ZdJzg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1724363052,
-        "narHash": "sha256-Nf/iQWamRVAwAPFccQMfm5Qcf+rLLnU1rWG3f9orDVE=",
+        "lastModified": 1724999960,
+        "narHash": "sha256-LB3jqSGW5u1ZcUcX6vO/qBOq5oXHlmOCxsTXGMEitp4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5de1564aed415bf9d0f281461babc2d101dd49ff",
+        "rev": "b96f849e725333eb2b1c7f1cb84ff102062468ba",
         "type": "github"
       },
       "original": {
@@ -1138,11 +1288,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1721782431,
-        "narHash": "sha256-UNDpwjYxNXQet/g3mgRLsQ9zxrbm9j2JEvP4ijF3AWs=",
+        "lastModified": 1724300212,
+        "narHash": "sha256-x3jl6OWTs+L9C7EtscuWZmGZWI0iSBDafvg3X7JMa1A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4f02464258baaf54992debfd010a7a3662a25536",
+        "rev": "4de4818c1ffa76d57787af936e8a23648bda6be4",
         "type": "github"
       },
       "original": {
@@ -1154,11 +1304,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1721933792,
-        "narHash": "sha256-zYVwABlQnxpbaHMfX6Wt9jhyQstFYwN2XjleOJV3VVg=",
+        "lastModified": 1724363052,
+        "narHash": "sha256-Nf/iQWamRVAwAPFccQMfm5Qcf+rLLnU1rWG3f9orDVE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2122a9b35b35719ad9a395fe783eabb092df01b1",
+        "rev": "5de1564aed415bf9d0f281461babc2d101dd49ff",
         "type": "github"
       },
       "original": {
@@ -1170,11 +1320,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1721933792,
-        "narHash": "sha256-zYVwABlQnxpbaHMfX6Wt9jhyQstFYwN2XjleOJV3VVg=",
+        "lastModified": 1724395761,
+        "narHash": "sha256-zRkDV/nbrnp3Y8oCADf5ETl1sDrdmAW6/bBVJ8EbIdQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2122a9b35b35719ad9a395fe783eabb092df01b1",
+        "rev": "ae815cee91b417be55d43781eb4b73ae1ecc396c",
         "type": "github"
       },
       "original": {
@@ -1219,11 +1369,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1724394001,
-        "narHash": "sha256-HqXMMxf4/wy+X9wT7CPpRMm+JLLfxQQnjtEJglhMSm8=",
+        "lastModified": 1724912852,
+        "narHash": "sha256-y4rrxShB/fEH+U4UkU/iU/2NB3iLR37hreNuRidIokA=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "911167921d49cd5c1c9b2436031d0da3945e787f",
+        "rev": "6bfd9210e312af6cfedba05d272e85618c93ab0d",
         "type": "github"
       },
       "original": {
@@ -1272,17 +1422,17 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_7",
-        "gitignore": "gitignore_4",
+        "flake-compat": "flake-compat_8",
+        "gitignore": "gitignore_5",
         "nixpkgs": "nixpkgs_9",
-        "nixpkgs-stable": "nixpkgs-stable_2"
+        "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1721042469,
-        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
+        "lastModified": 1724440431,
+        "narHash": "sha256-9etXEOUtzeMgqg1u0wp+EdwG7RpmrAZ2yX516bMj2aE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
+        "rev": "c8a54057aae480c56e28ef3e14e4960628ac495b",
         "type": "github"
       },
       "original": {
@@ -1352,14 +1502,15 @@
         "gen-luarc": "gen-luarc",
         "neorocks": "neorocks",
         "nixpkgs": "nixpkgs_8",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "pre-commit-hooks": "pre-commit-hooks",
+        "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1723582024,
-        "narHash": "sha256-OYfeJuo4FZUBdW9wGGCT0lZGYr/ur1uy8frcyUJMF3k=",
+        "lastModified": 1724821124,
+        "narHash": "sha256-sxlPAhy9Aqabn7fHo+Ap1wlMVtIMRWqRaUcDASRGovA=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "7cba8e599deca98d4b44cac1bcbd720c62937d90",
+        "rev": "dc0785d56ee70d1c83c7c427015beb6c7e62920b",
         "type": "github"
       },
       "original": {
@@ -1442,6 +1593,25 @@
       "original": {
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
+        "type": "github"
+      }
+    },
+    "vimcats": {
+      "inputs": {
+        "flake-parts": "flake-parts_8",
+        "nixpkgs": "nixpkgs_10"
+      },
+      "locked": {
+        "lastModified": 1724691612,
+        "narHash": "sha256-YZPLZgC0v5zw/+X3r0G1MZ+46c0K8J3ClFQYH5BqbUE=",
+        "owner": "mrcjkb",
+        "repo": "vimcats",
+        "rev": "a51bfb9587f95b8fd6a588bdfe97b7f8f4b1e624",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mrcjkb",
+        "repo": "vimcats",
         "type": "github"
       }
     },


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/562dc47189ad3c8696dbf460d38603a74d544849' (2024-08-07)
  → 'github:lewis6991/gitsigns.nvim/899e993850084ea33d001ec229d237bc020c19ae' (2024-08-28)
• Updated input 'home-manager':
    'github:nix-community/home-manager/5dc25356567119127f046b347c3060a8dd607365' (2024-08-23)
  → 'github:nix-community/home-manager/c2cd2a52e02f1dfa1c88f95abeb89298d46023be' (2024-08-23)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/7ad2eaeaca56d6ed63acacbfc114b99f1f67b982' (2024-08-20)
  → 'github:L3MON4D3/LuaSnip/45db5addf8d0a201e1cf247cae4cdce605ad3768' (2024-08-28)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/4fb7a5de4d5024a49bb60b7ff5ddb54252fe4622' (2024-08-23)
  → 'github:nix-community/neovim-nightly-overlay/d0f68c980e3a0a3a8e63ccca93a01f87fb77937e' (2024-08-30)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/6cedaa7c1b4f82a266e5d30f212273e60d62cb0d' (2024-08-21)
  → 'github:cachix/git-hooks.nix/4509ca64f1084e73bc7a721b20c669a8d4c5ebe6' (2024-08-28)
• Updated input 'neovim-nightly-overlay/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/11e4b8dc112e2f485d7c97e1cee77f9958f498f5' (2024-06-24)
  → 'github:hercules-ci/hercules-ci-effects/dba4367b9a9d9615456c430a6d6af716f6e84cef' (2024-08-29)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/3b32869ced32821fb58f0a7c08094105be7bdaf0' (2024-08-22)
  → 'github:neovim/neovim/4353996d0fa8e5872a334d68196d8088391960cf' (2024-08-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5de1564aed415bf9d0f281461babc2d101dd49ff' (2024-08-22)
  → 'github:nixos/nixpkgs/b96f849e725333eb2b1c7f1cb84ff102062468ba' (2024-08-30)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/911167921d49cd5c1c9b2436031d0da3945e787f' (2024-08-23)
  → 'github:neovim/nvim-lspconfig/6bfd9210e312af6cfedba05d272e85618c93ab0d' (2024-08-29)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/7cba8e599deca98d4b44cac1bcbd720c62937d90' (2024-08-13)
  → 'github:mrcjkb/rustaceanvim/dc0785d56ee70d1c83c7c427015beb6c7e62920b' (2024-08-28)
• Updated input 'rustacean-nvim/flake-parts':
    'github:hercules-ci/flake-parts/9227223f6d922fee3c7b190b2cc238a99527bbb7' (2024-07-03)
  → 'github:hercules-ci/flake-parts/8471fe90ad337a8074e957b69ca4d0089218391d' (2024-08-01)
• Updated input 'rustacean-nvim/flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz?narHash=sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI%3D' (2024-07-01)
  → 'https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz?narHash=sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q%3D' (2024-08-01)
• Updated input 'rustacean-nvim/gen-luarc':
    'github:mrcjkb/nix-gen-luarc-json/021e8078e43884c6cdc70ca753d9a0b146cd55a4' (2024-06-20)
  → 'github:mrcjkb/nix-gen-luarc-json/b36b69c4ded9f31b079523bc452e23458734cf00' (2024-08-19)
• Added input 'rustacean-nvim/gen-luarc/git-hooks':
    'github:cachix/git-hooks.nix/bfef0ada09e2c8ac55bbcd0831bd0c9d42e651ba' (2024-08-16)
• Added input 'rustacean-nvim/gen-luarc/git-hooks/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
• Added input 'rustacean-nvim/gen-luarc/git-hooks/gitignore':
    'github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394' (2024-02-28)
• Added input 'rustacean-nvim/gen-luarc/git-hooks/gitignore/nixpkgs':
    follows 'rustacean-nvim/gen-luarc/git-hooks/nixpkgs'
• Added input 'rustacean-nvim/gen-luarc/git-hooks/nixpkgs':
    follows 'rustacean-nvim/gen-luarc/nixpkgs'
• Added input 'rustacean-nvim/gen-luarc/git-hooks/nixpkgs-stable':
    'github:NixOS/nixpkgs/194846768975b7ad2c4988bdb82572c00222c0d7' (2024-07-07)
• Added input 'rustacean-nvim/gen-luarc/luvit-meta':
    'github:Bilal2453/luvit-meta/ce76f6f6cdc9201523a5875a4471dcfe0186eb60' (2024-01-20)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/2868f35af48fd893615a60b3c19f4f1131e2edcd' (2024-07-26)
  → 'github:nvim-neorocks/neorocks/960271da8c15fced6314deecfd7ef6f77787326c' (2024-08-24)
• Updated input 'rustacean-nvim/neorocks/flake-parts':
    'github:hercules-ci/flake-parts/9227223f6d922fee3c7b190b2cc238a99527bbb7' (2024-07-03)
  → 'github:hercules-ci/flake-parts/8471fe90ad337a8074e957b69ca4d0089218391d' (2024-08-01)
• Updated input 'rustacean-nvim/neorocks/flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz?narHash=sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI%3D' (2024-07-01)
  → 'https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz?narHash=sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q%3D' (2024-08-01)
• Updated input 'rustacean-nvim/neorocks/git-hooks':
    'github:cachix/git-hooks.nix/f451c19376071a90d8c58ab1a953c6e9840527fd' (2024-07-15)
  → 'github:cachix/git-hooks.nix/c8a54057aae480c56e28ef3e14e4960628ac495b' (2024-08-23)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/9d4c7b114a00f0c9ec4145e5674fc28af04e6489' (2024-07-25)
  → 'github:nix-community/neovim-nightly-overlay/4fb7a5de4d5024a49bb60b7ff5ddb54252fe4622' (2024-08-23)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/flake-parts':
    'github:hercules-ci/flake-parts/9227223f6d922fee3c7b190b2cc238a99527bbb7' (2024-07-03)
  → 'github:hercules-ci/flake-parts/8471fe90ad337a8074e957b69ca4d0089218391d' (2024-08-01)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks':
    'github:cachix/git-hooks.nix/f451c19376071a90d8c58ab1a953c6e9840527fd' (2024-07-15)
  → 'github:cachix/git-hooks.nix/6cedaa7c1b4f82a266e5d30f212273e60d62cb0d' (2024-08-21)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/b4b4cf46a7a2b6d7b4e997179166444b0e338ac8' (2024-07-24)
  → 'github:neovim/neovim/3b32869ced32821fb58f0a7c08094105be7bdaf0' (2024-08-22)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/4f02464258baaf54992debfd010a7a3662a25536' (2024-07-24)
  → 'github:NixOS/nixpkgs/4de4818c1ffa76d57787af936e8a23648bda6be4' (2024-08-22)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/2122a9b35b35719ad9a395fe783eabb092df01b1' (2024-07-25)
  → 'github:nixos/nixpkgs/5de1564aed415bf9d0f281461babc2d101dd49ff' (2024-08-22)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/2122a9b35b35719ad9a395fe783eabb092df01b1' (2024-07-25)
  → 'github:nixos/nixpkgs/ae815cee91b417be55d43781eb4b73ae1ecc396c' (2024-08-23)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/f451c19376071a90d8c58ab1a953c6e9840527fd' (2024-07-15)
  → 'github:cachix/pre-commit-hooks.nix/c8a54057aae480c56e28ef3e14e4960628ac495b' (2024-08-23)
• Added input 'rustacean-nvim/vimcats':
    'github:mrcjkb/vimcats/a51bfb9587f95b8fd6a588bdfe97b7f8f4b1e624' (2024-08-26)
• Added input 'rustacean-nvim/vimcats/flake-parts':
    'github:hercules-ci/flake-parts/c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4' (2023-10-03)
• Added input 'rustacean-nvim/vimcats/flake-parts/nixpkgs-lib':
    'github:NixOS/nixpkgs/f5892ddac112a1e9b3612c39af1b72987ee5783a?dir=lib' (2023-09-29)
• Added input 'rustacean-nvim/vimcats/nixpkgs':
    'github:NixOS/nixpkgs/12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d' (2023-10-15)

```

</p></details>

 - Added input [`rustacean-nvim/vimcats/nixpkgs`](https://github.com/NixOS/nixpkgs): [github.com/NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/tree/12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d/)
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`9d4c7b11` ➡️ `4fb7a5de`](https://github.com/nix-community/neovim-nightly-overlay/compare/9d4c7b114a00f0c9ec4145e5674fc28af04e6489...4fb7a5de4d5024a49bb60b7ff5ddb54252fe4622) <sub>(2024-07-25 to 2024-08-23)</sub>
 - Updated input `rustacean-nvim/flake-parts/nixpkgs-lib`: `5daf0514` ➡️ `a5d39417` <sub>(2024-07-01 to 2024-08-01)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`7cba8e59` ➡️ `dc0785d5`](https://github.com/mrcjkb/rustaceanvim/compare/7cba8e599deca98d4b44cac1bcbd720c62937d90...dc0785d56ee70d1c83c7c427015beb6c7e62920b) <sub>(2024-08-13 to 2024-08-28)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`2122a9b3` ➡️ `5de1564a`](https://github.com/nixos/nixpkgs/compare/2122a9b35b35719ad9a395fe783eabb092df01b1...5de1564aed415bf9d0f281461babc2d101dd49ff) <sub>(2024-07-25 to 2024-08-22)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`2868f35a` ➡️ `960271da`](https://github.com/nvim-neorocks/neorocks/compare/2868f35af48fd893615a60b3c19f4f1131e2edcd...960271da8c15fced6314deecfd7ef6f77787326c) <sub>(2024-07-26 to 2024-08-24)</sub>
 - Added input [`rustacean-nvim/vimcats/flake-parts`](https://github.com/hercules-ci/flake-parts): [github.com/hercules-ci/flake-parts](https://github.com/hercules-ci/flake-parts/tree/c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4/)
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [`b4b4cf46` ➡️ `3b32869c`](https://github.com/neovim/neovim/compare/b4b4cf46a7a2b6d7b4e997179166444b0e338ac8...3b32869ced32821fb58f0a7c08094105be7bdaf0) <sub>(2024-07-24 to 2024-08-22)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`4fb7a5de` ➡️ `d0f68c98`](https://github.com/nix-community/neovim-nightly-overlay/compare/4fb7a5de4d5024a49bb60b7ff5ddb54252fe4622...d0f68c980e3a0a3a8e63ccca93a01f87fb77937e) <sub>(2024-08-23 to 2024-08-30)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`7ad2eaea` ➡️ `45db5add`](https://github.com/L3MON4D3/LuaSnip/compare/7ad2eaeaca56d6ed63acacbfc114b99f1f67b982...45db5addf8d0a201e1cf247cae4cdce605ad3768) <sub>(2024-08-20 to 2024-08-28)</sub>
 - Added input [`rustacean-nvim/vimcats/flake-parts/nixpkgs-lib`](https://github.com/NixOS/nixpkgs): [github.com/NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/tree/f5892ddac112a1e9b3612c39af1b72987ee5783a/)
 - Added input [`rustacean-nvim/gen-luarc/git-hooks/flake-compat`](https://github.com/edolstra/flake-compat): [github.com/edolstra/flake-compat](https://github.com/edolstra/flake-compat/tree/0f9255e01c2351cc7d116c072cb317785dd33b33/)
 - Updated input `rustacean-nvim/neorocks/flake-parts/nixpkgs-lib`: `5daf0514` ➡️ `a5d39417` <sub>(2024-07-01 to 2024-08-01)</sub>
 - Added input `rustacean-nvim/gen-luarc/git-hooks/gitignore/nixpkgs`: ``
 - Updated input [`rustacean-nvim/flake-parts`](https://github.com/hercules-ci/flake-parts): [`9227223f` ➡️ `8471fe90`](https://github.com/hercules-ci/flake-parts/compare/9227223f6d922fee3c7b190b2cc238a99527bbb7...8471fe90ad337a8074e957b69ca4d0089218391d) <sub>(2024-07-03 to 2024-08-01)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`91116792` ➡️ `6bfd9210`](https://github.com/neovim/nvim-lspconfig/compare/911167921d49cd5c1c9b2436031d0da3945e787f...6bfd9210e312af6cfedba05d272e85618c93ab0d) <sub>(2024-08-23 to 2024-08-29)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`f451c193` ➡️ `c8a54057`](https://github.com/cachix/pre-commit-hooks.nix/compare/f451c19376071a90d8c58ab1a953c6e9840527fd...c8a54057aae480c56e28ef3e14e4960628ac495b) <sub>(2024-07-15 to 2024-08-23)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`2122a9b3` ➡️ `ae815cee`](https://github.com/nixos/nixpkgs/compare/2122a9b35b35719ad9a395fe783eabb092df01b1...ae815cee91b417be55d43781eb4b73ae1ecc396c) <sub>(2024-07-25 to 2024-08-23)</sub>
 - Added input [`rustacean-nvim/gen-luarc/luvit-meta`](https://github.com/Bilal2453/luvit-meta): [github.com/Bilal2453/luvit-meta](https://github.com/Bilal2453/luvit-meta/tree/ce76f6f6cdc9201523a5875a4471dcfe0186eb60/)
 - Updated input [`neovim-nightly-overlay/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`11e4b8dc` ➡️ `dba4367b`](https://github.com/hercules-ci/hercules-ci-effects/compare/11e4b8dc112e2f485d7c97e1cee77f9958f498f5...dba4367b9a9d9615456c430a6d6af716f6e84cef) <sub>(2024-06-24 to 2024-08-29)</sub>
 - Updated input [`rustacean-nvim/neorocks/git-hooks`](https://github.com/cachix/git-hooks.nix): [`f451c193` ➡️ `c8a54057`](https://github.com/cachix/git-hooks.nix/compare/f451c19376071a90d8c58ab1a953c6e9840527fd...c8a54057aae480c56e28ef3e14e4960628ac495b) <sub>(2024-07-15 to 2024-08-23)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`562dc471` ➡️ `899e9938`](https://github.com/lewis6991/gitsigns.nvim/compare/562dc47189ad3c8696dbf460d38603a74d544849...899e993850084ea33d001ec229d237bc020c19ae) <sub>(2024-08-07 to 2024-08-28)</sub>
 - Added input [`rustacean-nvim/vimcats`](https://github.com/mrcjkb/vimcats): [github.com/mrcjkb/vimcats](https://github.com/mrcjkb/vimcats/tree/a51bfb9587f95b8fd6a588bdfe97b7f8f4b1e624/)
 - Added input [`rustacean-nvim/gen-luarc/git-hooks/nixpkgs-stable`](https://github.com/NixOS/nixpkgs): [github.com/NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/tree/194846768975b7ad2c4988bdb82572c00222c0d7/)
 - Added input [`rustacean-nvim/gen-luarc/git-hooks/gitignore`](https://github.com/hercules-ci/gitignore.nix): [github.com/hercules-ci/gitignore.nix](https://github.com/hercules-ci/gitignore.nix/tree/637db329424fd7e46cf4185293b9cc8c88c95394/)
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`5de1564a` ➡️ `b96f849e`](https://github.com/nixos/nixpkgs/compare/5de1564aed415bf9d0f281461babc2d101dd49ff...b96f849e725333eb2b1c7f1cb84ff102062468ba) <sub>(2024-08-22 to 2024-08-30)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`6cedaa7c` ➡️ `4509ca64`](https://github.com/cachix/git-hooks.nix/compare/6cedaa7c1b4f82a266e5d30f212273e60d62cb0d...4509ca64f1084e73bc7a721b20c669a8d4c5ebe6) <sub>(2024-08-21 to 2024-08-28)</sub>
 - Added input [`rustacean-nvim/gen-luarc/git-hooks`](https://github.com/cachix/git-hooks.nix): [github.com/cachix/git-hooks.nix](https://github.com/cachix/git-hooks.nix/tree/bfef0ada09e2c8ac55bbcd0831bd0c9d42e651ba/)
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`4f024642` ➡️ `4de4818c`](https://github.com/NixOS/nixpkgs/compare/4f02464258baaf54992debfd010a7a3662a25536...4de4818c1ffa76d57787af936e8a23648bda6be4) <sub>(2024-07-24 to 2024-08-22)</sub>
 - Updated input [`rustacean-nvim/neorocks/flake-parts`](https://github.com/hercules-ci/flake-parts): [`9227223f` ➡️ `8471fe90`](https://github.com/hercules-ci/flake-parts/compare/9227223f6d922fee3c7b190b2cc238a99527bbb7...8471fe90ad337a8074e957b69ca4d0089218391d) <sub>(2024-07-03 to 2024-08-01)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks`](https://github.com/cachix/git-hooks.nix): [`f451c193` ➡️ `6cedaa7c`](https://github.com/cachix/git-hooks.nix/compare/f451c19376071a90d8c58ab1a953c6e9840527fd...6cedaa7c1b4f82a266e5d30f212273e60d62cb0d) <sub>(2024-07-15 to 2024-08-21)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`5dc25356` ➡️ `c2cd2a52`](https://github.com/nix-community/home-manager/compare/5dc25356567119127f046b347c3060a8dd607365...c2cd2a52e02f1dfa1c88f95abeb89298d46023be) <sub>(2024-08-23 to 2024-08-23)</sub>
 - Updated input [`rustacean-nvim/gen-luarc`](https://github.com/mrcjkb/nix-gen-luarc-json): [`021e8078` ➡️ `b36b69c4`](https://github.com/mrcjkb/nix-gen-luarc-json/compare/021e8078e43884c6cdc70ca753d9a0b146cd55a4...b36b69c4ded9f31b079523bc452e23458734cf00) <sub>(2024-06-20 to 2024-08-19)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`3b32869c` ➡️ `4353996d`](https://github.com/neovim/neovim/compare/3b32869ced32821fb58f0a7c08094105be7bdaf0...4353996d0fa8e5872a334d68196d8088391960cf) <sub>(2024-08-22 to 2024-08-29)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/flake-parts`](https://github.com/hercules-ci/flake-parts): [`9227223f` ➡️ `8471fe90`](https://github.com/hercules-ci/flake-parts/compare/9227223f6d922fee3c7b190b2cc238a99527bbb7...8471fe90ad337a8074e957b69ca4d0089218391d) <sub>(2024-07-03 to 2024-08-01)</sub>
 - Added input `rustacean-nvim/gen-luarc/git-hooks/nixpkgs`: ``