### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -271,11 +271,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1726153070,
-        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1726153070,
-        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
         "type": "github"
       },
       "original": {
@@ -330,11 +330,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726153070,
-        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
         "type": "github"
       },
       "original": {
@@ -521,11 +521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727805723,
-        "narHash": "sha256-b8flytpuc4Ey/g3mcvpS/ICORcD4h56QDZeP5LogevY=",
+        "lastModified": 1728580416,
+        "narHash": "sha256-nKttjKg6lE7O5S+wlBOkXsUGdOgVxZ8SWaCOyodW5so=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "2f5ae3fc91db865eff2c5a418da85a0fbe6238a3",
+        "rev": "4ebefcac44b5116cf5741be858245db769ddedd1",
         "type": "github"
       },
       "original": {
@@ -567,11 +567,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1726745158,
-        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
+        "lastModified": 1728092656,
+        "narHash": "sha256-eMeCTJZ5xBeQ0f9Os7K8DThNVSo9gy4umZLDfF5q6OM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
+        "rev": "1211305a5b237771e13fcca0c51e60ad47326a9a",
         "type": "github"
       },
       "original": {
@@ -598,11 +598,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726745158,
-        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
+        "lastModified": 1727805723,
+        "narHash": "sha256-b8flytpuc4Ey/g3mcvpS/ICORcD4h56QDZeP5LogevY=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
+        "rev": "2f5ae3fc91db865eff2c5a418da85a0fbe6238a3",
         "type": "github"
       },
       "original": {
@@ -843,11 +843,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728041527,
-        "narHash": "sha256-03liqiJtk9UP7YQHW4r8MduKCK242FQzud8iWvvlK+o=",
+        "lastModified": 1728650932,
+        "narHash": "sha256-mGKzqdsRyLnGNl6WjEr7+sghGgBtYHhJQ4mjpgRTCsU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e",
+        "rev": "65ae9c147349829d3df0222151f53f79821c5134",
         "type": "github"
       },
       "original": {
@@ -1044,11 +1044,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1727501146,
-        "narHash": "sha256-0iPwQojksI+NGB2iAj/pqf0ckqUUDKyBNzinFrGHK1s=",
+        "lastModified": 1728105821,
+        "narHash": "sha256-8R1NGPbmS4nNiKLUL2hGxfgXcNwHQqWTZtUJylVCfdg=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "c7c04e570ae09ed36a78e4ce6ca6728765236526",
+        "rev": "189645e30fd7f038c08df2ac665c4282ce810f87",
         "type": "github"
       },
       "original": {
@@ -1067,11 +1067,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1727415632,
-        "narHash": "sha256-PApi0lMoKu8Ragc1pyrcgFyye1Xhfh4qsL+tMyvnYjw=",
+        "lastModified": 1727852635,
+        "narHash": "sha256-eY0Y5ZDMo5IS+K42kMwAMCLsYHoAgPW3R4UxeGfzP0U=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "6a21da1b53a9a5c6467694b9456b4447cbd69816",
+        "rev": "377cf41246ee443c86c4ae48f66f5100038fe158",
         "type": "github"
       },
       "original": {
@@ -1092,11 +1092,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727852635,
-        "narHash": "sha256-eY0Y5ZDMo5IS+K42kMwAMCLsYHoAgPW3R4UxeGfzP0U=",
+        "lastModified": 1728631701,
+        "narHash": "sha256-LPqpJVV8Ws4uDfzp/Huu6myMW33lmZbFGTMoZ9LyRCU=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "377cf41246ee443c86c4ae48f66f5100038fe158",
+        "rev": "a2de61747149100c904c01eb8915e1c6ecec0379",
         "type": "github"
       },
       "original": {
@@ -1108,11 +1108,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1727825968,
-        "narHash": "sha256-7DbbGIAbJesqYEkZh2FaEo5wycZ/cRbvZP6k01Z5+ZM=",
+        "lastModified": 1728600525,
+        "narHash": "sha256-Q2QHD23/bkNdYTbXaRLaVYy/uUx3gw08NAehTfF5ZXs=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "2168d772b864fd05109fb4299e409d4bdc1df39d",
+        "rev": "6f1601a1b94e6ea724d8436600c64760525d1d2b",
         "type": "github"
       },
       "original": {
@@ -1124,11 +1124,11 @@
     "neovim-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1727394046,
-        "narHash": "sha256-vhOhvCtNWeuqtjMnV87Xb2zgFDJJUrWcAofzQNYyiR8=",
+        "lastModified": 1727825968,
+        "narHash": "sha256-7DbbGIAbJesqYEkZh2FaEo5wycZ/cRbvZP6k01Z5+ZM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "a9287dd882e082a17fc7dcf004d3f991ed29001b",
+        "rev": "2168d772b864fd05109fb4299e409d4bdc1df39d",
         "type": "github"
       },
       "original": {
@@ -1171,14 +1171,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1725233747,
-        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "lastModified": 1727825735,
+        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       }
     },
     "nixpkgs-lib_2": {
@@ -1195,14 +1195,14 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1725233747,
-        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "lastModified": 1727825735,
+        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       }
     },
     "nixpkgs-lib_4": {
@@ -1299,11 +1299,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1728031656,
-        "narHash": "sha256-JXumn7X+suKEcehp4rchSvBzIboqyybQ5bLK4wk7gQU=",
+        "lastModified": 1728538411,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eeeb90a1dd3c9bea3afdbc76fd34d0fb2a727c7a",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
         "type": "github"
       },
       "original": {
@@ -1363,11 +1363,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1727296349,
-        "narHash": "sha256-C3SRU3GMDNII9l16o4+nkybuxaDX4x5TBypwmmUBCo0=",
+        "lastModified": 1727747005,
+        "narHash": "sha256-2PBox0LkPhxirg1asEIpvfFARjq5KLw0EHPCy4unjPs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe866c653c24adf1520628236d4e70bbb2fdd949",
+        "rev": "9682b2197dabc185fcca802ac1ac21136e48fcc2",
         "type": "github"
       },
       "original": {
@@ -1379,11 +1379,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1727335715,
-        "narHash": "sha256-1uw3y94dA4l22LkqHRIsb7qr3rV5XdxQFqctINfx8Cc=",
+        "lastModified": 1728031656,
+        "narHash": "sha256-JXumn7X+suKEcehp4rchSvBzIboqyybQ5bLK4wk7gQU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "28b5b8af91ffd2623e995e20aee56510db49001a",
+        "rev": "eeeb90a1dd3c9bea3afdbc76fd34d0fb2a727c7a",
         "type": "github"
       },
       "original": {
@@ -1395,11 +1395,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1727524699,
-        "narHash": "sha256-k6YxGj08voz9NvuKExojiGXAVd69M8COtqWSKr6sQS4=",
+        "lastModified": 1728093190,
+        "narHash": "sha256-CAZF2NRuHmqTtRTNAruWpHA43Gg2UvuCNEIzabP0l6M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b5b2fecd0cadd82ef107c9583018f381ae70f222",
+        "rev": "e2f08f4d8b3ecb5cf5c9fd9cb2d53bb3c71807da",
         "type": "github"
       },
       "original": {
@@ -1444,11 +1444,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1728044677,
-        "narHash": "sha256-mVDPT2b3p7LvKBc17kS2FLmhljtFTv1CHe5+u8PcaWk=",
+        "lastModified": 1728624528,
+        "narHash": "sha256-886MSejFWKGH13RKh/uw7rkurEWcdvDJLRMSd3iVbs4=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "39f31e178466e4ed23c8ea6fddd5b7a4d9699398",
+        "rev": "c38af37e4ee71d70b7d60267d96b0a83e5d346f5",
         "type": "github"
       },
       "original": {
@@ -1503,11 +1503,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1727514110,
-        "narHash": "sha256-0YRcOxJG12VGDFH8iS8pJ0aYQQUAgo/r3ZAL+cSh9nk=",
+        "lastModified": 1728092656,
+        "narHash": "sha256-eMeCTJZ5xBeQ0f9Os7K8DThNVSo9gy4umZLDfF5q6OM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "85f7a7177c678de68224af3402ab8ee1bcee25c8",
+        "rev": "1211305a5b237771e13fcca0c51e60ad47326a9a",
         "type": "github"
       },
       "original": {
@@ -1519,11 +1519,11 @@
     "resty-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1728240593,
-        "narHash": "sha256-SNDtNVlh4NuyyNkepP2JmOhToyQ06zQfbgJij5wGWKs=",
+        "lastModified": 1728670756,
+        "narHash": "sha256-sg1DMnDZQX8M4DHdcqlRCW69wIu4z0+6dhxHXnSbHzw=",
         "owner": "lima1909",
         "repo": "resty.nvim",
-        "rev": "f3991244259c8005ae1aeff71937ce88f8f949d7",
+        "rev": "e364d86dcb1f9d38a70aa3a759f65a853227392f",
         "type": "github"
       },
       "original": {
@@ -1598,11 +1598,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1727792308,
-        "narHash": "sha256-jZ89BylW17fR2gT4eHtl36ryxng5l1JqscMwD4xrMvU=",
+        "lastModified": 1728324006,
+        "narHash": "sha256-SYFbGz+eYNYTueuL1cf413K2nFx79deJ64NpRwD1vMw=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "29f42cc149f915d771c550b6dfe7c788d856cf04",
+        "rev": "d1f56672638508a7bc971cde31a29df4018579a9",
         "type": "github"
       },
       "original": {
@@ -1675,11 +1675,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1727679374,
-        "narHash": "sha256-IwUBAPaWmwZtZgom7Nb6JvxGgignHXoTpKYZeW6fmBo=",
+        "lastModified": 1728518892,
+        "narHash": "sha256-HWNfj3/b+CUFgWR26IzAuMzlSCEuiK/7n8tWHwqAAik=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "eae0d8fbde590b0eaa2f9481948cd6fd7dd21656",
+        "rev": "df534c3042572fb958586facd02841e10186707c",
         "type": "github"
       },
       "original": {
@@ -1711,11 +1711,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1727657734,
-        "narHash": "sha256-L8h0CiOYwZVFjsTH6XiEb/636RiFLxE7YhH00uv2zK4=",
+        "lastModified": 1728608318,
+        "narHash": "sha256-SUWEOp+QcfHjYaqqr4Zwvh0x91IAJXvrdMkQtuWMlGc=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "6b53401918a9033a41159d012160c5fb5eb249ae",
+        "rev": "19d257cf889f79f4022163c3fbb5e08639077bd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e' (2024-10-04)
  → 'github:nix-community/home-manager/65ae9c147349829d3df0222151f53f79821c5134' (2024-10-11)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/377cf41246ee443c86c4ae48f66f5100038fe158' (2024-10-02)
  → 'github:nix-community/neovim-nightly-overlay/a2de61747149100c904c01eb8915e1c6ecec0379' (2024-10-11)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/2f5ae3fc91db865eff2c5a418da85a0fbe6238a3' (2024-10-01)
  → 'github:cachix/git-hooks.nix/4ebefcac44b5116cf5741be858245db769ddedd1' (2024-10-10)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/2168d772b864fd05109fb4299e409d4bdc1df39d' (2024-10-01)
  → 'github:neovim/neovim/6f1601a1b94e6ea724d8436600c64760525d1d2b' (2024-10-10)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/eeeb90a1dd3c9bea3afdbc76fd34d0fb2a727c7a' (2024-10-04)
  → 'github:nixos/nixpkgs/b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221' (2024-10-10)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/39f31e178466e4ed23c8ea6fddd5b7a4d9699398' (2024-10-04)
  → 'github:neovim/nvim-lspconfig/c38af37e4ee71d70b7d60267d96b0a83e5d346f5' (2024-10-11)
• Updated input 'resty-vim':
    'github:lima1909/resty.nvim/f3991244259c8005ae1aeff71937ce88f8f949d7' (2024-10-06)
  → 'github:lima1909/resty.nvim/e364d86dcb1f9d38a70aa3a759f65a853227392f' (2024-10-11)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/29f42cc149f915d771c550b6dfe7c788d856cf04' (2024-10-01)
  → 'github:mrcjkb/rustaceanvim/d1f56672638508a7bc971cde31a29df4018579a9' (2024-10-07)
• Updated input 'rustacean-nvim/flake-parts':
    'github:hercules-ci/flake-parts/bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a' (2024-09-12)
  → 'github:hercules-ci/flake-parts/3d04084d54bedc3d6b8b736c70ef449225c361b1' (2024-10-01)
• Updated input 'rustacean-nvim/flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz?narHash=sha256-Ss8QWLXdr2JCBPcYChJhz4xJm%2Bh/xjl4G0c0XlP6a74%3D' (2024-09-01)
  → 'https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz?narHash=sha256-0xHYkMkeLVQAMa7gvkddbPqpxph%2BhDzdu1XdGPJR%2BOs%3D' (2024-10-01)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/c7c04e570ae09ed36a78e4ce6ca6728765236526' (2024-09-28)
  → 'github:nvim-neorocks/neorocks/189645e30fd7f038c08df2ac665c4282ce810f87' (2024-10-05)
• Updated input 'rustacean-nvim/neorocks/flake-parts':
    'github:hercules-ci/flake-parts/bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a' (2024-09-12)
  → 'github:hercules-ci/flake-parts/3d04084d54bedc3d6b8b736c70ef449225c361b1' (2024-10-01)
• Updated input 'rustacean-nvim/neorocks/flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz?narHash=sha256-Ss8QWLXdr2JCBPcYChJhz4xJm%2Bh/xjl4G0c0XlP6a74%3D' (2024-09-01)
  → 'https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz?narHash=sha256-0xHYkMkeLVQAMa7gvkddbPqpxph%2BhDzdu1XdGPJR%2BOs%3D' (2024-10-01)
• Updated input 'rustacean-nvim/neorocks/git-hooks':
    'github:cachix/git-hooks.nix/4e743a6920eab45e8ba0fbe49dc459f1423a4b74' (2024-09-19)
  → 'github:cachix/git-hooks.nix/1211305a5b237771e13fcca0c51e60ad47326a9a' (2024-10-05)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/6a21da1b53a9a5c6467694b9456b4447cbd69816' (2024-09-27)
  → 'github:nix-community/neovim-nightly-overlay/377cf41246ee443c86c4ae48f66f5100038fe158' (2024-10-02)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/flake-parts':
    'github:hercules-ci/flake-parts/bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a' (2024-09-12)
  → 'github:hercules-ci/flake-parts/3d04084d54bedc3d6b8b736c70ef449225c361b1' (2024-10-01)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks':
    'github:cachix/git-hooks.nix/4e743a6920eab45e8ba0fbe49dc459f1423a4b74' (2024-09-19)
  → 'github:cachix/git-hooks.nix/2f5ae3fc91db865eff2c5a418da85a0fbe6238a3' (2024-10-01)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/a9287dd882e082a17fc7dcf004d3f991ed29001b' (2024-09-26)
  → 'github:neovim/neovim/2168d772b864fd05109fb4299e409d4bdc1df39d' (2024-10-01)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/fe866c653c24adf1520628236d4e70bbb2fdd949' (2024-09-25)
  → 'github:NixOS/nixpkgs/9682b2197dabc185fcca802ac1ac21136e48fcc2' (2024-10-01)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/28b5b8af91ffd2623e995e20aee56510db49001a' (2024-09-26)
  → 'github:nixos/nixpkgs/eeeb90a1dd3c9bea3afdbc76fd34d0fb2a727c7a' (2024-10-04)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/b5b2fecd0cadd82ef107c9583018f381ae70f222' (2024-09-28)
  → 'github:nixos/nixpkgs/e2f08f4d8b3ecb5cf5c9fd9cb2d53bb3c71807da' (2024-10-05)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/85f7a7177c678de68224af3402ab8ee1bcee25c8' (2024-09-28)
  → 'github:cachix/pre-commit-hooks.nix/1211305a5b237771e13fcca0c51e60ad47326a9a' (2024-10-05)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/eae0d8fbde590b0eaa2f9481948cd6fd7dd21656' (2024-09-30)
  → 'github:nvim-telescope/telescope.nvim/df534c3042572fb958586facd02841e10186707c' (2024-10-10)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/6b53401918a9033a41159d012160c5fb5eb249ae' (2024-09-30)
  → 'github:nvim-tree/nvim-web-devicons/19d257cf889f79f4022163c3fbb5e08639077bd8' (2024-10-11)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`6a21da1b` ➡️ `377cf412`](https://github.com/nix-community/neovim-nightly-overlay/compare/6a21da1b53a9a5c6467694b9456b4447cbd69816...377cf41246ee443c86c4ae48f66f5100038fe158) <sub>(2024-09-27 to 2024-10-02)</sub>
 - Updated input `rustacean-nvim/flake-parts/nixpkgs-lib`: `356624c1` ➡️ `fb192fec` <sub>(2024-09-01 to 2024-10-01)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`29f42cc1` ➡️ `d1f56672`](https://github.com/mrcjkb/rustaceanvim/compare/29f42cc149f915d771c550b6dfe7c788d856cf04...d1f56672638508a7bc971cde31a29df4018579a9) <sub>(2024-10-01 to 2024-10-07)</sub>
 - Updated input [`resty-vim`](https://github.com/lima1909/resty.nvim): [`f3991244` ➡️ `e364d86d`](https://github.com/lima1909/resty.nvim/compare/f3991244259c8005ae1aeff71937ce88f8f949d7...e364d86dcb1f9d38a70aa3a759f65a853227392f) <sub>(2024-10-06 to 2024-10-11)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`28b5b8af` ➡️ `eeeb90a1`](https://github.com/nixos/nixpkgs/compare/28b5b8af91ffd2623e995e20aee56510db49001a...eeeb90a1dd3c9bea3afdbc76fd34d0fb2a727c7a) <sub>(2024-09-26 to 2024-10-04)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`c7c04e57` ➡️ `189645e3`](https://github.com/nvim-neorocks/neorocks/compare/c7c04e570ae09ed36a78e4ce6ca6728765236526...189645e30fd7f038c08df2ac665c4282ce810f87) <sub>(2024-09-28 to 2024-10-05)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [`a9287dd8` ➡️ `2168d772`](https://github.com/neovim/neovim/compare/a9287dd882e082a17fc7dcf004d3f991ed29001b...2168d772b864fd05109fb4299e409d4bdc1df39d) <sub>(2024-09-26 to 2024-10-01)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`377cf412` ➡️ `a2de6174`](https://github.com/nix-community/neovim-nightly-overlay/compare/377cf41246ee443c86c4ae48f66f5100038fe158...a2de61747149100c904c01eb8915e1c6ecec0379) <sub>(2024-10-02 to 2024-10-11)</sub>
 - Updated input `rustacean-nvim/neorocks/flake-parts/nixpkgs-lib`: `356624c1` ➡️ `fb192fec` <sub>(2024-09-01 to 2024-10-01)</sub>
 - Updated input [`rustacean-nvim/flake-parts`](https://github.com/hercules-ci/flake-parts): [`bcef6817` ➡️ `3d04084d`](https://github.com/hercules-ci/flake-parts/compare/bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a...3d04084d54bedc3d6b8b736c70ef449225c361b1) <sub>(2024-09-12 to 2024-10-01)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`39f31e17` ➡️ `c38af37e`](https://github.com/neovim/nvim-lspconfig/compare/39f31e178466e4ed23c8ea6fddd5b7a4d9699398...c38af37e4ee71d70b7d60267d96b0a83e5d346f5) <sub>(2024-10-04 to 2024-10-11)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`85f7a717` ➡️ `1211305a`](https://github.com/cachix/pre-commit-hooks.nix/compare/85f7a7177c678de68224af3402ab8ee1bcee25c8...1211305a5b237771e13fcca0c51e60ad47326a9a) <sub>(2024-09-28 to 2024-10-05)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`b5b2fecd` ➡️ `e2f08f4d`](https://github.com/nixos/nixpkgs/compare/b5b2fecd0cadd82ef107c9583018f381ae70f222...e2f08f4d8b3ecb5cf5c9fd9cb2d53bb3c71807da) <sub>(2024-09-28 to 2024-10-05)</sub>
 - Updated input [`rustacean-nvim/neorocks/git-hooks`](https://github.com/cachix/git-hooks.nix): [`4e743a69` ➡️ `1211305a`](https://github.com/cachix/git-hooks.nix/compare/4e743a6920eab45e8ba0fbe49dc459f1423a4b74...1211305a5b237771e13fcca0c51e60ad47326a9a) <sub>(2024-09-19 to 2024-10-05)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`eeeb90a1` ➡️ `b69de56f`](https://github.com/nixos/nixpkgs/compare/eeeb90a1dd3c9bea3afdbc76fd34d0fb2a727c7a...b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221) <sub>(2024-10-04 to 2024-10-10)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`2f5ae3fc` ➡️ `4ebefcac`](https://github.com/cachix/git-hooks.nix/compare/2f5ae3fc91db865eff2c5a418da85a0fbe6238a3...4ebefcac44b5116cf5741be858245db769ddedd1) <sub>(2024-10-01 to 2024-10-10)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`eae0d8fb` ➡️ `df534c30`](https://github.com/nvim-telescope/telescope.nvim/compare/eae0d8fbde590b0eaa2f9481948cd6fd7dd21656...df534c3042572fb958586facd02841e10186707c) <sub>(2024-09-30 to 2024-10-10)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`fe866c65` ➡️ `9682b219`](https://github.com/NixOS/nixpkgs/compare/fe866c653c24adf1520628236d4e70bbb2fdd949...9682b2197dabc185fcca802ac1ac21136e48fcc2) <sub>(2024-09-25 to 2024-10-01)</sub>
 - Updated input [`rustacean-nvim/neorocks/flake-parts`](https://github.com/hercules-ci/flake-parts): [`bcef6817` ➡️ `3d04084d`](https://github.com/hercules-ci/flake-parts/compare/bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a...3d04084d54bedc3d6b8b736c70ef449225c361b1) <sub>(2024-09-12 to 2024-10-01)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`6b534019` ➡️ `19d257cf`](https://github.com/nvim-tree/nvim-web-devicons/compare/6b53401918a9033a41159d012160c5fb5eb249ae...19d257cf889f79f4022163c3fbb5e08639077bd8) <sub>(2024-09-30 to 2024-10-11)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks`](https://github.com/cachix/git-hooks.nix): [`4e743a69` ➡️ `2f5ae3fc`](https://github.com/cachix/git-hooks.nix/compare/4e743a6920eab45e8ba0fbe49dc459f1423a4b74...2f5ae3fc91db865eff2c5a418da85a0fbe6238a3) <sub>(2024-09-19 to 2024-10-01)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`509dbf8d` ➡️ `65ae9c14`](https://github.com/nix-community/home-manager/compare/509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e...65ae9c147349829d3df0222151f53f79821c5134) <sub>(2024-10-04 to 2024-10-11)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`2168d772` ➡️ `6f1601a1`](https://github.com/neovim/neovim/compare/2168d772b864fd05109fb4299e409d4bdc1df39d...6f1601a1b94e6ea724d8436600c64760525d1d2b) <sub>(2024-10-01 to 2024-10-10)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/flake-parts`](https://github.com/hercules-ci/flake-parts): [`bcef6817` ➡️ `3d04084d`](https://github.com/hercules-ci/flake-parts/compare/bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a...3d04084d54bedc3d6b8b736c70ef449225c361b1) <sub>(2024-09-12 to 2024-10-01)</sub>