### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1725234343,
+        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
         "type": "github"
       },
       "original": {
@@ -425,11 +425,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1721347143,
-        "narHash": "sha256-NLHaXpPrb4/QuVuTjl6YUUKA3/1r4VCOaNO48Dk9pms=",
+        "lastModified": 1725302615,
+        "narHash": "sha256-lFG5zmBPzmDda8LWJ4XjYEpA6QCLOq2hf14qvcHX7Ng=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "0444df68cd1cdabc7453d6bd84099458327e5513",
+        "rev": "1d18c696c4284e9ce9467a5c04d3adf8af43f994",
         "type": "github"
       },
       "original": {
@@ -505,11 +505,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724857454,
-        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
+        "lastModified": 1725513492,
+        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
+        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
         "type": "github"
       },
       "original": {
@@ -712,11 +712,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1724836172,
-        "narHash": "sha256-dy5Hc2yQMZ150G4mRyfSJe9nCMlW+4l548IQfzgoGUM=",
+        "lastModified": 1725453693,
+        "narHash": "sha256-s3y8ZuLV00GIhizcK/zqsJOTKecql7Xn3LGYmH7NLsQ=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "899e993850084ea33d001ec229d237bc020c19ae",
+        "rev": "1ef74b546732f185d0f806860fa5404df7614f28",
         "type": "github"
       },
       "original": {
@@ -778,11 +778,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724435763,
-        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
+        "lastModified": 1725628988,
+        "narHash": "sha256-Y6TBMTGu4bddUwszGjlcOuN0soVc1Gv43hp+1sT/GNI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
+        "rev": "127ccc3eb7e36fa75e8c3fbd8a343154f66cc1c6",
         "type": "github"
       },
       "original": {
@@ -812,11 +812,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1722636442,
-        "narHash": "sha256-+7IS0n3/F0I5j6ZbrVlLcIIPHY3o+/vLAqg/G48sG+w=",
+        "lastModified": 1725551787,
+        "narHash": "sha256-6LgsZHz8w3g4c9bRUwRAR+WIMwFGGf3P1VZQcKNRf2o=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "9d67858b437d4a1299be496d371b66fc0d3e01f6",
+        "rev": "1e531dc49ad36c88b45bf836081a7a2c8927e072",
         "type": "github"
       },
       "original": {
@@ -1027,11 +1027,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724996444,
-        "narHash": "sha256-bgDfNsVPleUyx6vNr5INJTLfkLycNmL3yvSBv1OguLs=",
+        "lastModified": 1725621813,
+        "narHash": "sha256-PULZxwVju7sX7YTDiu2Gr15htFEEoMJ95ZZ6FGj+qa0=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "d0f68c980e3a0a3a8e63ccca93a01f87fb77937e",
+        "rev": "f751e2e0c00a9393410361b205f42658611ae89b",
         "type": "github"
       },
       "original": {
@@ -1043,11 +1043,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1724970905,
-        "narHash": "sha256-6HqoxweeX3tQbchJpjUNiBKj/2P3oiQBR42B/QuB+a0=",
+        "lastModified": 1725578611,
+        "narHash": "sha256-sRezYqvmEjS/TIumXiwIN+ttuEPhNNtDnUY7wCpSCAs=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "4353996d0fa8e5872a334d68196d8088391960cf",
+        "rev": "9570ad24f52442d75d677412cfe2fa83a7ff7a88",
         "type": "github"
       },
       "original": {
@@ -1224,11 +1224,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1724999960,
-        "narHash": "sha256-LB3jqSGW5u1ZcUcX6vO/qBOq5oXHlmOCxsTXGMEitp4=",
+        "lastModified": 1725534445,
+        "narHash": "sha256-Yd0FK9SkWy+ZPuNqUgmVPXokxDgMJoGuNpMEtkfcf84=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b96f849e725333eb2b1c7f1cb84ff102062468ba",
+        "rev": "9bb1e7571aadf31ddb4af77fc64b2d59580f9a39",
         "type": "github"
       },
       "original": {
@@ -1369,11 +1369,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1724912852,
-        "narHash": "sha256-y4rrxShB/fEH+U4UkU/iU/2NB3iLR37hreNuRidIokA=",
+        "lastModified": 1725524791,
+        "narHash": "sha256-xel86Ebobiv7dgudH3+BfSOoE7XLnvMne8Jj5cItAp4=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "6bfd9210e312af6cfedba05d272e85618c93ab0d",
+        "rev": "bdbc65aadc708ce528efb22bca5f82a7cca6b54d",
         "type": "github"
       },
       "original": {
@@ -1506,11 +1506,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1724821124,
-        "narHash": "sha256-sxlPAhy9Aqabn7fHo+Ap1wlMVtIMRWqRaUcDASRGovA=",
+        "lastModified": 1725440651,
+        "narHash": "sha256-redx/Dj+R9zTaZLhwYrDtCUL664/ETs9+FQyFGnnPQU=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "dc0785d56ee70d1c83c7c427015beb6c7e62920b",
+        "rev": "3fd3e5c187ad7155d8bf1a689fa5b651407ab22e",
         "type": "github"
       },
       "original": {
@@ -1618,11 +1618,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1722734411,
-        "narHash": "sha256-TeWMlfNTA5+tiPq6D2TVWjdfJVr3FOwpqUDU8kfFZ8E=",
+        "lastModified": 1725592915,
+        "narHash": "sha256-2X72Xv+S9mZ79x1k28LxKH7RnARwB3ZHGGSzIkeuWj8=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "3722e3d1fb5fe1896a104eb489e8f8651260b520",
+        "rev": "9793801f974bba70e4ac5d7eae6c4f5659993d8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/0444df68cd1cdabc7453d6bd84099458327e5513' (2024-07-18)
  → 'github:tpope/vim-fugitive/1d18c696c4284e9ce9467a5c04d3adf8af43f994' (2024-09-02)
• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/899e993850084ea33d001ec229d237bc020c19ae' (2024-08-28)
  → 'github:lewis6991/gitsigns.nvim/1ef74b546732f185d0f806860fa5404df7614f28' (2024-09-04)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c2cd2a52e02f1dfa1c88f95abeb89298d46023be' (2024-08-23)
  → 'github:nix-community/home-manager/127ccc3eb7e36fa75e8c3fbd8a343154f66cc1c6' (2024-09-06)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/9d67858b437d4a1299be496d371b66fc0d3e01f6' (2024-08-02)
  → 'github:hyprwm/contrib/1e531dc49ad36c88b45bf836081a7a2c8927e072' (2024-09-05)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/d0f68c980e3a0a3a8e63ccca93a01f87fb77937e' (2024-08-30)
  → 'github:nix-community/neovim-nightly-overlay/f751e2e0c00a9393410361b205f42658611ae89b' (2024-09-06)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/8471fe90ad337a8074e957b69ca4d0089218391d' (2024-08-01)
  → 'github:hercules-ci/flake-parts/567b938d64d4b4112ee253b9274472dc3a346eb6' (2024-09-01)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/4509ca64f1084e73bc7a721b20c669a8d4c5ebe6' (2024-08-28)
  → 'github:cachix/git-hooks.nix/7570de7b9b504cfe92025dd1be797bf546f66528' (2024-09-05)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/4353996d0fa8e5872a334d68196d8088391960cf' (2024-08-29)
  → 'github:neovim/neovim/9570ad24f52442d75d677412cfe2fa83a7ff7a88' (2024-09-05)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b96f849e725333eb2b1c7f1cb84ff102062468ba' (2024-08-30)
  → 'github:nixos/nixpkgs/9bb1e7571aadf31ddb4af77fc64b2d59580f9a39' (2024-09-05)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/6bfd9210e312af6cfedba05d272e85618c93ab0d' (2024-08-29)
  → 'github:neovim/nvim-lspconfig/bdbc65aadc708ce528efb22bca5f82a7cca6b54d' (2024-09-05)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/dc0785d56ee70d1c83c7c427015beb6c7e62920b' (2024-08-28)
  → 'github:mrcjkb/rustaceanvim/3fd3e5c187ad7155d8bf1a689fa5b651407ab22e' (2024-09-04)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/3722e3d1fb5fe1896a104eb489e8f8651260b520' (2024-08-04)
  → 'github:nvim-tree/nvim-web-devicons/9793801f974bba70e4ac5d7eae6c4f5659993d8e' (2024-09-06)

```

</p></details>

 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`dc0785d5` ➡️ `3fd3e5c1`](https://github.com/mrcjkb/rustaceanvim/compare/dc0785d56ee70d1c83c7c427015beb6c7e62920b...3fd3e5c187ad7155d8bf1a689fa5b651407ab22e) <sub>(2024-08-28 to 2024-09-04)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`0444df68` ➡️ `1d18c696`](https://github.com/tpope/vim-fugitive/compare/0444df68cd1cdabc7453d6bd84099458327e5513...1d18c696c4284e9ce9467a5c04d3adf8af43f994) <sub>(2024-07-18 to 2024-09-02)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`d0f68c98` ➡️ `f751e2e0`](https://github.com/nix-community/neovim-nightly-overlay/compare/d0f68c980e3a0a3a8e63ccca93a01f87fb77937e...f751e2e0c00a9393410361b205f42658611ae89b) <sub>(2024-08-30 to 2024-09-06)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`9d67858b` ➡️ `1e531dc4`](https://github.com/hyprwm/contrib/compare/9d67858b437d4a1299be496d371b66fc0d3e01f6...1e531dc49ad36c88b45bf836081a7a2c8927e072) <sub>(2024-08-02 to 2024-09-05)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`6bfd9210` ➡️ `bdbc65aa`](https://github.com/neovim/nvim-lspconfig/compare/6bfd9210e312af6cfedba05d272e85618c93ab0d...bdbc65aadc708ce528efb22bca5f82a7cca6b54d) <sub>(2024-08-29 to 2024-09-05)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`899e9938` ➡️ `1ef74b54`](https://github.com/lewis6991/gitsigns.nvim/compare/899e993850084ea33d001ec229d237bc020c19ae...1ef74b546732f185d0f806860fa5404df7614f28) <sub>(2024-08-28 to 2024-09-04)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`b96f849e` ➡️ `9bb1e757`](https://github.com/nixos/nixpkgs/compare/b96f849e725333eb2b1c7f1cb84ff102062468ba...9bb1e7571aadf31ddb4af77fc64b2d59580f9a39) <sub>(2024-08-30 to 2024-09-05)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`4509ca64` ➡️ `7570de7b`](https://github.com/cachix/git-hooks.nix/compare/4509ca64f1084e73bc7a721b20c669a8d4c5ebe6...7570de7b9b504cfe92025dd1be797bf546f66528) <sub>(2024-08-28 to 2024-09-05)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`3722e3d1` ➡️ `9793801f`](https://github.com/nvim-tree/nvim-web-devicons/compare/3722e3d1fb5fe1896a104eb489e8f8651260b520...9793801f974bba70e4ac5d7eae6c4f5659993d8e) <sub>(2024-08-04 to 2024-09-06)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`c2cd2a52` ➡️ `127ccc3e`](https://github.com/nix-community/home-manager/compare/c2cd2a52e02f1dfa1c88f95abeb89298d46023be...127ccc3eb7e36fa75e8c3fbd8a343154f66cc1c6) <sub>(2024-08-23 to 2024-09-06)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`4353996d` ➡️ `9570ad24`](https://github.com/neovim/neovim/compare/4353996d0fa8e5872a334d68196d8088391960cf...9570ad24f52442d75d677412cfe2fa83a7ff7a88) <sub>(2024-08-29 to 2024-09-05)</sub>
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`8471fe90` ➡️ `567b938d`](https://github.com/hercules-ci/flake-parts/compare/8471fe90ad337a8074e957b69ca4d0089218391d...567b938d64d4b4112ee253b9274472dc3a346eb6) <sub>(2024-08-01 to 2024-09-01)</sub>