### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -216,11 +216,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725234343,
-        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1725234343,
+        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1725234343,
+        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
         "type": "github"
       },
       "original": {
@@ -314,11 +314,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1725234343,
+        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
         "type": "github"
       },
       "original": {
@@ -425,11 +425,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1725302615,
-        "narHash": "sha256-lFG5zmBPzmDda8LWJ4XjYEpA6QCLOq2hf14qvcHX7Ng=",
+        "lastModified": 1725670815,
+        "narHash": "sha256-ArYerBws+MBY4BpKh16J5TfVTrA0OFKPoZq7c2YQjp0=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "1d18c696c4284e9ce9467a5c04d3adf8af43f994",
+        "rev": "d4877e54cef67f5af4f950935b1ade19ed6b7370",
         "type": "github"
       },
       "original": {
@@ -551,11 +551,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1724440431,
-        "narHash": "sha256-9etXEOUtzeMgqg1u0wp+EdwG7RpmrAZ2yX516bMj2aE=",
+        "lastModified": 1725513492,
+        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "c8a54057aae480c56e28ef3e14e4960628ac495b",
+        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
         "type": "github"
       },
       "original": {
@@ -582,11 +582,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724227338,
-        "narHash": "sha256-TuSaYdhOxeaaE9885mFO1lZHHax33GD5A9dczJrGUjw=",
+        "lastModified": 1725513492,
+        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "6cedaa7c1b4f82a266e5d30f212273e60d62cb0d",
+        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
         "type": "github"
       },
       "original": {
@@ -758,11 +758,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719226092,
-        "narHash": "sha256-YNkUMcCUCpnULp40g+svYsaH1RbSEj6s4WdZY/SHe38=",
+        "lastModified": 1724947644,
+        "narHash": "sha256-MHHrHasTngp7EYQOObHJ1a/IsRF+wodHqOckhH6uZbk=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "11e4b8dc112e2f485d7c97e1cee77f9958f498f5",
+        "rev": "dba4367b9a9d9615456c430a6d6af716f6e84cef",
         "type": "github"
       },
       "original": {
@@ -778,11 +778,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725628988,
-        "narHash": "sha256-Y6TBMTGu4bddUwszGjlcOuN0soVc1Gv43hp+1sT/GNI=",
+        "lastModified": 1726222338,
+        "narHash": "sha256-KuA8ciNR8qCF3dQaCaeh0JWyQUgEwkwDHr/f49Q5/e8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "127ccc3eb7e36fa75e8c3fbd8a343154f66cc1c6",
+        "rev": "503af483e1b328691ea3a434d331995595fb2e3d",
         "type": "github"
       },
       "original": {
@@ -925,11 +925,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1724868934,
-        "narHash": "sha256-1b9hT6+wUoH31JUjWHaBOJMg2juMxoA1vPfme3zBEYg=",
+        "lastModified": 1726165831,
+        "narHash": "sha256-nkaa1NGOI28Et2QitQB+Spv+J42QVdHE1oywteLcJJw=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "45db5addf8d0a201e1cf247cae4cdce605ad3768",
+        "rev": "e808bee352d1a6fcf902ca1a71cee76e60e24071",
         "type": "github"
       },
       "original": {
@@ -979,11 +979,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1724477135,
-        "narHash": "sha256-uoHYEefxVLWtAvWw41t11R8l7oQG7MgwvnA0FYVsY2s=",
+        "lastModified": 1725686700,
+        "narHash": "sha256-wCjTrQhEcsU3Gb4wUzKZgJzD/Ydm+cwU+wzRUAhwua0=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "960271da8c15fced6314deecfd7ef6f77787326c",
+        "rev": "b4ecf2fc5d258e2d8754d573785209098877fa93",
         "type": "github"
       },
       "original": {
@@ -1002,11 +1002,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1724391918,
-        "narHash": "sha256-cE2PmF0Ayw/flzTL3aEtiak5QkBTp0z265CDWnUKoM8=",
+        "lastModified": 1725621813,
+        "narHash": "sha256-PULZxwVju7sX7YTDiu2Gr15htFEEoMJ95ZZ6FGj+qa0=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "4fb7a5de4d5024a49bb60b7ff5ddb54252fe4622",
+        "rev": "f751e2e0c00a9393410361b205f42658611ae89b",
         "type": "github"
       },
       "original": {
@@ -1027,11 +1027,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725621813,
-        "narHash": "sha256-PULZxwVju7sX7YTDiu2Gr15htFEEoMJ95ZZ6FGj+qa0=",
+        "lastModified": 1726189029,
+        "narHash": "sha256-A6rw8kgxTDmuGD6D8kooF9V++iAeXXgqay0vKG/zi/M=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "f751e2e0c00a9393410361b205f42658611ae89b",
+        "rev": "3b426df85fb2edc0da26673c464709e9c8b0c654",
         "type": "github"
       },
       "original": {
@@ -1041,6 +1041,22 @@
       }
     },
     "neovim-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1726157817,
+        "narHash": "sha256-Vu2rOpAKlEFu+dGewEBsnAuHHxj8XbGqF52WGmu1NNY=",
+        "owner": "neovim",
+        "repo": "neovim",
+        "rev": "deac7df80a1491ae65b68a1a1047902bcd775adc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "neovim",
+        "repo": "neovim",
+        "type": "github"
+      }
+    },
+    "neovim-src_2": {
       "flake": false,
       "locked": {
         "lastModified": 1725578611,
@@ -1056,30 +1072,14 @@
         "type": "github"
       }
     },
-    "neovim-src_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1724363148,
-        "narHash": "sha256-mvxaYMDkhOM0f1LEmu43u2qMtHkY40Me4bcP2XqQ9MM=",
-        "owner": "neovim",
-        "repo": "neovim",
-        "rev": "3b32869ced32821fb58f0a7c08094105be7bdaf0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "neovim",
-        "repo": "neovim",
-        "type": "github"
-      }
-    },
     "nightfox-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1721661222,
-        "narHash": "sha256-2efugsL7pbQ78XxwWRybnfxhuqe7LSUgpTlwcJJTAX0=",
+        "lastModified": 1725836615,
+        "narHash": "sha256-fVHC3FfGeRGYtB1MKpmLSITk9TDBY/yDCOlQuKvAH5I=",
         "owner": "EdenEast",
         "repo": "nightfox.nvim",
-        "rev": "d3e8b1acc095baf57af81bb5e89fe7c4359eb619",
+        "rev": "7557f26defd093c4e9bc17f28b08403f706f5a44",
         "type": "github"
       },
       "original": {
@@ -1106,14 +1106,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1722555339,
-        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "lastModified": 1725233747,
+        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       }
     },
     "nixpkgs-lib_2": {
@@ -1130,14 +1130,14 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1722555339,
-        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "lastModified": 1725233747,
+        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       }
     },
     "nixpkgs-lib_4": {
@@ -1224,11 +1224,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1725534445,
-        "narHash": "sha256-Yd0FK9SkWy+ZPuNqUgmVPXokxDgMJoGuNpMEtkfcf84=",
+        "lastModified": 1726142289,
+        "narHash": "sha256-Jks8O42La+nm5AMTSq/PvM5O+fUAhIy0Ce1QYqLkyZ4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9bb1e7571aadf31ddb4af77fc64b2d59580f9a39",
+        "rev": "280db3decab4cbeb22a4599bd472229ab74d25e1",
         "type": "github"
       },
       "original": {
@@ -1288,11 +1288,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1724300212,
-        "narHash": "sha256-x3jl6OWTs+L9C7EtscuWZmGZWI0iSBDafvg3X7JMa1A=",
+        "lastModified": 1725503534,
+        "narHash": "sha256-hd1eRyPtTkRnAPYpnEfzugQwAifVYMmOR3z+MTTSw+g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4de4818c1ffa76d57787af936e8a23648bda6be4",
+        "rev": "fcb54ddcc974cff59bdfb7c1ac9e080299763d2d",
         "type": "github"
       },
       "original": {
@@ -1304,11 +1304,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1724363052,
-        "narHash": "sha256-Nf/iQWamRVAwAPFccQMfm5Qcf+rLLnU1rWG3f9orDVE=",
+        "lastModified": 1725534445,
+        "narHash": "sha256-Yd0FK9SkWy+ZPuNqUgmVPXokxDgMJoGuNpMEtkfcf84=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5de1564aed415bf9d0f281461babc2d101dd49ff",
+        "rev": "9bb1e7571aadf31ddb4af77fc64b2d59580f9a39",
         "type": "github"
       },
       "original": {
@@ -1320,11 +1320,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1724395761,
-        "narHash": "sha256-zRkDV/nbrnp3Y8oCADf5ETl1sDrdmAW6/bBVJ8EbIdQ=",
+        "lastModified": 1725534445,
+        "narHash": "sha256-Yd0FK9SkWy+ZPuNqUgmVPXokxDgMJoGuNpMEtkfcf84=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ae815cee91b417be55d43781eb4b73ae1ecc396c",
+        "rev": "9bb1e7571aadf31ddb4af77fc64b2d59580f9a39",
         "type": "github"
       },
       "original": {
@@ -1369,11 +1369,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1725524791,
-        "narHash": "sha256-xel86Ebobiv7dgudH3+BfSOoE7XLnvMne8Jj5cItAp4=",
+        "lastModified": 1726121715,
+        "narHash": "sha256-QfU7Xywjqw5S55gOBtQ10S5fK7wyFqhKzBwqCRoejQQ=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "bdbc65aadc708ce528efb22bca5f82a7cca6b54d",
+        "rev": "bb682c167a0878338b4313b55538953d1c039085",
         "type": "github"
       },
       "original": {
@@ -1428,11 +1428,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1724440431,
-        "narHash": "sha256-9etXEOUtzeMgqg1u0wp+EdwG7RpmrAZ2yX516bMj2aE=",
+        "lastModified": 1725513492,
+        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c8a54057aae480c56e28ef3e14e4960628ac495b",
+        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
         "type": "github"
       },
       "original": {
@@ -1506,11 +1506,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1725440651,
-        "narHash": "sha256-redx/Dj+R9zTaZLhwYrDtCUL664/ETs9+FQyFGnnPQU=",
+        "lastModified": 1726158967,
+        "narHash": "sha256-wZ8SZjHSU1WnhkKx2hXgI5pLRSglOM52kOtJbB3QCds=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "3fd3e5c187ad7155d8bf1a689fa5b651407ab22e",
+        "rev": "5610d5e01dc803717cc0b6b87625f2fbb548b49e",
         "type": "github"
       },
       "original": {
@@ -1583,11 +1583,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1723686624,
-        "narHash": "sha256-rNzfnORvbKoglt20i/rKmlkysPUBlB89F6dRKgB5MKU=",
+        "lastModified": 1726189953,
+        "narHash": "sha256-dF6O5elMbm5JOeMI7UAyrwhq8Ng52/yBwpNJRWNAizQ=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "5972437de807c3bc101565175da66a1aa4f8707a",
+        "rev": "927c10f748e49c543b2d544c321a1245302ff324",
         "type": "github"
       },
       "original": {
@@ -1602,11 +1602,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1724691612,
-        "narHash": "sha256-YZPLZgC0v5zw/+X3r0G1MZ+46c0K8J3ClFQYH5BqbUE=",
+        "lastModified": 1725500280,
+        "narHash": "sha256-Gk3wy8OvvW26bd+wVRjuHPch6DJOXJjW2TK7Jbe0hrw=",
         "owner": "mrcjkb",
         "repo": "vimcats",
-        "rev": "a51bfb9587f95b8fd6a588bdfe97b7f8f4b1e624",
+        "rev": "eeba18f1205388f403b1b3cc5a71747e0ca0a2ba",
         "type": "github"
       },
       "original": {
@@ -1618,11 +1618,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1725592915,
-        "narHash": "sha256-2X72Xv+S9mZ79x1k28LxKH7RnARwB3ZHGGSzIkeuWj8=",
+        "lastModified": 1726159044,
+        "narHash": "sha256-Nk0TGuM7hcDBupQIHftPgcVebIp0DI2P8lYGkpL3kZg=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "9793801f974bba70e4ac5d7eae6c4f5659993d8e",
+        "rev": "9154484705968658e9aab2b894d1b2a64bf9f83d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/1d18c696c4284e9ce9467a5c04d3adf8af43f994' (2024-09-02)
  → 'github:tpope/vim-fugitive/d4877e54cef67f5af4f950935b1ade19ed6b7370' (2024-09-07)
• Updated input 'home-manager':
    'github:nix-community/home-manager/127ccc3eb7e36fa75e8c3fbd8a343154f66cc1c6' (2024-09-06)
  → 'github:nix-community/home-manager/503af483e1b328691ea3a434d331995595fb2e3d' (2024-09-13)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/45db5addf8d0a201e1cf247cae4cdce605ad3768' (2024-08-28)
  → 'github:L3MON4D3/LuaSnip/e808bee352d1a6fcf902ca1a71cee76e60e24071' (2024-09-12)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/f751e2e0c00a9393410361b205f42658611ae89b' (2024-09-06)
  → 'github:nix-community/neovim-nightly-overlay/3b426df85fb2edc0da26673c464709e9c8b0c654' (2024-09-13)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/567b938d64d4b4112ee253b9274472dc3a346eb6' (2024-09-01)
  → 'github:hercules-ci/flake-parts/bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a' (2024-09-12)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/9570ad24f52442d75d677412cfe2fa83a7ff7a88' (2024-09-05)
  → 'github:neovim/neovim/deac7df80a1491ae65b68a1a1047902bcd775adc' (2024-09-12)
• Updated input 'nightfox-nvim':
    'github:EdenEast/nightfox.nvim/d3e8b1acc095baf57af81bb5e89fe7c4359eb619' (2024-07-22)
  → 'github:EdenEast/nightfox.nvim/7557f26defd093c4e9bc17f28b08403f706f5a44' (2024-09-08)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/9bb1e7571aadf31ddb4af77fc64b2d59580f9a39' (2024-09-05)
  → 'github:nixos/nixpkgs/280db3decab4cbeb22a4599bd472229ab74d25e1' (2024-09-12)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/bdbc65aadc708ce528efb22bca5f82a7cca6b54d' (2024-09-05)
  → 'github:neovim/nvim-lspconfig/bb682c167a0878338b4313b55538953d1c039085' (2024-09-12)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/3fd3e5c187ad7155d8bf1a689fa5b651407ab22e' (2024-09-04)
  → 'github:mrcjkb/rustaceanvim/5610d5e01dc803717cc0b6b87625f2fbb548b49e' (2024-09-12)
• Updated input 'rustacean-nvim/flake-parts':
    'github:hercules-ci/flake-parts/8471fe90ad337a8074e957b69ca4d0089218391d' (2024-08-01)
  → 'github:hercules-ci/flake-parts/567b938d64d4b4112ee253b9274472dc3a346eb6' (2024-09-01)
• Updated input 'rustacean-nvim/flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz?narHash=sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q%3D' (2024-08-01)
  → 'https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz?narHash=sha256-Ss8QWLXdr2JCBPcYChJhz4xJm%2Bh/xjl4G0c0XlP6a74%3D' (2024-09-01)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/960271da8c15fced6314deecfd7ef6f77787326c' (2024-08-24)
  → 'github:nvim-neorocks/neorocks/b4ecf2fc5d258e2d8754d573785209098877fa93' (2024-09-07)
• Updated input 'rustacean-nvim/neorocks/flake-parts':
    'github:hercules-ci/flake-parts/8471fe90ad337a8074e957b69ca4d0089218391d' (2024-08-01)
  → 'github:hercules-ci/flake-parts/567b938d64d4b4112ee253b9274472dc3a346eb6' (2024-09-01)
• Updated input 'rustacean-nvim/neorocks/flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz?narHash=sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q%3D' (2024-08-01)
  → 'https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz?narHash=sha256-Ss8QWLXdr2JCBPcYChJhz4xJm%2Bh/xjl4G0c0XlP6a74%3D' (2024-09-01)
• Updated input 'rustacean-nvim/neorocks/git-hooks':
    'github:cachix/git-hooks.nix/c8a54057aae480c56e28ef3e14e4960628ac495b' (2024-08-23)
  → 'github:cachix/git-hooks.nix/7570de7b9b504cfe92025dd1be797bf546f66528' (2024-09-05)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/4fb7a5de4d5024a49bb60b7ff5ddb54252fe4622' (2024-08-23)
  → 'github:nix-community/neovim-nightly-overlay/f751e2e0c00a9393410361b205f42658611ae89b' (2024-09-06)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/flake-parts':
    'github:hercules-ci/flake-parts/8471fe90ad337a8074e957b69ca4d0089218391d' (2024-08-01)
  → 'github:hercules-ci/flake-parts/567b938d64d4b4112ee253b9274472dc3a346eb6' (2024-09-01)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks':
    'github:cachix/git-hooks.nix/6cedaa7c1b4f82a266e5d30f212273e60d62cb0d' (2024-08-21)
  → 'github:cachix/git-hooks.nix/7570de7b9b504cfe92025dd1be797bf546f66528' (2024-09-05)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/11e4b8dc112e2f485d7c97e1cee77f9958f498f5' (2024-06-24)
  → 'github:hercules-ci/hercules-ci-effects/dba4367b9a9d9615456c430a6d6af716f6e84cef' (2024-08-29)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/3b32869ced32821fb58f0a7c08094105be7bdaf0' (2024-08-22)
  → 'github:neovim/neovim/9570ad24f52442d75d677412cfe2fa83a7ff7a88' (2024-09-05)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/4de4818c1ffa76d57787af936e8a23648bda6be4' (2024-08-22)
  → 'github:NixOS/nixpkgs/fcb54ddcc974cff59bdfb7c1ac9e080299763d2d' (2024-09-05)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/5de1564aed415bf9d0f281461babc2d101dd49ff' (2024-08-22)
  → 'github:nixos/nixpkgs/9bb1e7571aadf31ddb4af77fc64b2d59580f9a39' (2024-09-05)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/ae815cee91b417be55d43781eb4b73ae1ecc396c' (2024-08-23)
  → 'github:nixos/nixpkgs/9bb1e7571aadf31ddb4af77fc64b2d59580f9a39' (2024-09-05)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/c8a54057aae480c56e28ef3e14e4960628ac495b' (2024-08-23)
  → 'github:cachix/pre-commit-hooks.nix/7570de7b9b504cfe92025dd1be797bf546f66528' (2024-09-05)
• Updated input 'rustacean-nvim/vimcats':
    'github:mrcjkb/vimcats/a51bfb9587f95b8fd6a588bdfe97b7f8f4b1e624' (2024-08-26)
  → 'github:mrcjkb/vimcats/eeba18f1205388f403b1b3cc5a71747e0ca0a2ba' (2024-09-05)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/5972437de807c3bc101565175da66a1aa4f8707a' (2024-08-15)
  → 'github:nvim-telescope/telescope.nvim/927c10f748e49c543b2d544c321a1245302ff324' (2024-09-13)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/9793801f974bba70e4ac5d7eae6c4f5659993d8e' (2024-09-06)
  → 'github:nvim-tree/nvim-web-devicons/9154484705968658e9aab2b894d1b2a64bf9f83d' (2024-09-12)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`4fb7a5de` ➡️ `f751e2e0`](https://github.com/nix-community/neovim-nightly-overlay/compare/4fb7a5de4d5024a49bb60b7ff5ddb54252fe4622...f751e2e0c00a9393410361b205f42658611ae89b) <sub>(2024-08-23 to 2024-09-06)</sub>
 - Updated input `rustacean-nvim/flake-parts/nixpkgs-lib`: `a5d39417` ➡️ `356624c1` <sub>(2024-08-01 to 2024-09-01)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`3fd3e5c1` ➡️ `5610d5e0`](https://github.com/mrcjkb/rustaceanvim/compare/3fd3e5c187ad7155d8bf1a689fa5b651407ab22e...5610d5e01dc803717cc0b6b87625f2fbb548b49e) <sub>(2024-09-04 to 2024-09-12)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`5de1564a` ➡️ `9bb1e757`](https://github.com/nixos/nixpkgs/compare/5de1564aed415bf9d0f281461babc2d101dd49ff...9bb1e7571aadf31ddb4af77fc64b2d59580f9a39) <sub>(2024-08-22 to 2024-09-05)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`960271da` ➡️ `b4ecf2fc`](https://github.com/nvim-neorocks/neorocks/compare/960271da8c15fced6314deecfd7ef6f77787326c...b4ecf2fc5d258e2d8754d573785209098877fa93) <sub>(2024-08-24 to 2024-09-07)</sub>
 - Updated input [`nightfox-nvim`](https://github.com/EdenEast/nightfox.nvim): [`d3e8b1ac` ➡️ `7557f26d`](https://github.com/EdenEast/nightfox.nvim/compare/d3e8b1acc095baf57af81bb5e89fe7c4359eb619...7557f26defd093c4e9bc17f28b08403f706f5a44) <sub>(2024-07-22 to 2024-09-08)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`1d18c696` ➡️ `d4877e54`](https://github.com/tpope/vim-fugitive/compare/1d18c696c4284e9ce9467a5c04d3adf8af43f994...d4877e54cef67f5af4f950935b1ade19ed6b7370) <sub>(2024-09-02 to 2024-09-07)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [`3b32869c` ➡️ `9570ad24`](https://github.com/neovim/neovim/compare/3b32869ced32821fb58f0a7c08094105be7bdaf0...9570ad24f52442d75d677412cfe2fa83a7ff7a88) <sub>(2024-08-22 to 2024-09-05)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`11e4b8dc` ➡️ `dba4367b`](https://github.com/hercules-ci/hercules-ci-effects/compare/11e4b8dc112e2f485d7c97e1cee77f9958f498f5...dba4367b9a9d9615456c430a6d6af716f6e84cef) <sub>(2024-06-24 to 2024-08-29)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`f751e2e0` ➡️ `3b426df8`](https://github.com/nix-community/neovim-nightly-overlay/compare/f751e2e0c00a9393410361b205f42658611ae89b...3b426df85fb2edc0da26673c464709e9c8b0c654) <sub>(2024-09-06 to 2024-09-13)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`45db5add` ➡️ `e808bee3`](https://github.com/L3MON4D3/LuaSnip/compare/45db5addf8d0a201e1cf247cae4cdce605ad3768...e808bee352d1a6fcf902ca1a71cee76e60e24071) <sub>(2024-08-28 to 2024-09-12)</sub>
 - Updated input `rustacean-nvim/neorocks/flake-parts/nixpkgs-lib`: `a5d39417` ➡️ `356624c1` <sub>(2024-08-01 to 2024-09-01)</sub>
 - Updated input [`rustacean-nvim/flake-parts`](https://github.com/hercules-ci/flake-parts): [`8471fe90` ➡️ `567b938d`](https://github.com/hercules-ci/flake-parts/compare/8471fe90ad337a8074e957b69ca4d0089218391d...567b938d64d4b4112ee253b9274472dc3a346eb6) <sub>(2024-08-01 to 2024-09-01)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`bdbc65aa` ➡️ `bb682c16`](https://github.com/neovim/nvim-lspconfig/compare/bdbc65aadc708ce528efb22bca5f82a7cca6b54d...bb682c167a0878338b4313b55538953d1c039085) <sub>(2024-09-05 to 2024-09-12)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`c8a54057` ➡️ `7570de7b`](https://github.com/cachix/pre-commit-hooks.nix/compare/c8a54057aae480c56e28ef3e14e4960628ac495b...7570de7b9b504cfe92025dd1be797bf546f66528) <sub>(2024-08-23 to 2024-09-05)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`ae815cee` ➡️ `9bb1e757`](https://github.com/nixos/nixpkgs/compare/ae815cee91b417be55d43781eb4b73ae1ecc396c...9bb1e7571aadf31ddb4af77fc64b2d59580f9a39) <sub>(2024-08-23 to 2024-09-05)</sub>
 - Updated input [`rustacean-nvim/neorocks/git-hooks`](https://github.com/cachix/git-hooks.nix): [`c8a54057` ➡️ `7570de7b`](https://github.com/cachix/git-hooks.nix/compare/c8a54057aae480c56e28ef3e14e4960628ac495b...7570de7b9b504cfe92025dd1be797bf546f66528) <sub>(2024-08-23 to 2024-09-05)</sub>
 - Updated input [`rustacean-nvim/vimcats`](https://github.com/mrcjkb/vimcats): [`a51bfb95` ➡️ `eeba18f1`](https://github.com/mrcjkb/vimcats/compare/a51bfb9587f95b8fd6a588bdfe97b7f8f4b1e624...eeba18f1205388f403b1b3cc5a71747e0ca0a2ba) <sub>(2024-08-26 to 2024-09-05)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`9bb1e757` ➡️ `280db3de`](https://github.com/nixos/nixpkgs/compare/9bb1e7571aadf31ddb4af77fc64b2d59580f9a39...280db3decab4cbeb22a4599bd472229ab74d25e1) <sub>(2024-09-05 to 2024-09-12)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`5972437d` ➡️ `927c10f7`](https://github.com/nvim-telescope/telescope.nvim/compare/5972437de807c3bc101565175da66a1aa4f8707a...927c10f748e49c543b2d544c321a1245302ff324) <sub>(2024-08-15 to 2024-09-13)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`4de4818c` ➡️ `fcb54ddc`](https://github.com/NixOS/nixpkgs/compare/4de4818c1ffa76d57787af936e8a23648bda6be4...fcb54ddcc974cff59bdfb7c1ac9e080299763d2d) <sub>(2024-08-22 to 2024-09-05)</sub>
 - Updated input [`rustacean-nvim/neorocks/flake-parts`](https://github.com/hercules-ci/flake-parts): [`8471fe90` ➡️ `567b938d`](https://github.com/hercules-ci/flake-parts/compare/8471fe90ad337a8074e957b69ca4d0089218391d...567b938d64d4b4112ee253b9274472dc3a346eb6) <sub>(2024-08-01 to 2024-09-01)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`9793801f` ➡️ `91544847`](https://github.com/nvim-tree/nvim-web-devicons/compare/9793801f974bba70e4ac5d7eae6c4f5659993d8e...9154484705968658e9aab2b894d1b2a64bf9f83d) <sub>(2024-09-06 to 2024-09-12)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks`](https://github.com/cachix/git-hooks.nix): [`6cedaa7c` ➡️ `7570de7b`](https://github.com/cachix/git-hooks.nix/compare/6cedaa7c1b4f82a266e5d30f212273e60d62cb0d...7570de7b9b504cfe92025dd1be797bf546f66528) <sub>(2024-08-21 to 2024-09-05)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`127ccc3e` ➡️ `503af483`](https://github.com/nix-community/home-manager/compare/127ccc3eb7e36fa75e8c3fbd8a343154f66cc1c6...503af483e1b328691ea3a434d331995595fb2e3d) <sub>(2024-09-06 to 2024-09-13)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`9570ad24` ➡️ `deac7df8`](https://github.com/neovim/neovim/compare/9570ad24f52442d75d677412cfe2fa83a7ff7a88...deac7df80a1491ae65b68a1a1047902bcd775adc) <sub>(2024-09-05 to 2024-09-12)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/flake-parts`](https://github.com/hercules-ci/flake-parts): [`8471fe90` ➡️ `567b938d`](https://github.com/hercules-ci/flake-parts/compare/8471fe90ad337a8074e957b69ca4d0089218391d...567b938d64d4b4112ee253b9274472dc3a346eb6) <sub>(2024-08-01 to 2024-09-01)</sub>
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`567b938d` ➡️ `bcef6817`](https://github.com/hercules-ci/flake-parts/compare/567b938d64d4b4112ee253b9274472dc3a346eb6...bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a) <sub>(2024-09-01 to 2024-09-12)</sub>