### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -567,11 +567,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1725513492,
-        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
+        "lastModified": 1726745158,
+        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
+        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
         "type": "github"
       },
       "original": {
@@ -598,11 +598,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725513492,
-        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
+        "lastModified": 1726745158,
+        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
+        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
         "type": "github"
       },
       "original": {
@@ -777,11 +777,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1725453693,
-        "narHash": "sha256-s3y8ZuLV00GIhizcK/zqsJOTKecql7Xn3LGYmH7NLsQ=",
+        "lastModified": 1727424886,
+        "narHash": "sha256-o2Y57z7IuIa9wvLlzyslcs3/+iaZzuqM1NImlKAPt5Y=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "1ef74b546732f185d0f806860fa5404df7614f28",
+        "rev": "863903631e676b33e8be2acb17512fdc1b80b4fb",
         "type": "github"
       },
       "original": {
@@ -843,11 +843,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726863345,
-        "narHash": "sha256-fjbKe1/UJpLT6tQLAKJ/djJFdnmAh2kkdsgmylyFrQA=",
+        "lastModified": 1727383923,
+        "narHash": "sha256-4/vacp3CwdGoPf8U4e/N8OsGYtO09WTcQK5FqYfJbKs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dfe4d334b172071e7189d971ddecd3a7f811b48d",
+        "rev": "ffe2d07e771580a005e675108212597e5b367d2d",
         "type": "github"
       },
       "original": {
@@ -958,11 +958,11 @@
     "lspkind-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1721915252,
-        "narHash": "sha256-1KK6JhQUtA5mxwRSKU5e3pTQzZwaoAjzycBLx5X/xlA=",
+        "lastModified": 1727343567,
+        "narHash": "sha256-72j9A16OGm90eL/iQPEuNSvFh7mSUMKQhbTGpSjbnKM=",
         "owner": "onsails",
         "repo": "lspkind.nvim",
-        "rev": "cff4ae321a91ee3473a92ea1a8c637e3a9510aec",
+        "rev": "59c3f419af48a2ffb2320cea85e44e5a95f71664",
         "type": "github"
       },
       "original": {
@@ -1044,11 +1044,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1726291442,
-        "narHash": "sha256-V0heel8HhLtvFzBBSss7EKnBowhTYN+xO4DYCwsPSxw=",
+        "lastModified": 1726896389,
+        "narHash": "sha256-Qxh7GmtsB94T9EzROLvXIr486c//1M+S8apU7KoTVA0=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "b628f6aef1453ebad58a970070c112855e93c044",
+        "rev": "39308fea510539a516a2620f859dd2c8f96fc935",
         "type": "github"
       },
       "original": {
@@ -1067,11 +1067,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1726189029,
-        "narHash": "sha256-A6rw8kgxTDmuGD6D8kooF9V++iAeXXgqay0vKG/zi/M=",
+        "lastModified": 1726814269,
+        "narHash": "sha256-eXI81wCtybqgK05ky5/tmj4AZDKmtoNQcGZEX0vnoe8=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "3b426df85fb2edc0da26673c464709e9c8b0c654",
+        "rev": "25aca068d0bd63c6db17c29bd3641256ea62a2c1",
         "type": "github"
       },
       "original": {
@@ -1092,11 +1092,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726814269,
-        "narHash": "sha256-eXI81wCtybqgK05ky5/tmj4AZDKmtoNQcGZEX0vnoe8=",
+        "lastModified": 1727415632,
+        "narHash": "sha256-PApi0lMoKu8Ragc1pyrcgFyye1Xhfh4qsL+tMyvnYjw=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "25aca068d0bd63c6db17c29bd3641256ea62a2c1",
+        "rev": "6a21da1b53a9a5c6467694b9456b4447cbd69816",
         "type": "github"
       },
       "original": {
@@ -1108,11 +1108,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1726786786,
-        "narHash": "sha256-SMRChiJK6Td+TtiphiXP+fc8ZNElfmAeHTF2y2y9y9w=",
+        "lastModified": 1727394046,
+        "narHash": "sha256-vhOhvCtNWeuqtjMnV87Xb2zgFDJJUrWcAofzQNYyiR8=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "f01c764cc6f82399edfa0d47a7bafbf7c95e2747",
+        "rev": "a9287dd882e082a17fc7dcf004d3f991ed29001b",
         "type": "github"
       },
       "original": {
@@ -1124,11 +1124,11 @@
     "neovim-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1726157817,
-        "narHash": "sha256-Vu2rOpAKlEFu+dGewEBsnAuHHxj8XbGqF52WGmu1NNY=",
+        "lastModified": 1726786786,
+        "narHash": "sha256-SMRChiJK6Td+TtiphiXP+fc8ZNElfmAeHTF2y2y9y9w=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "deac7df80a1491ae65b68a1a1047902bcd775adc",
+        "rev": "f01c764cc6f82399edfa0d47a7bafbf7c95e2747",
         "type": "github"
       },
       "original": {
@@ -1299,11 +1299,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726652927,
-        "narHash": "sha256-WO6Lmbn37PlamY2fDg3B187THkSKU/W01z8SxoIqJd0=",
+        "lastModified": 1727335715,
+        "narHash": "sha256-1uw3y94dA4l22LkqHRIsb7qr3rV5XdxQFqctINfx8Cc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "294eb5975def0caa718fca92dc5a9d656ae392a9",
+        "rev": "28b5b8af91ffd2623e995e20aee56510db49001a",
         "type": "github"
       },
       "original": {
@@ -1363,11 +1363,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1726108120,
-        "narHash": "sha256-Ji5wO1lLG99grI0qCRb6FyRPpH9tfdfD1QP/r7IlgfM=",
+        "lastModified": 1726583932,
+        "narHash": "sha256-zACxiQx8knB3F8+Ze+1BpiYrI+CbhxyWpcSID9kVhkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "111ed8812c10d7dc3017de46cbf509600c93f551",
+        "rev": "658e7223191d2598641d50ee4e898126768fe847",
         "type": "github"
       },
       "original": {
@@ -1379,11 +1379,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1726206720,
-        "narHash": "sha256-tI7141IHDABMNgz4iXDo8agCp0SeTLbaIZ2DRndwcmk=",
+        "lastModified": 1726745986,
+        "narHash": "sha256-xB35C2fpz7iyNcj9sn0a+wM2C4CQ6DGTn5VUHogstYs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "673d99f1406cb09b8eb6feab4743ebdf70046557",
+        "rev": "268bb5090a3c6ac5e1615b38542a868b52ef8088",
         "type": "github"
       },
       "original": {
@@ -1395,11 +1395,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1726206720,
-        "narHash": "sha256-tI7141IHDABMNgz4iXDo8agCp0SeTLbaIZ2DRndwcmk=",
+        "lastModified": 1726871744,
+        "narHash": "sha256-V5LpfdHyQkUF7RfOaDPrZDP+oqz88lTJrMT1+stXNwo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "673d99f1406cb09b8eb6feab4743ebdf70046557",
+        "rev": "a1d92660c6b3b7c26fb883500a80ea9d33321be2",
         "type": "github"
       },
       "original": {
@@ -1444,11 +1444,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1726818571,
-        "narHash": "sha256-fhhVVL9+SLpJBhh1QvNe6lmqqmpUBeL+uuv8+yk5tBk=",
+        "lastModified": 1727236446,
+        "narHash": "sha256-0P1BCn5vxrQHHN/wvpLVg4a0iSTuDKpHWUOo5VoP0to=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "b064131428f6bbbbc905f4451ba6779fda334a3a",
+        "rev": "a9bc587e9ae0cbcb3e90a2e9342f86b3b78c4408",
         "type": "github"
       },
       "original": {
@@ -1503,11 +1503,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1725513492,
-        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
+        "lastModified": 1726745158,
+        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
+        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
         "type": "github"
       },
       "original": {
@@ -1581,11 +1581,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1726829280,
-        "narHash": "sha256-n3w3zmFcAA1x9U53pu9H2vH7dbCbSVNo+aHDZ9SPpf4=",
+        "lastModified": 1727446547,
+        "narHash": "sha256-fQZe0CtY+gXLeuv1+hr2CJwUWK2lvdOFJ9HNlq3brAo=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "f9ecc0c3084186a60513b83139a643a5cbf3bdf7",
+        "rev": "ebbd10006d2deeb71c46d58c4c69aa3d5c088310",
         "type": "github"
       },
       "original": {
@@ -1658,11 +1658,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1726712810,
-        "narHash": "sha256-3gFcpdzRPAeGrB69FbCLYO16BWnkAb0hRawi9//t7QM=",
+        "lastModified": 1727310136,
+        "narHash": "sha256-b94coi21QBmm8dCfulIbiw0lI9SAqodaBqMgb3j8qBU=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "b5fd7f7ae0ea4537511077ed8ef4a6021cedba2f",
+        "rev": "cb3f98d935842836cc115e8c9e4b38c1380fbb6b",
         "type": "github"
       },
       "original": {
@@ -1694,11 +1694,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1726797642,
-        "narHash": "sha256-+0C+hY/CD8876PaliC+JnuIzUgkO+QtfO7Z1+ihGgC4=",
+        "lastModified": 1726878294,
+        "narHash": "sha256-9jof2xfh8Ett7KtXqPnWMh60bPQSM1mfWQv2QeD/zYY=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "31bd21ac46b2b6039aa0b856ca02b018cf549ef7",
+        "rev": "26220156aafb198b2de6a4cf80c1b120a3768da0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/1ef74b546732f185d0f806860fa5404df7614f28' (2024-09-04)
  → 'github:lewis6991/gitsigns.nvim/863903631e676b33e8be2acb17512fdc1b80b4fb' (2024-09-27)
• Updated input 'home-manager':
    'github:nix-community/home-manager/dfe4d334b172071e7189d971ddecd3a7f811b48d' (2024-09-20)
  → 'github:nix-community/home-manager/ffe2d07e771580a005e675108212597e5b367d2d' (2024-09-26)
• Updated input 'lspkind-nvim':
    'github:onsails/lspkind.nvim/cff4ae321a91ee3473a92ea1a8c637e3a9510aec' (2024-07-25)
  → 'github:onsails/lspkind.nvim/59c3f419af48a2ffb2320cea85e44e5a95f71664' (2024-09-26)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/25aca068d0bd63c6db17c29bd3641256ea62a2c1' (2024-09-20)
  → 'github:nix-community/neovim-nightly-overlay/6a21da1b53a9a5c6467694b9456b4447cbd69816' (2024-09-27)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/f01c764cc6f82399edfa0d47a7bafbf7c95e2747' (2024-09-19)
  → 'github:neovim/neovim/a9287dd882e082a17fc7dcf004d3f991ed29001b' (2024-09-26)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/294eb5975def0caa718fca92dc5a9d656ae392a9' (2024-09-18)
  → 'github:nixos/nixpkgs/28b5b8af91ffd2623e995e20aee56510db49001a' (2024-09-26)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/b064131428f6bbbbc905f4451ba6779fda334a3a' (2024-09-20)
  → 'github:neovim/nvim-lspconfig/a9bc587e9ae0cbcb3e90a2e9342f86b3b78c4408' (2024-09-25)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/f9ecc0c3084186a60513b83139a643a5cbf3bdf7' (2024-09-20)
  → 'github:mrcjkb/rustaceanvim/ebbd10006d2deeb71c46d58c4c69aa3d5c088310' (2024-09-27)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/b628f6aef1453ebad58a970070c112855e93c044' (2024-09-14)
  → 'github:nvim-neorocks/neorocks/39308fea510539a516a2620f859dd2c8f96fc935' (2024-09-21)
• Updated input 'rustacean-nvim/neorocks/git-hooks':
    'github:cachix/git-hooks.nix/7570de7b9b504cfe92025dd1be797bf546f66528' (2024-09-05)
  → 'github:cachix/git-hooks.nix/4e743a6920eab45e8ba0fbe49dc459f1423a4b74' (2024-09-19)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/3b426df85fb2edc0da26673c464709e9c8b0c654' (2024-09-13)
  → 'github:nix-community/neovim-nightly-overlay/25aca068d0bd63c6db17c29bd3641256ea62a2c1' (2024-09-20)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks':
    'github:cachix/git-hooks.nix/7570de7b9b504cfe92025dd1be797bf546f66528' (2024-09-05)
  → 'github:cachix/git-hooks.nix/4e743a6920eab45e8ba0fbe49dc459f1423a4b74' (2024-09-19)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/deac7df80a1491ae65b68a1a1047902bcd775adc' (2024-09-12)
  → 'github:neovim/neovim/f01c764cc6f82399edfa0d47a7bafbf7c95e2747' (2024-09-19)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/111ed8812c10d7dc3017de46cbf509600c93f551' (2024-09-12)
  → 'github:NixOS/nixpkgs/658e7223191d2598641d50ee4e898126768fe847' (2024-09-17)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/673d99f1406cb09b8eb6feab4743ebdf70046557' (2024-09-13)
  → 'github:nixos/nixpkgs/268bb5090a3c6ac5e1615b38542a868b52ef8088' (2024-09-19)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/673d99f1406cb09b8eb6feab4743ebdf70046557' (2024-09-13)
  → 'github:nixos/nixpkgs/a1d92660c6b3b7c26fb883500a80ea9d33321be2' (2024-09-20)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/7570de7b9b504cfe92025dd1be797bf546f66528' (2024-09-05)
  → 'github:cachix/pre-commit-hooks.nix/4e743a6920eab45e8ba0fbe49dc459f1423a4b74' (2024-09-19)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/b5fd7f7ae0ea4537511077ed8ef4a6021cedba2f' (2024-09-19)
  → 'github:nvim-telescope/telescope.nvim/cb3f98d935842836cc115e8c9e4b38c1380fbb6b' (2024-09-26)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/31bd21ac46b2b6039aa0b856ca02b018cf549ef7' (2024-09-20)
  → 'github:nvim-tree/nvim-web-devicons/26220156aafb198b2de6a4cf80c1b120a3768da0' (2024-09-21)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`3b426df8` ➡️ `25aca068`](https://github.com/nix-community/neovim-nightly-overlay/compare/3b426df85fb2edc0da26673c464709e9c8b0c654...25aca068d0bd63c6db17c29bd3641256ea62a2c1) <sub>(2024-09-13 to 2024-09-20)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`f9ecc0c3` ➡️ `ebbd1000`](https://github.com/mrcjkb/rustaceanvim/compare/f9ecc0c3084186a60513b83139a643a5cbf3bdf7...ebbd10006d2deeb71c46d58c4c69aa3d5c088310) <sub>(2024-09-20 to 2024-09-27)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`673d99f1` ➡️ `268bb509`](https://github.com/nixos/nixpkgs/compare/673d99f1406cb09b8eb6feab4743ebdf70046557...268bb5090a3c6ac5e1615b38542a868b52ef8088) <sub>(2024-09-13 to 2024-09-19)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`b628f6ae` ➡️ `39308fea`](https://github.com/nvim-neorocks/neorocks/compare/b628f6aef1453ebad58a970070c112855e93c044...39308fea510539a516a2620f859dd2c8f96fc935) <sub>(2024-09-14 to 2024-09-21)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [`deac7df8` ➡️ `f01c764c`](https://github.com/neovim/neovim/compare/deac7df80a1491ae65b68a1a1047902bcd775adc...f01c764cc6f82399edfa0d47a7bafbf7c95e2747) <sub>(2024-09-12 to 2024-09-19)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`25aca068` ➡️ `6a21da1b`](https://github.com/nix-community/neovim-nightly-overlay/compare/25aca068d0bd63c6db17c29bd3641256ea62a2c1...6a21da1b53a9a5c6467694b9456b4447cbd69816) <sub>(2024-09-20 to 2024-09-27)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`b0641314` ➡️ `a9bc587e`](https://github.com/neovim/nvim-lspconfig/compare/b064131428f6bbbbc905f4451ba6779fda334a3a...a9bc587e9ae0cbcb3e90a2e9342f86b3b78c4408) <sub>(2024-09-20 to 2024-09-25)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`7570de7b` ➡️ `4e743a69`](https://github.com/cachix/pre-commit-hooks.nix/compare/7570de7b9b504cfe92025dd1be797bf546f66528...4e743a6920eab45e8ba0fbe49dc459f1423a4b74) <sub>(2024-09-05 to 2024-09-19)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`673d99f1` ➡️ `a1d92660`](https://github.com/nixos/nixpkgs/compare/673d99f1406cb09b8eb6feab4743ebdf70046557...a1d92660c6b3b7c26fb883500a80ea9d33321be2) <sub>(2024-09-13 to 2024-09-20)</sub>
 - Updated input [`rustacean-nvim/neorocks/git-hooks`](https://github.com/cachix/git-hooks.nix): [`7570de7b` ➡️ `4e743a69`](https://github.com/cachix/git-hooks.nix/compare/7570de7b9b504cfe92025dd1be797bf546f66528...4e743a6920eab45e8ba0fbe49dc459f1423a4b74) <sub>(2024-09-05 to 2024-09-19)</sub>
 - Updated input [`lspkind-nvim`](https://github.com/onsails/lspkind.nvim): [`cff4ae32` ➡️ `59c3f419`](https://github.com/onsails/lspkind.nvim/compare/cff4ae321a91ee3473a92ea1a8c637e3a9510aec...59c3f419af48a2ffb2320cea85e44e5a95f71664) <sub>(2024-07-25 to 2024-09-26)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`1ef74b54` ➡️ `86390363`](https://github.com/lewis6991/gitsigns.nvim/compare/1ef74b546732f185d0f806860fa5404df7614f28...863903631e676b33e8be2acb17512fdc1b80b4fb) <sub>(2024-09-04 to 2024-09-27)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`294eb597` ➡️ `28b5b8af`](https://github.com/nixos/nixpkgs/compare/294eb5975def0caa718fca92dc5a9d656ae392a9...28b5b8af91ffd2623e995e20aee56510db49001a) <sub>(2024-09-18 to 2024-09-26)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`b5fd7f7a` ➡️ `cb3f98d9`](https://github.com/nvim-telescope/telescope.nvim/compare/b5fd7f7ae0ea4537511077ed8ef4a6021cedba2f...cb3f98d935842836cc115e8c9e4b38c1380fbb6b) <sub>(2024-09-19 to 2024-09-26)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`111ed881` ➡️ `658e7223`](https://github.com/NixOS/nixpkgs/compare/111ed8812c10d7dc3017de46cbf509600c93f551...658e7223191d2598641d50ee4e898126768fe847) <sub>(2024-09-12 to 2024-09-17)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`31bd21ac` ➡️ `26220156`](https://github.com/nvim-tree/nvim-web-devicons/compare/31bd21ac46b2b6039aa0b856ca02b018cf549ef7...26220156aafb198b2de6a4cf80c1b120a3768da0) <sub>(2024-09-20 to 2024-09-21)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks`](https://github.com/cachix/git-hooks.nix): [`7570de7b` ➡️ `4e743a69`](https://github.com/cachix/git-hooks.nix/compare/7570de7b9b504cfe92025dd1be797bf546f66528...4e743a6920eab45e8ba0fbe49dc459f1423a4b74) <sub>(2024-09-05 to 2024-09-19)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`dfe4d334` ➡️ `ffe2d07e`](https://github.com/nix-community/home-manager/compare/dfe4d334b172071e7189d971ddecd3a7f811b48d...ffe2d07e771580a005e675108212597e5b367d2d) <sub>(2024-09-20 to 2024-09-26)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`f01c764c` ➡️ `a9287dd8`](https://github.com/neovim/neovim/compare/f01c764cc6f82399edfa0d47a7bafbf7c95e2747...a9287dd882e082a17fc7dcf004d3f991ed29001b) <sub>(2024-09-19 to 2024-09-26)</sub>