### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -232,11 +232,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726153070,
-        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
         "type": "github"
       },
       "original": {
@@ -521,11 +521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726745158,
-        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
+        "lastModified": 1727805723,
+        "narHash": "sha256-b8flytpuc4Ey/g3mcvpS/ICORcD4h56QDZeP5LogevY=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
+        "rev": "2f5ae3fc91db865eff2c5a418da85a0fbe6238a3",
         "type": "github"
       },
       "original": {
@@ -843,11 +843,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727383923,
-        "narHash": "sha256-4/vacp3CwdGoPf8U4e/N8OsGYtO09WTcQK5FqYfJbKs=",
+        "lastModified": 1728041527,
+        "narHash": "sha256-03liqiJtk9UP7YQHW4r8MduKCK242FQzud8iWvvlK+o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ffe2d07e771580a005e675108212597e5b367d2d",
+        "rev": "509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e",
         "type": "github"
       },
       "original": {
@@ -1044,11 +1044,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1726896389,
-        "narHash": "sha256-Qxh7GmtsB94T9EzROLvXIr486c//1M+S8apU7KoTVA0=",
+        "lastModified": 1727501146,
+        "narHash": "sha256-0iPwQojksI+NGB2iAj/pqf0ckqUUDKyBNzinFrGHK1s=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "39308fea510539a516a2620f859dd2c8f96fc935",
+        "rev": "c7c04e570ae09ed36a78e4ce6ca6728765236526",
         "type": "github"
       },
       "original": {
@@ -1067,11 +1067,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1726814269,
-        "narHash": "sha256-eXI81wCtybqgK05ky5/tmj4AZDKmtoNQcGZEX0vnoe8=",
+        "lastModified": 1727415632,
+        "narHash": "sha256-PApi0lMoKu8Ragc1pyrcgFyye1Xhfh4qsL+tMyvnYjw=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "25aca068d0bd63c6db17c29bd3641256ea62a2c1",
+        "rev": "6a21da1b53a9a5c6467694b9456b4447cbd69816",
         "type": "github"
       },
       "original": {
@@ -1092,11 +1092,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727415632,
-        "narHash": "sha256-PApi0lMoKu8Ragc1pyrcgFyye1Xhfh4qsL+tMyvnYjw=",
+        "lastModified": 1727852635,
+        "narHash": "sha256-eY0Y5ZDMo5IS+K42kMwAMCLsYHoAgPW3R4UxeGfzP0U=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "6a21da1b53a9a5c6467694b9456b4447cbd69816",
+        "rev": "377cf41246ee443c86c4ae48f66f5100038fe158",
         "type": "github"
       },
       "original": {
@@ -1108,11 +1108,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1727394046,
-        "narHash": "sha256-vhOhvCtNWeuqtjMnV87Xb2zgFDJJUrWcAofzQNYyiR8=",
+        "lastModified": 1727825968,
+        "narHash": "sha256-7DbbGIAbJesqYEkZh2FaEo5wycZ/cRbvZP6k01Z5+ZM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "a9287dd882e082a17fc7dcf004d3f991ed29001b",
+        "rev": "2168d772b864fd05109fb4299e409d4bdc1df39d",
         "type": "github"
       },
       "original": {
@@ -1124,11 +1124,11 @@
     "neovim-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1726786786,
-        "narHash": "sha256-SMRChiJK6Td+TtiphiXP+fc8ZNElfmAeHTF2y2y9y9w=",
+        "lastModified": 1727394046,
+        "narHash": "sha256-vhOhvCtNWeuqtjMnV87Xb2zgFDJJUrWcAofzQNYyiR8=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "f01c764cc6f82399edfa0d47a7bafbf7c95e2747",
+        "rev": "a9287dd882e082a17fc7dcf004d3f991ed29001b",
         "type": "github"
       },
       "original": {
@@ -1299,11 +1299,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1727335715,
-        "narHash": "sha256-1uw3y94dA4l22LkqHRIsb7qr3rV5XdxQFqctINfx8Cc=",
+        "lastModified": 1728031656,
+        "narHash": "sha256-JXumn7X+suKEcehp4rchSvBzIboqyybQ5bLK4wk7gQU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "28b5b8af91ffd2623e995e20aee56510db49001a",
+        "rev": "eeeb90a1dd3c9bea3afdbc76fd34d0fb2a727c7a",
         "type": "github"
       },
       "original": {
@@ -1363,11 +1363,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1726583932,
-        "narHash": "sha256-zACxiQx8knB3F8+Ze+1BpiYrI+CbhxyWpcSID9kVhkQ=",
+        "lastModified": 1727296349,
+        "narHash": "sha256-C3SRU3GMDNII9l16o4+nkybuxaDX4x5TBypwmmUBCo0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "658e7223191d2598641d50ee4e898126768fe847",
+        "rev": "fe866c653c24adf1520628236d4e70bbb2fdd949",
         "type": "github"
       },
       "original": {
@@ -1379,11 +1379,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1726745986,
-        "narHash": "sha256-xB35C2fpz7iyNcj9sn0a+wM2C4CQ6DGTn5VUHogstYs=",
+        "lastModified": 1727335715,
+        "narHash": "sha256-1uw3y94dA4l22LkqHRIsb7qr3rV5XdxQFqctINfx8Cc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "268bb5090a3c6ac5e1615b38542a868b52ef8088",
+        "rev": "28b5b8af91ffd2623e995e20aee56510db49001a",
         "type": "github"
       },
       "original": {
@@ -1395,11 +1395,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1726871744,
-        "narHash": "sha256-V5LpfdHyQkUF7RfOaDPrZDP+oqz88lTJrMT1+stXNwo=",
+        "lastModified": 1727524699,
+        "narHash": "sha256-k6YxGj08voz9NvuKExojiGXAVd69M8COtqWSKr6sQS4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a1d92660c6b3b7c26fb883500a80ea9d33321be2",
+        "rev": "b5b2fecd0cadd82ef107c9583018f381ae70f222",
         "type": "github"
       },
       "original": {
@@ -1444,11 +1444,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1727236446,
-        "narHash": "sha256-0P1BCn5vxrQHHN/wvpLVg4a0iSTuDKpHWUOo5VoP0to=",
+        "lastModified": 1728044677,
+        "narHash": "sha256-mVDPT2b3p7LvKBc17kS2FLmhljtFTv1CHe5+u8PcaWk=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "a9bc587e9ae0cbcb3e90a2e9342f86b3b78c4408",
+        "rev": "39f31e178466e4ed23c8ea6fddd5b7a4d9699398",
         "type": "github"
       },
       "original": {
@@ -1503,11 +1503,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1726745158,
-        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
+        "lastModified": 1727514110,
+        "narHash": "sha256-0YRcOxJG12VGDFH8iS8pJ0aYQQUAgo/r3ZAL+cSh9nk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
+        "rev": "85f7a7177c678de68224af3402ab8ee1bcee25c8",
         "type": "github"
       },
       "original": {
@@ -1581,11 +1581,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1727446547,
-        "narHash": "sha256-fQZe0CtY+gXLeuv1+hr2CJwUWK2lvdOFJ9HNlq3brAo=",
+        "lastModified": 1727792308,
+        "narHash": "sha256-jZ89BylW17fR2gT4eHtl36ryxng5l1JqscMwD4xrMvU=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "ebbd10006d2deeb71c46d58c4c69aa3d5c088310",
+        "rev": "29f42cc149f915d771c550b6dfe7c788d856cf04",
         "type": "github"
       },
       "original": {
@@ -1658,11 +1658,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1727310136,
-        "narHash": "sha256-b94coi21QBmm8dCfulIbiw0lI9SAqodaBqMgb3j8qBU=",
+        "lastModified": 1727679374,
+        "narHash": "sha256-IwUBAPaWmwZtZgom7Nb6JvxGgignHXoTpKYZeW6fmBo=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "cb3f98d935842836cc115e8c9e4b38c1380fbb6b",
+        "rev": "eae0d8fbde590b0eaa2f9481948cd6fd7dd21656",
         "type": "github"
       },
       "original": {
@@ -1694,11 +1694,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1726878294,
-        "narHash": "sha256-9jof2xfh8Ett7KtXqPnWMh60bPQSM1mfWQv2QeD/zYY=",
+        "lastModified": 1727657734,
+        "narHash": "sha256-L8h0CiOYwZVFjsTH6XiEb/636RiFLxE7YhH00uv2zK4=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "26220156aafb198b2de6a4cf80c1b120a3768da0",
+        "rev": "6b53401918a9033a41159d012160c5fb5eb249ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/ffe2d07e771580a005e675108212597e5b367d2d' (2024-09-26)
  → 'github:nix-community/home-manager/509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e' (2024-10-04)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/6a21da1b53a9a5c6467694b9456b4447cbd69816' (2024-09-27)
  → 'github:nix-community/neovim-nightly-overlay/377cf41246ee443c86c4ae48f66f5100038fe158' (2024-10-02)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a' (2024-09-12)
  → 'github:hercules-ci/flake-parts/3d04084d54bedc3d6b8b736c70ef449225c361b1' (2024-10-01)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/4e743a6920eab45e8ba0fbe49dc459f1423a4b74' (2024-09-19)
  → 'github:cachix/git-hooks.nix/2f5ae3fc91db865eff2c5a418da85a0fbe6238a3' (2024-10-01)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/a9287dd882e082a17fc7dcf004d3f991ed29001b' (2024-09-26)
  → 'github:neovim/neovim/2168d772b864fd05109fb4299e409d4bdc1df39d' (2024-10-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/28b5b8af91ffd2623e995e20aee56510db49001a' (2024-09-26)
  → 'github:nixos/nixpkgs/eeeb90a1dd3c9bea3afdbc76fd34d0fb2a727c7a' (2024-10-04)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/a9bc587e9ae0cbcb3e90a2e9342f86b3b78c4408' (2024-09-25)
  → 'github:neovim/nvim-lspconfig/39f31e178466e4ed23c8ea6fddd5b7a4d9699398' (2024-10-04)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/ebbd10006d2deeb71c46d58c4c69aa3d5c088310' (2024-09-27)
  → 'github:mrcjkb/rustaceanvim/29f42cc149f915d771c550b6dfe7c788d856cf04' (2024-10-01)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/39308fea510539a516a2620f859dd2c8f96fc935' (2024-09-21)
  → 'github:nvim-neorocks/neorocks/c7c04e570ae09ed36a78e4ce6ca6728765236526' (2024-09-28)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/25aca068d0bd63c6db17c29bd3641256ea62a2c1' (2024-09-20)
  → 'github:nix-community/neovim-nightly-overlay/6a21da1b53a9a5c6467694b9456b4447cbd69816' (2024-09-27)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/f01c764cc6f82399edfa0d47a7bafbf7c95e2747' (2024-09-19)
  → 'github:neovim/neovim/a9287dd882e082a17fc7dcf004d3f991ed29001b' (2024-09-26)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/658e7223191d2598641d50ee4e898126768fe847' (2024-09-17)
  → 'github:NixOS/nixpkgs/fe866c653c24adf1520628236d4e70bbb2fdd949' (2024-09-25)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/268bb5090a3c6ac5e1615b38542a868b52ef8088' (2024-09-19)
  → 'github:nixos/nixpkgs/28b5b8af91ffd2623e995e20aee56510db49001a' (2024-09-26)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/a1d92660c6b3b7c26fb883500a80ea9d33321be2' (2024-09-20)
  → 'github:nixos/nixpkgs/b5b2fecd0cadd82ef107c9583018f381ae70f222' (2024-09-28)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/4e743a6920eab45e8ba0fbe49dc459f1423a4b74' (2024-09-19)
  → 'github:cachix/pre-commit-hooks.nix/85f7a7177c678de68224af3402ab8ee1bcee25c8' (2024-09-28)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/cb3f98d935842836cc115e8c9e4b38c1380fbb6b' (2024-09-26)
  → 'github:nvim-telescope/telescope.nvim/eae0d8fbde590b0eaa2f9481948cd6fd7dd21656' (2024-09-30)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/26220156aafb198b2de6a4cf80c1b120a3768da0' (2024-09-21)
  → 'github:nvim-tree/nvim-web-devicons/6b53401918a9033a41159d012160c5fb5eb249ae' (2024-09-30)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`25aca068` ➡️ `6a21da1b`](https://github.com/nix-community/neovim-nightly-overlay/compare/25aca068d0bd63c6db17c29bd3641256ea62a2c1...6a21da1b53a9a5c6467694b9456b4447cbd69816) <sub>(2024-09-20 to 2024-09-27)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`ebbd1000` ➡️ `29f42cc1`](https://github.com/mrcjkb/rustaceanvim/compare/ebbd10006d2deeb71c46d58c4c69aa3d5c088310...29f42cc149f915d771c550b6dfe7c788d856cf04) <sub>(2024-09-27 to 2024-10-01)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`268bb509` ➡️ `28b5b8af`](https://github.com/nixos/nixpkgs/compare/268bb5090a3c6ac5e1615b38542a868b52ef8088...28b5b8af91ffd2623e995e20aee56510db49001a) <sub>(2024-09-19 to 2024-09-26)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`39308fea` ➡️ `c7c04e57`](https://github.com/nvim-neorocks/neorocks/compare/39308fea510539a516a2620f859dd2c8f96fc935...c7c04e570ae09ed36a78e4ce6ca6728765236526) <sub>(2024-09-21 to 2024-09-28)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [`f01c764c` ➡️ `a9287dd8`](https://github.com/neovim/neovim/compare/f01c764cc6f82399edfa0d47a7bafbf7c95e2747...a9287dd882e082a17fc7dcf004d3f991ed29001b) <sub>(2024-09-19 to 2024-09-26)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`6a21da1b` ➡️ `377cf412`](https://github.com/nix-community/neovim-nightly-overlay/compare/6a21da1b53a9a5c6467694b9456b4447cbd69816...377cf41246ee443c86c4ae48f66f5100038fe158) <sub>(2024-09-27 to 2024-10-02)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`a9bc587e` ➡️ `39f31e17`](https://github.com/neovim/nvim-lspconfig/compare/a9bc587e9ae0cbcb3e90a2e9342f86b3b78c4408...39f31e178466e4ed23c8ea6fddd5b7a4d9699398) <sub>(2024-09-25 to 2024-10-04)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`4e743a69` ➡️ `85f7a717`](https://github.com/cachix/pre-commit-hooks.nix/compare/4e743a6920eab45e8ba0fbe49dc459f1423a4b74...85f7a7177c678de68224af3402ab8ee1bcee25c8) <sub>(2024-09-19 to 2024-09-28)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`a1d92660` ➡️ `b5b2fecd`](https://github.com/nixos/nixpkgs/compare/a1d92660c6b3b7c26fb883500a80ea9d33321be2...b5b2fecd0cadd82ef107c9583018f381ae70f222) <sub>(2024-09-20 to 2024-09-28)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`28b5b8af` ➡️ `eeeb90a1`](https://github.com/nixos/nixpkgs/compare/28b5b8af91ffd2623e995e20aee56510db49001a...eeeb90a1dd3c9bea3afdbc76fd34d0fb2a727c7a) <sub>(2024-09-26 to 2024-10-04)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`4e743a69` ➡️ `2f5ae3fc`](https://github.com/cachix/git-hooks.nix/compare/4e743a6920eab45e8ba0fbe49dc459f1423a4b74...2f5ae3fc91db865eff2c5a418da85a0fbe6238a3) <sub>(2024-09-19 to 2024-10-01)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`cb3f98d9` ➡️ `eae0d8fb`](https://github.com/nvim-telescope/telescope.nvim/compare/cb3f98d935842836cc115e8c9e4b38c1380fbb6b...eae0d8fbde590b0eaa2f9481948cd6fd7dd21656) <sub>(2024-09-26 to 2024-09-30)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`658e7223` ➡️ `fe866c65`](https://github.com/NixOS/nixpkgs/compare/658e7223191d2598641d50ee4e898126768fe847...fe866c653c24adf1520628236d4e70bbb2fdd949) <sub>(2024-09-17 to 2024-09-25)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`26220156` ➡️ `6b534019`](https://github.com/nvim-tree/nvim-web-devicons/compare/26220156aafb198b2de6a4cf80c1b120a3768da0...6b53401918a9033a41159d012160c5fb5eb249ae) <sub>(2024-09-21 to 2024-09-30)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`ffe2d07e` ➡️ `509dbf8d`](https://github.com/nix-community/home-manager/compare/ffe2d07e771580a005e675108212597e5b367d2d...509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e) <sub>(2024-09-26 to 2024-10-04)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`a9287dd8` ➡️ `2168d772`](https://github.com/neovim/neovim/compare/a9287dd882e082a17fc7dcf004d3f991ed29001b...2168d772b864fd05109fb4299e409d4bdc1df39d) <sub>(2024-09-26 to 2024-10-01)</sub>
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`bcef6817` ➡️ `3d04084d`](https://github.com/hercules-ci/flake-parts/compare/bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a...3d04084d54bedc3d6b8b736c70ef449225c361b1) <sub>(2024-09-12 to 2024-10-01)</sub>