### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -208,6 +208,22 @@
         "type": "github"
       }
     },
+    "flake-compat_9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -255,11 +271,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1725234343,
-        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
         "type": "github"
       },
       "original": {
@@ -291,11 +307,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1725234343,
-        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
         "type": "github"
       },
       "original": {
@@ -314,11 +330,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725234343,
-        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
         "type": "github"
       },
       "original": {
@@ -355,11 +371,11 @@
         "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
-        "lastModified": 1696343447,
-        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "lastModified": 1725234343,
+        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
         "type": "github"
       },
       "original": {
@@ -373,11 +389,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -505,11 +521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725513492,
-        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
+        "lastModified": 1726745158,
+        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
+        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
         "type": "github"
       },
       "original": {
@@ -591,6 +607,32 @@
       },
       "original": {
         "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks_5": {
+      "inputs": {
+        "flake-compat": "flake-compat_9",
+        "gitignore": "gitignore_6",
+        "nixpkgs": [
+          "rustacean-nvim",
+          "vimcats",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable_4"
+      },
+      "locked": {
+        "lastModified": 1725438226,
+        "narHash": "sha256-lL4hQ+g2qiZ02WfidLkrujaT23c6E2Wm7S0ZQhSB8Jk=",
+        "owner": "mrcjkb",
+        "repo": "git-hooks.nix",
+        "rev": "ec0f4d97f48a1f32bd87804e2390f03999790ec0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mrcjkb",
+        "ref": "clippy",
         "repo": "git-hooks.nix",
         "type": "github"
       }
@@ -709,6 +751,29 @@
         "type": "github"
       }
     },
+    "gitignore_6": {
+      "inputs": {
+        "nixpkgs": [
+          "rustacean-nvim",
+          "vimcats",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
@@ -778,11 +843,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726222338,
-        "narHash": "sha256-KuA8ciNR8qCF3dQaCaeh0JWyQUgEwkwDHr/f49Q5/e8=",
+        "lastModified": 1726863345,
+        "narHash": "sha256-fjbKe1/UJpLT6tQLAKJ/djJFdnmAh2kkdsgmylyFrQA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "503af483e1b328691ea3a434d331995595fb2e3d",
+        "rev": "dfe4d334b172071e7189d971ddecd3a7f811b48d",
         "type": "github"
       },
       "original": {
@@ -877,11 +942,11 @@
     "lsp-signature-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1718424851,
-        "narHash": "sha256-cU6Xz1ZzRU5JM1qFiUrT3m02JcTJUQR6Grlf87j9ztw=",
+        "lastModified": 1726445971,
+        "narHash": "sha256-W6bN3R10B84noK7MOzvUOIc82WwyojIS97iFL/dO5yk=",
         "owner": "ray-x",
         "repo": "lsp_signature.nvim",
-        "rev": "a38da0a61c172bb59e34befc12efe48359884793",
+        "rev": "fc38521ea4d9ec8dbd4c2819ba8126cea743943b",
         "type": "github"
       },
       "original": {
@@ -979,11 +1044,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1725686700,
-        "narHash": "sha256-wCjTrQhEcsU3Gb4wUzKZgJzD/Ydm+cwU+wzRUAhwua0=",
+        "lastModified": 1726291442,
+        "narHash": "sha256-V0heel8HhLtvFzBBSss7EKnBowhTYN+xO4DYCwsPSxw=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "b4ecf2fc5d258e2d8754d573785209098877fa93",
+        "rev": "b628f6aef1453ebad58a970070c112855e93c044",
         "type": "github"
       },
       "original": {
@@ -1002,11 +1067,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1725621813,
-        "narHash": "sha256-PULZxwVju7sX7YTDiu2Gr15htFEEoMJ95ZZ6FGj+qa0=",
+        "lastModified": 1726189029,
+        "narHash": "sha256-A6rw8kgxTDmuGD6D8kooF9V++iAeXXgqay0vKG/zi/M=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "f751e2e0c00a9393410361b205f42658611ae89b",
+        "rev": "3b426df85fb2edc0da26673c464709e9c8b0c654",
         "type": "github"
       },
       "original": {
@@ -1027,11 +1092,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726189029,
-        "narHash": "sha256-A6rw8kgxTDmuGD6D8kooF9V++iAeXXgqay0vKG/zi/M=",
+        "lastModified": 1726814269,
+        "narHash": "sha256-eXI81wCtybqgK05ky5/tmj4AZDKmtoNQcGZEX0vnoe8=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "3b426df85fb2edc0da26673c464709e9c8b0c654",
+        "rev": "25aca068d0bd63c6db17c29bd3641256ea62a2c1",
         "type": "github"
       },
       "original": {
@@ -1043,11 +1108,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1726157817,
-        "narHash": "sha256-Vu2rOpAKlEFu+dGewEBsnAuHHxj8XbGqF52WGmu1NNY=",
+        "lastModified": 1726786786,
+        "narHash": "sha256-SMRChiJK6Td+TtiphiXP+fc8ZNElfmAeHTF2y2y9y9w=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "deac7df80a1491ae65b68a1a1047902bcd775adc",
+        "rev": "f01c764cc6f82399edfa0d47a7bafbf7c95e2747",
         "type": "github"
       },
       "original": {
@@ -1059,11 +1124,11 @@
     "neovim-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1725578611,
-        "narHash": "sha256-sRezYqvmEjS/TIumXiwIN+ttuEPhNNtDnUY7wCpSCAs=",
+        "lastModified": 1726157817,
+        "narHash": "sha256-Vu2rOpAKlEFu+dGewEBsnAuHHxj8XbGqF52WGmu1NNY=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "9570ad24f52442d75d677412cfe2fa83a7ff7a88",
+        "rev": "deac7df80a1491ae65b68a1a1047902bcd775adc",
         "type": "github"
       },
       "original": {
@@ -1142,20 +1207,14 @@
     },
     "nixpkgs-lib_4": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1696019113,
-        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
-        "type": "github"
+        "lastModified": 1725233747,
+        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       }
     },
     "nixpkgs-stable": {
@@ -1206,13 +1265,29 @@
         "type": "github"
       }
     },
-    "nixpkgs_10": {
+    "nixpkgs-stable_4": {
       "locked": {
-        "lastModified": 1697379843,
-        "narHash": "sha256-RcnGuJgC2K/UpTy+d32piEoBXq2M+nVFzM3ah/ZdJzg=",
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_10": {
+      "locked": {
+        "lastModified": 1725910328,
+        "narHash": "sha256-n9pCtzGZ0httmTwMuEbi5E78UQ4ZbQMr1pzi5N0LAG8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5775c2583f1801df7b790bf7f7d710a19bac66f4",
         "type": "github"
       },
       "original": {
@@ -1224,11 +1299,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726142289,
-        "narHash": "sha256-Jks8O42La+nm5AMTSq/PvM5O+fUAhIy0Ce1QYqLkyZ4=",
+        "lastModified": 1726652927,
+        "narHash": "sha256-WO6Lmbn37PlamY2fDg3B187THkSKU/W01z8SxoIqJd0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "280db3decab4cbeb22a4599bd472229ab74d25e1",
+        "rev": "294eb5975def0caa718fca92dc5a9d656ae392a9",
         "type": "github"
       },
       "original": {
@@ -1288,11 +1363,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1725503534,
-        "narHash": "sha256-hd1eRyPtTkRnAPYpnEfzugQwAifVYMmOR3z+MTTSw+g=",
+        "lastModified": 1726108120,
+        "narHash": "sha256-Ji5wO1lLG99grI0qCRb6FyRPpH9tfdfD1QP/r7IlgfM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fcb54ddcc974cff59bdfb7c1ac9e080299763d2d",
+        "rev": "111ed8812c10d7dc3017de46cbf509600c93f551",
         "type": "github"
       },
       "original": {
@@ -1304,11 +1379,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1725534445,
-        "narHash": "sha256-Yd0FK9SkWy+ZPuNqUgmVPXokxDgMJoGuNpMEtkfcf84=",
+        "lastModified": 1726206720,
+        "narHash": "sha256-tI7141IHDABMNgz4iXDo8agCp0SeTLbaIZ2DRndwcmk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9bb1e7571aadf31ddb4af77fc64b2d59580f9a39",
+        "rev": "673d99f1406cb09b8eb6feab4743ebdf70046557",
         "type": "github"
       },
       "original": {
@@ -1320,11 +1395,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1725534445,
-        "narHash": "sha256-Yd0FK9SkWy+ZPuNqUgmVPXokxDgMJoGuNpMEtkfcf84=",
+        "lastModified": 1726206720,
+        "narHash": "sha256-tI7141IHDABMNgz4iXDo8agCp0SeTLbaIZ2DRndwcmk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9bb1e7571aadf31ddb4af77fc64b2d59580f9a39",
+        "rev": "673d99f1406cb09b8eb6feab4743ebdf70046557",
         "type": "github"
       },
       "original": {
@@ -1369,11 +1444,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1726121715,
-        "narHash": "sha256-QfU7Xywjqw5S55gOBtQ10S5fK7wyFqhKzBwqCRoejQQ=",
+        "lastModified": 1726818571,
+        "narHash": "sha256-fhhVVL9+SLpJBhh1QvNe6lmqqmpUBeL+uuv8+yk5tBk=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "bb682c167a0878338b4313b55538953d1c039085",
+        "rev": "b064131428f6bbbbc905f4451ba6779fda334a3a",
         "type": "github"
       },
       "original": {
@@ -1407,11 +1482,11 @@
     "plenary-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1724044857,
-        "narHash": "sha256-6Gm+4zZ80quI5iAW6qPAWTq9h1csPWkZFZ9KnFgYRM0=",
+        "lastModified": 1726602776,
+        "narHash": "sha256-bmmPekAvuBvLQmrnnX0n+FRBqfVxBsObhxIEkDGAla4=",
         "owner": "nvim-lua",
         "repo": "plenary.nvim",
-        "rev": "ec289423a1693aeae6cd0d503bac2856af74edaa",
+        "rev": "2d9b06177a975543726ce5c73fca176cedbffe9d",
         "type": "github"
       },
       "original": {
@@ -1506,11 +1581,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1726158967,
-        "narHash": "sha256-wZ8SZjHSU1WnhkKx2hXgI5pLRSglOM52kOtJbB3QCds=",
+        "lastModified": 1726829280,
+        "narHash": "sha256-n3w3zmFcAA1x9U53pu9H2vH7dbCbSVNo+aHDZ9SPpf4=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "5610d5e01dc803717cc0b6b87625f2fbb548b49e",
+        "rev": "f9ecc0c3084186a60513b83139a643a5cbf3bdf7",
         "type": "github"
       },
       "original": {
@@ -1583,11 +1658,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1726189953,
-        "narHash": "sha256-dF6O5elMbm5JOeMI7UAyrwhq8Ng52/yBwpNJRWNAizQ=",
+        "lastModified": 1726712810,
+        "narHash": "sha256-3gFcpdzRPAeGrB69FbCLYO16BWnkAb0hRawi9//t7QM=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "927c10f748e49c543b2d544c321a1245302ff324",
+        "rev": "b5fd7f7ae0ea4537511077ed8ef4a6021cedba2f",
         "type": "github"
       },
       "original": {
@@ -1599,14 +1674,15 @@
     "vimcats": {
       "inputs": {
         "flake-parts": "flake-parts_8",
+        "git-hooks": "git-hooks_5",
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1725500280,
-        "narHash": "sha256-Gk3wy8OvvW26bd+wVRjuHPch6DJOXJjW2TK7Jbe0hrw=",
+        "lastModified": 1726045206,
+        "narHash": "sha256-/ekQF2pE/juZ7AVge9bqodQLx4n0uaV4j2taD5U78R0=",
         "owner": "mrcjkb",
         "repo": "vimcats",
-        "rev": "eeba18f1205388f403b1b3cc5a71747e0ca0a2ba",
+        "rev": "fd213ad22ffbfff87899c872752a1c92814c93fa",
         "type": "github"
       },
       "original": {
@@ -1618,11 +1694,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1726159044,
-        "narHash": "sha256-Nk0TGuM7hcDBupQIHftPgcVebIp0DI2P8lYGkpL3kZg=",
+        "lastModified": 1726797642,
+        "narHash": "sha256-+0C+hY/CD8876PaliC+JnuIzUgkO+QtfO7Z1+ihGgC4=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "9154484705968658e9aab2b894d1b2a64bf9f83d",
+        "rev": "31bd21ac46b2b6039aa0b856ca02b018cf549ef7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'flake-utils':
    'github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a' (2024-03-11)
  → 'github:numtide/flake-utils/c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a' (2024-09-17)
• Updated input 'home-manager':
    'github:nix-community/home-manager/503af483e1b328691ea3a434d331995595fb2e3d' (2024-09-13)
  → 'github:nix-community/home-manager/dfe4d334b172071e7189d971ddecd3a7f811b48d' (2024-09-20)
• Updated input 'lsp-signature-nvim':
    'github:ray-x/lsp_signature.nvim/a38da0a61c172bb59e34befc12efe48359884793' (2024-06-15)
  → 'github:ray-x/lsp_signature.nvim/fc38521ea4d9ec8dbd4c2819ba8126cea743943b' (2024-09-16)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/3b426df85fb2edc0da26673c464709e9c8b0c654' (2024-09-13)
  → 'github:nix-community/neovim-nightly-overlay/25aca068d0bd63c6db17c29bd3641256ea62a2c1' (2024-09-20)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/7570de7b9b504cfe92025dd1be797bf546f66528' (2024-09-05)
  → 'github:cachix/git-hooks.nix/4e743a6920eab45e8ba0fbe49dc459f1423a4b74' (2024-09-19)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/deac7df80a1491ae65b68a1a1047902bcd775adc' (2024-09-12)
  → 'github:neovim/neovim/f01c764cc6f82399edfa0d47a7bafbf7c95e2747' (2024-09-19)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/280db3decab4cbeb22a4599bd472229ab74d25e1' (2024-09-12)
  → 'github:nixos/nixpkgs/294eb5975def0caa718fca92dc5a9d656ae392a9' (2024-09-18)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/bb682c167a0878338b4313b55538953d1c039085' (2024-09-12)
  → 'github:neovim/nvim-lspconfig/b064131428f6bbbbc905f4451ba6779fda334a3a' (2024-09-20)
• Updated input 'plenary-nvim':
    'github:nvim-lua/plenary.nvim/ec289423a1693aeae6cd0d503bac2856af74edaa' (2024-08-19)
  → 'github:nvim-lua/plenary.nvim/2d9b06177a975543726ce5c73fca176cedbffe9d' (2024-09-17)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/5610d5e01dc803717cc0b6b87625f2fbb548b49e' (2024-09-12)
  → 'github:mrcjkb/rustaceanvim/f9ecc0c3084186a60513b83139a643a5cbf3bdf7' (2024-09-20)
• Updated input 'rustacean-nvim/flake-parts':
    'github:hercules-ci/flake-parts/567b938d64d4b4112ee253b9274472dc3a346eb6' (2024-09-01)
  → 'github:hercules-ci/flake-parts/bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a' (2024-09-12)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/b4ecf2fc5d258e2d8754d573785209098877fa93' (2024-09-07)
  → 'github:nvim-neorocks/neorocks/b628f6aef1453ebad58a970070c112855e93c044' (2024-09-14)
• Updated input 'rustacean-nvim/neorocks/flake-parts':
    'github:hercules-ci/flake-parts/567b938d64d4b4112ee253b9274472dc3a346eb6' (2024-09-01)
  → 'github:hercules-ci/flake-parts/bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a' (2024-09-12)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/f751e2e0c00a9393410361b205f42658611ae89b' (2024-09-06)
  → 'github:nix-community/neovim-nightly-overlay/3b426df85fb2edc0da26673c464709e9c8b0c654' (2024-09-13)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/flake-parts':
    'github:hercules-ci/flake-parts/567b938d64d4b4112ee253b9274472dc3a346eb6' (2024-09-01)
  → 'github:hercules-ci/flake-parts/bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a' (2024-09-12)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/9570ad24f52442d75d677412cfe2fa83a7ff7a88' (2024-09-05)
  → 'github:neovim/neovim/deac7df80a1491ae65b68a1a1047902bcd775adc' (2024-09-12)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/fcb54ddcc974cff59bdfb7c1ac9e080299763d2d' (2024-09-05)
  → 'github:NixOS/nixpkgs/111ed8812c10d7dc3017de46cbf509600c93f551' (2024-09-12)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/9bb1e7571aadf31ddb4af77fc64b2d59580f9a39' (2024-09-05)
  → 'github:nixos/nixpkgs/673d99f1406cb09b8eb6feab4743ebdf70046557' (2024-09-13)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/9bb1e7571aadf31ddb4af77fc64b2d59580f9a39' (2024-09-05)
  → 'github:nixos/nixpkgs/673d99f1406cb09b8eb6feab4743ebdf70046557' (2024-09-13)
• Updated input 'rustacean-nvim/vimcats':
    'github:mrcjkb/vimcats/eeba18f1205388f403b1b3cc5a71747e0ca0a2ba' (2024-09-05)
  → 'github:mrcjkb/vimcats/fd213ad22ffbfff87899c872752a1c92814c93fa' (2024-09-11)
• Updated input 'rustacean-nvim/vimcats/flake-parts':
    'github:hercules-ci/flake-parts/c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4' (2023-10-03)
  → 'github:hercules-ci/flake-parts/567b938d64d4b4112ee253b9274472dc3a346eb6' (2024-09-01)
• Updated input 'rustacean-nvim/vimcats/flake-parts/nixpkgs-lib':
    'github:NixOS/nixpkgs/f5892ddac112a1e9b3612c39af1b72987ee5783a?dir=lib' (2023-09-29)
  → 'https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz?narHash=sha256-Ss8QWLXdr2JCBPcYChJhz4xJm%2Bh/xjl4G0c0XlP6a74%3D' (2024-09-01)
• Added input 'rustacean-nvim/vimcats/git-hooks':
    'github:mrcjkb/git-hooks.nix/ec0f4d97f48a1f32bd87804e2390f03999790ec0' (2024-09-04)
• Added input 'rustacean-nvim/vimcats/git-hooks/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
• Added input 'rustacean-nvim/vimcats/git-hooks/gitignore':
    'github:hercules-ci/gitignore.nix/637db329424fd7e46cf4185293b9cc8c88c95394' (2024-02-28)
• Added input 'rustacean-nvim/vimcats/git-hooks/gitignore/nixpkgs':
    follows 'rustacean-nvim/vimcats/git-hooks/nixpkgs'
• Added input 'rustacean-nvim/vimcats/git-hooks/nixpkgs':
    follows 'rustacean-nvim/vimcats/nixpkgs'
• Added input 'rustacean-nvim/vimcats/git-hooks/nixpkgs-stable':
    'github:NixOS/nixpkgs/194846768975b7ad2c4988bdb82572c00222c0d7' (2024-07-07)
• Updated input 'rustacean-nvim/vimcats/nixpkgs':
    'github:NixOS/nixpkgs/12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d' (2023-10-15)
  → 'github:NixOS/nixpkgs/5775c2583f1801df7b790bf7f7d710a19bac66f4' (2024-09-09)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/927c10f748e49c543b2d544c321a1245302ff324' (2024-09-13)
  → 'github:nvim-telescope/telescope.nvim/b5fd7f7ae0ea4537511077ed8ef4a6021cedba2f' (2024-09-19)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/9154484705968658e9aab2b894d1b2a64bf9f83d' (2024-09-12)
  → 'github:nvim-tree/nvim-web-devicons/31bd21ac46b2b6039aa0b856ca02b018cf549ef7' (2024-09-20)

```

</p></details>

 - Updated input [`rustacean-nvim/vimcats/nixpkgs`](https://github.com/NixOS/nixpkgs): [`12bdeb01` ➡️ `5775c258`](https://github.com/NixOS/nixpkgs/compare/12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d...5775c2583f1801df7b790bf7f7d710a19bac66f4) <sub>(2023-10-15 to 2024-09-09)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`f751e2e0` ➡️ `3b426df8`](https://github.com/nix-community/neovim-nightly-overlay/compare/f751e2e0c00a9393410361b205f42658611ae89b...3b426df85fb2edc0da26673c464709e9c8b0c654) <sub>(2024-09-06 to 2024-09-13)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`5610d5e0` ➡️ `f9ecc0c3`](https://github.com/mrcjkb/rustaceanvim/compare/5610d5e01dc803717cc0b6b87625f2fbb548b49e...f9ecc0c3084186a60513b83139a643a5cbf3bdf7) <sub>(2024-09-12 to 2024-09-20)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`9bb1e757` ➡️ `673d99f1`](https://github.com/nixos/nixpkgs/compare/9bb1e7571aadf31ddb4af77fc64b2d59580f9a39...673d99f1406cb09b8eb6feab4743ebdf70046557) <sub>(2024-09-05 to 2024-09-13)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`b4ecf2fc` ➡️ `b628f6ae`](https://github.com/nvim-neorocks/neorocks/compare/b4ecf2fc5d258e2d8754d573785209098877fa93...b628f6aef1453ebad58a970070c112855e93c044) <sub>(2024-09-07 to 2024-09-14)</sub>
 - Updated input [`lsp-signature-nvim`](https://github.com/ray-x/lsp_signature.nvim): [`a38da0a6` ➡️ `fc38521e`](https://github.com/ray-x/lsp_signature.nvim/compare/a38da0a61c172bb59e34befc12efe48359884793...fc38521ea4d9ec8dbd4c2819ba8126cea743943b) <sub>(2024-06-15 to 2024-09-16)</sub>
 - Added input [`rustacean-nvim/vimcats/git-hooks`](https://github.com/mrcjkb/git-hooks.nix): [github.com/mrcjkb/git-hooks.nix](https://github.com/mrcjkb/git-hooks.nix/tree/ec0f4d97f48a1f32bd87804e2390f03999790ec0/)
 - Updated input [`rustacean-nvim/vimcats/flake-parts`](https://github.com/hercules-ci/flake-parts): [`c9afaba3` ➡️ `567b938d`](https://github.com/hercules-ci/flake-parts/compare/c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4...567b938d64d4b4112ee253b9274472dc3a346eb6) <sub>(2023-10-03 to 2024-09-01)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [`9570ad24` ➡️ `deac7df8`](https://github.com/neovim/neovim/compare/9570ad24f52442d75d677412cfe2fa83a7ff7a88...deac7df80a1491ae65b68a1a1047902bcd775adc) <sub>(2024-09-05 to 2024-09-12)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`3b426df8` ➡️ `25aca068`](https://github.com/nix-community/neovim-nightly-overlay/compare/3b426df85fb2edc0da26673c464709e9c8b0c654...25aca068d0bd63c6db17c29bd3641256ea62a2c1) <sub>(2024-09-13 to 2024-09-20)</sub>
 - Added input [`rustacean-nvim/vimcats/git-hooks/flake-compat`](https://github.com/edolstra/flake-compat): [github.com/edolstra/flake-compat](https://github.com/edolstra/flake-compat/tree/0f9255e01c2351cc7d116c072cb317785dd33b33/)
 - Updated input `rustacean-nvim/vimcats/flake-parts/nixpkgs-lib`: `f5892dda` ➡️ `356624c1` <sub>(2023-09-29 to 2024-09-01)</sub>
 - Updated input [`rustacean-nvim/flake-parts`](https://github.com/hercules-ci/flake-parts): [`567b938d` ➡️ `bcef6817`](https://github.com/hercules-ci/flake-parts/compare/567b938d64d4b4112ee253b9274472dc3a346eb6...bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a) <sub>(2024-09-01 to 2024-09-12)</sub>
 - Updated input [`plenary-nvim`](https://github.com/nvim-lua/plenary.nvim): [`ec289423` ➡️ `2d9b0617`](https://github.com/nvim-lua/plenary.nvim/compare/ec289423a1693aeae6cd0d503bac2856af74edaa...2d9b06177a975543726ce5c73fca176cedbffe9d) <sub>(2024-08-19 to 2024-09-17)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`bb682c16` ➡️ `b0641314`](https://github.com/neovim/nvim-lspconfig/compare/bb682c167a0878338b4313b55538953d1c039085...b064131428f6bbbbc905f4451ba6779fda334a3a) <sub>(2024-09-12 to 2024-09-20)</sub>
 - Added input [`rustacean-nvim/vimcats/git-hooks/nixpkgs-stable`](https://github.com/NixOS/nixpkgs): [github.com/NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/tree/194846768975b7ad2c4988bdb82572c00222c0d7/)
 - Added input [`rustacean-nvim/vimcats/git-hooks/gitignore`](https://github.com/hercules-ci/gitignore.nix): [github.com/hercules-ci/gitignore.nix](https://github.com/hercules-ci/gitignore.nix/tree/637db329424fd7e46cf4185293b9cc8c88c95394/)
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`9bb1e757` ➡️ `673d99f1`](https://github.com/nixos/nixpkgs/compare/9bb1e7571aadf31ddb4af77fc64b2d59580f9a39...673d99f1406cb09b8eb6feab4743ebdf70046557) <sub>(2024-09-05 to 2024-09-13)</sub>
 - Updated input [`rustacean-nvim/vimcats`](https://github.com/mrcjkb/vimcats): [`eeba18f1` ➡️ `fd213ad2`](https://github.com/mrcjkb/vimcats/compare/eeba18f1205388f403b1b3cc5a71747e0ca0a2ba...fd213ad22ffbfff87899c872752a1c92814c93fa) <sub>(2024-09-05 to 2024-09-11)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`280db3de` ➡️ `294eb597`](https://github.com/nixos/nixpkgs/compare/280db3decab4cbeb22a4599bd472229ab74d25e1...294eb5975def0caa718fca92dc5a9d656ae392a9) <sub>(2024-09-12 to 2024-09-18)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`7570de7b` ➡️ `4e743a69`](https://github.com/cachix/git-hooks.nix/compare/7570de7b9b504cfe92025dd1be797bf546f66528...4e743a6920eab45e8ba0fbe49dc459f1423a4b74) <sub>(2024-09-05 to 2024-09-19)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`927c10f7` ➡️ `b5fd7f7a`](https://github.com/nvim-telescope/telescope.nvim/compare/927c10f748e49c543b2d544c321a1245302ff324...b5fd7f7ae0ea4537511077ed8ef4a6021cedba2f) <sub>(2024-09-13 to 2024-09-19)</sub>
 - Added input `rustacean-nvim/vimcats/git-hooks/nixpkgs`: ``
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`fcb54ddc` ➡️ `111ed881`](https://github.com/NixOS/nixpkgs/compare/fcb54ddcc974cff59bdfb7c1ac9e080299763d2d...111ed8812c10d7dc3017de46cbf509600c93f551) <sub>(2024-09-05 to 2024-09-12)</sub>
 - Updated input [`rustacean-nvim/neorocks/flake-parts`](https://github.com/hercules-ci/flake-parts): [`567b938d` ➡️ `bcef6817`](https://github.com/hercules-ci/flake-parts/compare/567b938d64d4b4112ee253b9274472dc3a346eb6...bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a) <sub>(2024-09-01 to 2024-09-12)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`91544847` ➡️ `31bd21ac`](https://github.com/nvim-tree/nvim-web-devicons/compare/9154484705968658e9aab2b894d1b2a64bf9f83d...31bd21ac46b2b6039aa0b856ca02b018cf549ef7) <sub>(2024-09-12 to 2024-09-20)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`503af483` ➡️ `dfe4d334`](https://github.com/nix-community/home-manager/compare/503af483e1b328691ea3a434d331995595fb2e3d...dfe4d334b172071e7189d971ddecd3a7f811b48d) <sub>(2024-09-13 to 2024-09-20)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`deac7df8` ➡️ `f01c764c`](https://github.com/neovim/neovim/compare/deac7df80a1491ae65b68a1a1047902bcd775adc...f01c764cc6f82399edfa0d47a7bafbf7c95e2747) <sub>(2024-09-12 to 2024-09-19)</sub>
 - Added input `rustacean-nvim/vimcats/git-hooks/gitignore/nixpkgs`: ``
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/flake-parts`](https://github.com/hercules-ci/flake-parts): [`567b938d` ➡️ `bcef6817`](https://github.com/hercules-ci/flake-parts/compare/567b938d64d4b4112ee253b9274472dc3a346eb6...bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a) <sub>(2024-09-01 to 2024-09-12)</sub>
 - Updated input [`flake-utils`](https://github.com/numtide/flake-utils): [`b1d9ab70` ➡️ `c1dfcf08`](https://github.com/numtide/flake-utils/compare/b1d9ab70662946ef0850d488da1c9019f3a9752a...c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a) <sub>(2024-03-11 to 2024-09-17)</sub>