### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -521,11 +521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728580416,
-        "narHash": "sha256-nKttjKg6lE7O5S+wlBOkXsUGdOgVxZ8SWaCOyodW5so=",
+        "lastModified": 1729104314,
+        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4ebefcac44b5116cf5741be858245db769ddedd1",
+        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
         "type": "github"
       },
       "original": {
@@ -567,11 +567,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1728092656,
-        "narHash": "sha256-eMeCTJZ5xBeQ0f9Os7K8DThNVSo9gy4umZLDfF5q6OM=",
+        "lastModified": 1728651332,
+        "narHash": "sha256-lm+asqDSTj0m6j1dtEte1/XG+uzZbwxS3tn7JLaBw84=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "1211305a5b237771e13fcca0c51e60ad47326a9a",
+        "rev": "06bb5971c139959d9a951f34e4264d32f5d998e7",
         "type": "github"
       },
       "original": {
@@ -598,11 +598,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727805723,
-        "narHash": "sha256-b8flytpuc4Ey/g3mcvpS/ICORcD4h56QDZeP5LogevY=",
+        "lastModified": 1728580416,
+        "narHash": "sha256-nKttjKg6lE7O5S+wlBOkXsUGdOgVxZ8SWaCOyodW5so=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "2f5ae3fc91db865eff2c5a418da85a0fbe6238a3",
+        "rev": "4ebefcac44b5116cf5741be858245db769ddedd1",
         "type": "github"
       },
       "original": {
@@ -843,11 +843,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728650932,
-        "narHash": "sha256-mGKzqdsRyLnGNl6WjEr7+sghGgBtYHhJQ4mjpgRTCsU=",
+        "lastModified": 1729260213,
+        "narHash": "sha256-jAvHoU/1y/yCuXzr2fNF+q6uKmr8Jj2xgAisK4QB9to=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "65ae9c147349829d3df0222151f53f79821c5134",
+        "rev": "09a0c0c02953318bf94425738c7061ffdc4cba75",
         "type": "github"
       },
       "original": {
@@ -859,11 +859,11 @@
     "hop-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1723130452,
-        "narHash": "sha256-hNo4iqssFjvaWN65cqo/NyuwYzgKiIjwsqFzk2EG/h4=",
+        "lastModified": 1729186441,
+        "narHash": "sha256-lvNKCzuje6lO8IRc4flKO2ePOpuGlsdNP6yfPiprvh4=",
         "owner": "smoka7",
         "repo": "hop.nvim",
-        "rev": "8f51ef02700bb3cdcce94e92eff16170a6343c4f",
+        "rev": "08ddca799089ab96a6d1763db0b8adc5320bf050",
         "type": "github"
       },
       "original": {
@@ -877,11 +877,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1725551787,
-        "narHash": "sha256-6LgsZHz8w3g4c9bRUwRAR+WIMwFGGf3P1VZQcKNRf2o=",
+        "lastModified": 1729224425,
+        "narHash": "sha256-w9dNUedNe2qnhHuhcRf7A1l29+/6DxdMfwN6g4U3c/w=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "1e531dc49ad36c88b45bf836081a7a2c8927e072",
+        "rev": "d72bc8b1cd30d448bd438e8328f8eeb4c0f2ddb6",
         "type": "github"
       },
       "original": {
@@ -1044,11 +1044,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1728105821,
-        "narHash": "sha256-8R1NGPbmS4nNiKLUL2hGxfgXcNwHQqWTZtUJylVCfdg=",
+        "lastModified": 1728710931,
+        "narHash": "sha256-guSpjhNm1DiKUUdmbVAzUy4YcsCa7HP5NimiUItisZ8=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "189645e30fd7f038c08df2ac665c4282ce810f87",
+        "rev": "9001b52860c1dc78a6d156bda2f3592769539d2e",
         "type": "github"
       },
       "original": {
@@ -1067,11 +1067,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1727852635,
-        "narHash": "sha256-eY0Y5ZDMo5IS+K42kMwAMCLsYHoAgPW3R4UxeGfzP0U=",
+        "lastModified": 1728631701,
+        "narHash": "sha256-LPqpJVV8Ws4uDfzp/Huu6myMW33lmZbFGTMoZ9LyRCU=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "377cf41246ee443c86c4ae48f66f5100038fe158",
+        "rev": "a2de61747149100c904c01eb8915e1c6ecec0379",
         "type": "github"
       },
       "original": {
@@ -1092,11 +1092,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728631701,
-        "narHash": "sha256-LPqpJVV8Ws4uDfzp/Huu6myMW33lmZbFGTMoZ9LyRCU=",
+        "lastModified": 1729147490,
+        "narHash": "sha256-F0/iQVbbIFctMPwK4JEd4fxVzNwaq7NnD5oen59S24s=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "a2de61747149100c904c01eb8915e1c6ecec0379",
+        "rev": "e2047498667aeb24e8493ff430a20cff713915f4",
         "type": "github"
       },
       "original": {
@@ -1108,11 +1108,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1728600525,
-        "narHash": "sha256-Q2QHD23/bkNdYTbXaRLaVYy/uUx3gw08NAehTfF5ZXs=",
+        "lastModified": 1729121305,
+        "narHash": "sha256-c94xkA/RuszC4PfmB+MWqOo2vbO66GTO6XKer0mbltA=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "6f1601a1b94e6ea724d8436600c64760525d1d2b",
+        "rev": "852954ff6d96adce0158f74ca494fdcef3aa1921",
         "type": "github"
       },
       "original": {
@@ -1124,11 +1124,11 @@
     "neovim-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1727825968,
-        "narHash": "sha256-7DbbGIAbJesqYEkZh2FaEo5wycZ/cRbvZP6k01Z5+ZM=",
+        "lastModified": 1728600525,
+        "narHash": "sha256-Q2QHD23/bkNdYTbXaRLaVYy/uUx3gw08NAehTfF5ZXs=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "2168d772b864fd05109fb4299e409d4bdc1df39d",
+        "rev": "6f1601a1b94e6ea724d8436600c64760525d1d2b",
         "type": "github"
       },
       "original": {
@@ -1299,11 +1299,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1728538411,
-        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "lastModified": 1728979988,
+        "narHash": "sha256-GBJRnbFLDg0y7ridWJHAP4Nn7oss50/VNgqoXaf/RVk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "rev": "7881fbfd2e3ed1dfa315fca889b2cfd94be39337",
         "type": "github"
       },
       "original": {
@@ -1363,11 +1363,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1727747005,
-        "narHash": "sha256-2PBox0LkPhxirg1asEIpvfFARjq5KLw0EHPCy4unjPs=",
+        "lastModified": 1728538411,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9682b2197dabc185fcca802ac1ac21136e48fcc2",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
         "type": "github"
       },
       "original": {
@@ -1379,11 +1379,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1728031656,
-        "narHash": "sha256-JXumn7X+suKEcehp4rchSvBzIboqyybQ5bLK4wk7gQU=",
+        "lastModified": 1728538411,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eeeb90a1dd3c9bea3afdbc76fd34d0fb2a727c7a",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
         "type": "github"
       },
       "original": {
@@ -1395,11 +1395,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1728093190,
-        "narHash": "sha256-CAZF2NRuHmqTtRTNAruWpHA43Gg2UvuCNEIzabP0l6M=",
+        "lastModified": 1728538411,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2f08f4d8b3ecb5cf5c9fd9cb2d53bb3c71807da",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
         "type": "github"
       },
       "original": {
@@ -1444,11 +1444,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1728624528,
-        "narHash": "sha256-886MSejFWKGH13RKh/uw7rkurEWcdvDJLRMSd3iVbs4=",
+        "lastModified": 1729266494,
+        "narHash": "sha256-YlaHcVXVc5ikU/MEMeVOtoGB7ztxDtKwcmmKfzCxByE=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "c38af37e4ee71d70b7d60267d96b0a83e5d346f5",
+        "rev": "b55b9659de9ac17e05df4787bb023e4c7ef45329",
         "type": "github"
       },
       "original": {
@@ -1503,11 +1503,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1728092656,
-        "narHash": "sha256-eMeCTJZ5xBeQ0f9Os7K8DThNVSo9gy4umZLDfF5q6OM=",
+        "lastModified": 1728727368,
+        "narHash": "sha256-7FMyNISP7K6XDSIt1NJxkXZnEdV3HZUXvFoBaJ/qdOg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "1211305a5b237771e13fcca0c51e60ad47326a9a",
+        "rev": "eb74e0be24a11a1531b5b8659535580554d30b28",
         "type": "github"
       },
       "original": {
@@ -1519,11 +1519,11 @@
     "resty-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1728670756,
-        "narHash": "sha256-sg1DMnDZQX8M4DHdcqlRCW69wIu4z0+6dhxHXnSbHzw=",
+        "lastModified": 1729276613,
+        "narHash": "sha256-y0ipLGRfX6YfqqsztvrVQr9k+mqrf9GXziOE0Wt/LBM=",
         "owner": "lima1909",
         "repo": "resty.nvim",
-        "rev": "e364d86dcb1f9d38a70aa3a759f65a853227392f",
+        "rev": "2c7d41e6d9ffd61cb82624af6253517df705abcc",
         "type": "github"
       },
       "original": {
@@ -1598,11 +1598,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1728324006,
-        "narHash": "sha256-SYFbGz+eYNYTueuL1cf413K2nFx79deJ64NpRwD1vMw=",
+        "lastModified": 1729179129,
+        "narHash": "sha256-CTxEf7w2Pr24Q7QP8sXrq8Yx5eK/Qs0cykMF6gLUNN8=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "d1f56672638508a7bc971cde31a29df4018579a9",
+        "rev": "6eb1c41463a0ad02a4fe799321cc7f651b87e576",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/65ae9c147349829d3df0222151f53f79821c5134' (2024-10-11)
  → 'github:nix-community/home-manager/09a0c0c02953318bf94425738c7061ffdc4cba75' (2024-10-18)
• Updated input 'hop-nvim':
    'github:smoka7/hop.nvim/8f51ef02700bb3cdcce94e92eff16170a6343c4f' (2024-08-08)
  → 'github:smoka7/hop.nvim/08ddca799089ab96a6d1763db0b8adc5320bf050' (2024-10-17)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/1e531dc49ad36c88b45bf836081a7a2c8927e072' (2024-09-05)
  → 'github:hyprwm/contrib/d72bc8b1cd30d448bd438e8328f8eeb4c0f2ddb6' (2024-10-18)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/a2de61747149100c904c01eb8915e1c6ecec0379' (2024-10-11)
  → 'github:nix-community/neovim-nightly-overlay/e2047498667aeb24e8493ff430a20cff713915f4' (2024-10-17)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/4ebefcac44b5116cf5741be858245db769ddedd1' (2024-10-10)
  → 'github:cachix/git-hooks.nix/3c3e88f0f544d6bb54329832616af7eb971b6be6' (2024-10-16)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/6f1601a1b94e6ea724d8436600c64760525d1d2b' (2024-10-10)
  → 'github:neovim/neovim/852954ff6d96adce0158f74ca494fdcef3aa1921' (2024-10-16)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221' (2024-10-10)
  → 'github:nixos/nixpkgs/7881fbfd2e3ed1dfa315fca889b2cfd94be39337' (2024-10-15)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/c38af37e4ee71d70b7d60267d96b0a83e5d346f5' (2024-10-11)
  → 'github:neovim/nvim-lspconfig/b55b9659de9ac17e05df4787bb023e4c7ef45329' (2024-10-18)
• Updated input 'resty-vim':
    'github:lima1909/resty.nvim/e364d86dcb1f9d38a70aa3a759f65a853227392f' (2024-10-11)
  → 'github:lima1909/resty.nvim/2c7d41e6d9ffd61cb82624af6253517df705abcc' (2024-10-18)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/d1f56672638508a7bc971cde31a29df4018579a9' (2024-10-07)
  → 'github:mrcjkb/rustaceanvim/6eb1c41463a0ad02a4fe799321cc7f651b87e576' (2024-10-17)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/189645e30fd7f038c08df2ac665c4282ce810f87' (2024-10-05)
  → 'github:nvim-neorocks/neorocks/9001b52860c1dc78a6d156bda2f3592769539d2e' (2024-10-12)
• Updated input 'rustacean-nvim/neorocks/git-hooks':
    'github:cachix/git-hooks.nix/1211305a5b237771e13fcca0c51e60ad47326a9a' (2024-10-05)
  → 'github:cachix/git-hooks.nix/06bb5971c139959d9a951f34e4264d32f5d998e7' (2024-10-11)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/377cf41246ee443c86c4ae48f66f5100038fe158' (2024-10-02)
  → 'github:nix-community/neovim-nightly-overlay/a2de61747149100c904c01eb8915e1c6ecec0379' (2024-10-11)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks':
    'github:cachix/git-hooks.nix/2f5ae3fc91db865eff2c5a418da85a0fbe6238a3' (2024-10-01)
  → 'github:cachix/git-hooks.nix/4ebefcac44b5116cf5741be858245db769ddedd1' (2024-10-10)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/2168d772b864fd05109fb4299e409d4bdc1df39d' (2024-10-01)
  → 'github:neovim/neovim/6f1601a1b94e6ea724d8436600c64760525d1d2b' (2024-10-10)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/9682b2197dabc185fcca802ac1ac21136e48fcc2' (2024-10-01)
  → 'github:NixOS/nixpkgs/b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221' (2024-10-10)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/eeeb90a1dd3c9bea3afdbc76fd34d0fb2a727c7a' (2024-10-04)
  → 'github:nixos/nixpkgs/b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221' (2024-10-10)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/e2f08f4d8b3ecb5cf5c9fd9cb2d53bb3c71807da' (2024-10-05)
  → 'github:nixos/nixpkgs/b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221' (2024-10-10)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/1211305a5b237771e13fcca0c51e60ad47326a9a' (2024-10-05)
  → 'github:cachix/pre-commit-hooks.nix/eb74e0be24a11a1531b5b8659535580554d30b28' (2024-10-12)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`377cf412` ➡️ `a2de6174`](https://github.com/nix-community/neovim-nightly-overlay/compare/377cf41246ee443c86c4ae48f66f5100038fe158...a2de61747149100c904c01eb8915e1c6ecec0379) <sub>(2024-10-02 to 2024-10-11)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`d1f56672` ➡️ `6eb1c414`](https://github.com/mrcjkb/rustaceanvim/compare/d1f56672638508a7bc971cde31a29df4018579a9...6eb1c41463a0ad02a4fe799321cc7f651b87e576) <sub>(2024-10-07 to 2024-10-17)</sub>
 - Updated input [`resty-vim`](https://github.com/lima1909/resty.nvim): [`e364d86d` ➡️ `2c7d41e6`](https://github.com/lima1909/resty.nvim/compare/e364d86dcb1f9d38a70aa3a759f65a853227392f...2c7d41e6d9ffd61cb82624af6253517df705abcc) <sub>(2024-10-11 to 2024-10-18)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`eeeb90a1` ➡️ `b69de56f`](https://github.com/nixos/nixpkgs/compare/eeeb90a1dd3c9bea3afdbc76fd34d0fb2a727c7a...b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221) <sub>(2024-10-04 to 2024-10-10)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`189645e3` ➡️ `9001b528`](https://github.com/nvim-neorocks/neorocks/compare/189645e30fd7f038c08df2ac665c4282ce810f87...9001b52860c1dc78a6d156bda2f3592769539d2e) <sub>(2024-10-05 to 2024-10-12)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [`2168d772` ➡️ `6f1601a1`](https://github.com/neovim/neovim/compare/2168d772b864fd05109fb4299e409d4bdc1df39d...6f1601a1b94e6ea724d8436600c64760525d1d2b) <sub>(2024-10-01 to 2024-10-10)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`a2de6174` ➡️ `e2047498`](https://github.com/nix-community/neovim-nightly-overlay/compare/a2de61747149100c904c01eb8915e1c6ecec0379...e2047498667aeb24e8493ff430a20cff713915f4) <sub>(2024-10-11 to 2024-10-17)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`1e531dc4` ➡️ `d72bc8b1`](https://github.com/hyprwm/contrib/compare/1e531dc49ad36c88b45bf836081a7a2c8927e072...d72bc8b1cd30d448bd438e8328f8eeb4c0f2ddb6) <sub>(2024-09-05 to 2024-10-18)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`c38af37e` ➡️ `b55b9659`](https://github.com/neovim/nvim-lspconfig/compare/c38af37e4ee71d70b7d60267d96b0a83e5d346f5...b55b9659de9ac17e05df4787bb023e4c7ef45329) <sub>(2024-10-11 to 2024-10-18)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`1211305a` ➡️ `eb74e0be`](https://github.com/cachix/pre-commit-hooks.nix/compare/1211305a5b237771e13fcca0c51e60ad47326a9a...eb74e0be24a11a1531b5b8659535580554d30b28) <sub>(2024-10-05 to 2024-10-12)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`e2f08f4d` ➡️ `b69de56f`](https://github.com/nixos/nixpkgs/compare/e2f08f4d8b3ecb5cf5c9fd9cb2d53bb3c71807da...b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221) <sub>(2024-10-05 to 2024-10-10)</sub>
 - Updated input [`rustacean-nvim/neorocks/git-hooks`](https://github.com/cachix/git-hooks.nix): [`1211305a` ➡️ `06bb5971`](https://github.com/cachix/git-hooks.nix/compare/1211305a5b237771e13fcca0c51e60ad47326a9a...06bb5971c139959d9a951f34e4264d32f5d998e7) <sub>(2024-10-05 to 2024-10-11)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`b69de56f` ➡️ `7881fbfd`](https://github.com/nixos/nixpkgs/compare/b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221...7881fbfd2e3ed1dfa315fca889b2cfd94be39337) <sub>(2024-10-10 to 2024-10-15)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`4ebefcac` ➡️ `3c3e88f0`](https://github.com/cachix/git-hooks.nix/compare/4ebefcac44b5116cf5741be858245db769ddedd1...3c3e88f0f544d6bb54329832616af7eb971b6be6) <sub>(2024-10-10 to 2024-10-16)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`9682b219` ➡️ `b69de56f`](https://github.com/NixOS/nixpkgs/compare/9682b2197dabc185fcca802ac1ac21136e48fcc2...b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221) <sub>(2024-10-01 to 2024-10-10)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks`](https://github.com/cachix/git-hooks.nix): [`2f5ae3fc` ➡️ `4ebefcac`](https://github.com/cachix/git-hooks.nix/compare/2f5ae3fc91db865eff2c5a418da85a0fbe6238a3...4ebefcac44b5116cf5741be858245db769ddedd1) <sub>(2024-10-01 to 2024-10-10)</sub>
 - Updated input [`hop-nvim`](https://github.com/smoka7/hop.nvim): [`8f51ef02` ➡️ `08ddca79`](https://github.com/smoka7/hop.nvim/compare/8f51ef02700bb3cdcce94e92eff16170a6343c4f...08ddca799089ab96a6d1763db0b8adc5320bf050) <sub>(2024-08-08 to 2024-10-17)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`65ae9c14` ➡️ `09a0c0c0`](https://github.com/nix-community/home-manager/compare/65ae9c147349829d3df0222151f53f79821c5134...09a0c0c02953318bf94425738c7061ffdc4cba75) <sub>(2024-10-11 to 2024-10-18)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`6f1601a1` ➡️ `852954ff`](https://github.com/neovim/neovim/compare/6f1601a1b94e6ea724d8436600c64760525d1d2b...852954ff6d96adce0158f74ca494fdcef3aa1921) <sub>(2024-10-10 to 2024-10-16)</sub>