### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -567,11 +567,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1728651332,
-        "narHash": "sha256-lm+asqDSTj0m6j1dtEte1/XG+uzZbwxS3tn7JLaBw84=",
+        "lastModified": 1729104314,
+        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "06bb5971c139959d9a951f34e4264d32f5d998e7",
+        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
         "type": "github"
       },
       "original": {
@@ -598,11 +598,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728580416,
-        "narHash": "sha256-nKttjKg6lE7O5S+wlBOkXsUGdOgVxZ8SWaCOyodW5so=",
+        "lastModified": 1729104314,
+        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4ebefcac44b5116cf5741be858245db769ddedd1",
+        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
         "type": "github"
       },
       "original": {
@@ -777,11 +777,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1727424886,
-        "narHash": "sha256-o2Y57z7IuIa9wvLlzyslcs3/+iaZzuqM1NImlKAPt5Y=",
+        "lastModified": 1729430860,
+        "narHash": "sha256-jR7/rX2bsOMkWc4MHMRlBDdELgl8JOVjGOcx6bl/nYw=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "863903631e676b33e8be2acb17512fdc1b80b4fb",
+        "rev": "ee7634ab4f0a6606438fe13e16cbf2065589a5ed",
         "type": "github"
       },
       "original": {
@@ -843,11 +843,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729260213,
-        "narHash": "sha256-jAvHoU/1y/yCuXzr2fNF+q6uKmr8Jj2xgAisK4QB9to=",
+        "lastModified": 1729864948,
+        "narHash": "sha256-CeGSqbN6S8JmzYJX/HqZjr7dMGlvHLLnJJarwB45lPs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "09a0c0c02953318bf94425738c7061ffdc4cba75",
+        "rev": "0c0268a3c80d30b989d0aadbd65f38d4fa27a9a0",
         "type": "github"
       },
       "original": {
@@ -958,11 +958,11 @@
     "lspkind-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1727343567,
-        "narHash": "sha256-72j9A16OGm90eL/iQPEuNSvFh7mSUMKQhbTGpSjbnKM=",
+        "lastModified": 1729872608,
+        "narHash": "sha256-/ifgjqqCQw67l3+gUs00tt860pa92M1WYdjdZ0lhxak=",
         "owner": "onsails",
         "repo": "lspkind.nvim",
-        "rev": "59c3f419af48a2ffb2320cea85e44e5a95f71664",
+        "rev": "a700f1436d4a938b1a1a93c9962dc796afbaef4d",
         "type": "github"
       },
       "original": {
@@ -990,11 +990,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1726165831,
-        "narHash": "sha256-nkaa1NGOI28Et2QitQB+Spv+J42QVdHE1oywteLcJJw=",
+        "lastModified": 1729695074,
+        "narHash": "sha256-YGJrw20jZLzOwvBYptZG/vQQpHuk9WiH5guW2DqDTSw=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "e808bee352d1a6fcf902ca1a71cee76e60e24071",
+        "rev": "787dee55ca364cc9119787165418fe93b74c1842",
         "type": "github"
       },
       "original": {
@@ -1044,11 +1044,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1728710931,
-        "narHash": "sha256-guSpjhNm1DiKUUdmbVAzUy4YcsCa7HP5NimiUItisZ8=",
+        "lastModified": 1729315397,
+        "narHash": "sha256-j/juRj9MDCOMYcCGXTogUigGYDPjwwYuxnuyBul78tk=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "9001b52860c1dc78a6d156bda2f3592769539d2e",
+        "rev": "bd4927a47d96bc2eb88f11079075ce4db5be8a4f",
         "type": "github"
       },
       "original": {
@@ -1067,11 +1067,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1728631701,
-        "narHash": "sha256-LPqpJVV8Ws4uDfzp/Huu6myMW33lmZbFGTMoZ9LyRCU=",
+        "lastModified": 1729147490,
+        "narHash": "sha256-F0/iQVbbIFctMPwK4JEd4fxVzNwaq7NnD5oen59S24s=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "a2de61747149100c904c01eb8915e1c6ecec0379",
+        "rev": "e2047498667aeb24e8493ff430a20cff713915f4",
         "type": "github"
       },
       "original": {
@@ -1124,11 +1124,11 @@
     "neovim-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1728600525,
-        "narHash": "sha256-Q2QHD23/bkNdYTbXaRLaVYy/uUx3gw08NAehTfF5ZXs=",
+        "lastModified": 1729121305,
+        "narHash": "sha256-c94xkA/RuszC4PfmB+MWqOo2vbO66GTO6XKer0mbltA=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "6f1601a1b94e6ea724d8436600c64760525d1d2b",
+        "rev": "852954ff6d96adce0158f74ca494fdcef3aa1921",
         "type": "github"
       },
       "original": {
@@ -1299,11 +1299,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1728979988,
-        "narHash": "sha256-GBJRnbFLDg0y7ridWJHAP4Nn7oss50/VNgqoXaf/RVk=",
+        "lastModified": 1729850857,
+        "narHash": "sha256-WvLXzNNnnw+qpFOmgaM3JUlNEH+T4s22b5i2oyyCpXE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7881fbfd2e3ed1dfa315fca889b2cfd94be39337",
+        "rev": "41dea55321e5a999b17033296ac05fe8a8b5a257",
         "type": "github"
       },
       "original": {
@@ -1363,11 +1363,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1728538411,
-        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "lastModified": 1728863046,
+        "narHash": "sha256-DZBO2465PL5V89e8hFSJewyH4QbCPpW3ssws7ckT/0A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "rev": "d4f247e89f6e10120f911e2e2d2254a050d0f732",
         "type": "github"
       },
       "original": {
@@ -1379,11 +1379,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1728538411,
-        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "lastModified": 1729265718,
+        "narHash": "sha256-4HQI+6LsO3kpWTYuVGIzhJs1cetFcwT7quWCk/6rqeo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "rev": "ccc0c2126893dd20963580b6478d1a10a4512185",
         "type": "github"
       },
       "original": {
@@ -1395,11 +1395,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1728538411,
-        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "lastModified": 1729265718,
+        "narHash": "sha256-4HQI+6LsO3kpWTYuVGIzhJs1cetFcwT7quWCk/6rqeo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "rev": "ccc0c2126893dd20963580b6478d1a10a4512185",
         "type": "github"
       },
       "original": {
@@ -1428,11 +1428,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1722509464,
-        "narHash": "sha256-NcodgUp8obTsjgc+5j2dKr0f3FelYikQTJngfZXRZzo=",
+        "lastModified": 1729519807,
+        "narHash": "sha256-dAsXxv1RtgMc1i5QrR2xqOeK6aRgYNqdYyTXVBXhVJ4=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "ae644feb7b67bf1ce4260c231d1d4300b19c6f30",
+        "rev": "29fb4854573355792df9e156cb779f0d31308796",
         "type": "github"
       },
       "original": {
@@ -1444,11 +1444,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1729266494,
-        "narHash": "sha256-YlaHcVXVc5ikU/MEMeVOtoGB7ztxDtKwcmmKfzCxByE=",
+        "lastModified": 1729867839,
+        "narHash": "sha256-kupMS2sWSQxnhPB/DEsX9lMS7ZYwp7sVqLDWeL7EAB8=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "b55b9659de9ac17e05df4787bb023e4c7ef45329",
+        "rev": "4ae8ea049034a4f1b95b3e671ab9d35c16eeafb9",
         "type": "github"
       },
       "original": {
@@ -1503,11 +1503,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1728727368,
-        "narHash": "sha256-7FMyNISP7K6XDSIt1NJxkXZnEdV3HZUXvFoBaJ/qdOg=",
+        "lastModified": 1729104314,
+        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "eb74e0be24a11a1531b5b8659535580554d30b28",
+        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
         "type": "github"
       },
       "original": {
@@ -1519,11 +1519,11 @@
     "resty-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1729276613,
-        "narHash": "sha256-y0ipLGRfX6YfqqsztvrVQr9k+mqrf9GXziOE0Wt/LBM=",
+        "lastModified": 1729795338,
+        "narHash": "sha256-yxwi4s0Jsys/DNYfQffObufr8Xay+cCPFbyFYefYLF4=",
         "owner": "lima1909",
         "repo": "resty.nvim",
-        "rev": "2c7d41e6d9ffd61cb82624af6253517df705abcc",
+        "rev": "666491c9eb33e84fccb958e5eaf19a48bb8b51a8",
         "type": "github"
       },
       "original": {
@@ -1599,11 +1599,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1729179129,
-        "narHash": "sha256-CTxEf7w2Pr24Q7QP8sXrq8Yx5eK/Qs0cykMF6gLUNN8=",
+        "lastModified": 1729549323,
+        "narHash": "sha256-G/sp/G+ch1AJTpDCEV4Kpc5yp322Muss0niVwdEywYA=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "6eb1c41463a0ad02a4fe799321cc7f651b87e576",
+        "rev": "f9b22ae03946a1938288400841cb62ec53077973",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/863903631e676b33e8be2acb17512fdc1b80b4fb' (2024-09-27)
  → 'github:lewis6991/gitsigns.nvim/ee7634ab4f0a6606438fe13e16cbf2065589a5ed' (2024-10-20)
• Updated input 'home-manager':
    'github:nix-community/home-manager/09a0c0c02953318bf94425738c7061ffdc4cba75' (2024-10-18)
  → 'github:nix-community/home-manager/0c0268a3c80d30b989d0aadbd65f38d4fa27a9a0' (2024-10-25)
• Updated input 'lspkind-nvim':
    'github:onsails/lspkind.nvim/59c3f419af48a2ffb2320cea85e44e5a95f71664' (2024-09-26)
  → 'github:onsails/lspkind.nvim/a700f1436d4a938b1a1a93c9962dc796afbaef4d' (2024-10-25)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/e808bee352d1a6fcf902ca1a71cee76e60e24071' (2024-09-12)
  → 'github:L3MON4D3/LuaSnip/787dee55ca364cc9119787165418fe93b74c1842' (2024-10-23)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/7881fbfd2e3ed1dfa315fca889b2cfd94be39337' (2024-10-15)
  → 'github:nixos/nixpkgs/41dea55321e5a999b17033296ac05fe8a8b5a257' (2024-10-25)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/ae644feb7b67bf1ce4260c231d1d4300b19c6f30' (2024-08-01)
  → 'github:hrsh7th/nvim-cmp/29fb4854573355792df9e156cb779f0d31308796' (2024-10-21)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/b55b9659de9ac17e05df4787bb023e4c7ef45329' (2024-10-18)
  → 'github:neovim/nvim-lspconfig/4ae8ea049034a4f1b95b3e671ab9d35c16eeafb9' (2024-10-25)
• Updated input 'resty-vim':
    'github:lima1909/resty.nvim/2c7d41e6d9ffd61cb82624af6253517df705abcc' (2024-10-18)
  → 'github:lima1909/resty.nvim/666491c9eb33e84fccb958e5eaf19a48bb8b51a8' (2024-10-24)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/6eb1c41463a0ad02a4fe799321cc7f651b87e576' (2024-10-17)
  → 'github:mrcjkb/rustaceanvim/f9b22ae03946a1938288400841cb62ec53077973' (2024-10-21)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/9001b52860c1dc78a6d156bda2f3592769539d2e' (2024-10-12)
  → 'github:nvim-neorocks/neorocks/bd4927a47d96bc2eb88f11079075ce4db5be8a4f' (2024-10-19)
• Updated input 'rustacean-nvim/neorocks/git-hooks':
    'github:cachix/git-hooks.nix/06bb5971c139959d9a951f34e4264d32f5d998e7' (2024-10-11)
  → 'github:cachix/git-hooks.nix/3c3e88f0f544d6bb54329832616af7eb971b6be6' (2024-10-16)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/a2de61747149100c904c01eb8915e1c6ecec0379' (2024-10-11)
  → 'github:nix-community/neovim-nightly-overlay/e2047498667aeb24e8493ff430a20cff713915f4' (2024-10-17)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks':
    'github:cachix/git-hooks.nix/4ebefcac44b5116cf5741be858245db769ddedd1' (2024-10-10)
  → 'github:cachix/git-hooks.nix/3c3e88f0f544d6bb54329832616af7eb971b6be6' (2024-10-16)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/6f1601a1b94e6ea724d8436600c64760525d1d2b' (2024-10-10)
  → 'github:neovim/neovim/852954ff6d96adce0158f74ca494fdcef3aa1921' (2024-10-16)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221' (2024-10-10)
  → 'github:NixOS/nixpkgs/d4f247e89f6e10120f911e2e2d2254a050d0f732' (2024-10-13)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221' (2024-10-10)
  → 'github:nixos/nixpkgs/ccc0c2126893dd20963580b6478d1a10a4512185' (2024-10-18)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221' (2024-10-10)
  → 'github:nixos/nixpkgs/ccc0c2126893dd20963580b6478d1a10a4512185' (2024-10-18)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/eb74e0be24a11a1531b5b8659535580554d30b28' (2024-10-12)
  → 'github:cachix/pre-commit-hooks.nix/3c3e88f0f544d6bb54329832616af7eb971b6be6' (2024-10-16)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`a2de6174` ➡️ `e2047498`](https://github.com/nix-community/neovim-nightly-overlay/compare/a2de61747149100c904c01eb8915e1c6ecec0379...e2047498667aeb24e8493ff430a20cff713915f4) <sub>(2024-10-11 to 2024-10-17)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`6eb1c414` ➡️ `f9b22ae0`](https://github.com/mrcjkb/rustaceanvim/compare/6eb1c41463a0ad02a4fe799321cc7f651b87e576...f9b22ae03946a1938288400841cb62ec53077973) <sub>(2024-10-17 to 2024-10-21)</sub>
 - Updated input [`resty-vim`](https://github.com/lima1909/resty.nvim): [`2c7d41e6` ➡️ `666491c9`](https://github.com/lima1909/resty.nvim/compare/2c7d41e6d9ffd61cb82624af6253517df705abcc...666491c9eb33e84fccb958e5eaf19a48bb8b51a8) <sub>(2024-10-18 to 2024-10-24)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`b69de56f` ➡️ `ccc0c212`](https://github.com/nixos/nixpkgs/compare/b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221...ccc0c2126893dd20963580b6478d1a10a4512185) <sub>(2024-10-10 to 2024-10-18)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`9001b528` ➡️ `bd4927a4`](https://github.com/nvim-neorocks/neorocks/compare/9001b52860c1dc78a6d156bda2f3592769539d2e...bd4927a47d96bc2eb88f11079075ce4db5be8a4f) <sub>(2024-10-12 to 2024-10-19)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [`6f1601a1` ➡️ `852954ff`](https://github.com/neovim/neovim/compare/6f1601a1b94e6ea724d8436600c64760525d1d2b...852954ff6d96adce0158f74ca494fdcef3aa1921) <sub>(2024-10-10 to 2024-10-16)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`e808bee3` ➡️ `787dee55`](https://github.com/L3MON4D3/LuaSnip/compare/e808bee352d1a6fcf902ca1a71cee76e60e24071...787dee55ca364cc9119787165418fe93b74c1842) <sub>(2024-09-12 to 2024-10-23)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`b55b9659` ➡️ `4ae8ea04`](https://github.com/neovim/nvim-lspconfig/compare/b55b9659de9ac17e05df4787bb023e4c7ef45329...4ae8ea049034a4f1b95b3e671ab9d35c16eeafb9) <sub>(2024-10-18 to 2024-10-25)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`ae644feb` ➡️ `29fb4854`](https://github.com/hrsh7th/nvim-cmp/compare/ae644feb7b67bf1ce4260c231d1d4300b19c6f30...29fb4854573355792df9e156cb779f0d31308796) <sub>(2024-08-01 to 2024-10-21)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`eb74e0be` ➡️ `3c3e88f0`](https://github.com/cachix/pre-commit-hooks.nix/compare/eb74e0be24a11a1531b5b8659535580554d30b28...3c3e88f0f544d6bb54329832616af7eb971b6be6) <sub>(2024-10-12 to 2024-10-16)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`b69de56f` ➡️ `ccc0c212`](https://github.com/nixos/nixpkgs/compare/b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221...ccc0c2126893dd20963580b6478d1a10a4512185) <sub>(2024-10-10 to 2024-10-18)</sub>
 - Updated input [`rustacean-nvim/neorocks/git-hooks`](https://github.com/cachix/git-hooks.nix): [`06bb5971` ➡️ `3c3e88f0`](https://github.com/cachix/git-hooks.nix/compare/06bb5971c139959d9a951f34e4264d32f5d998e7...3c3e88f0f544d6bb54329832616af7eb971b6be6) <sub>(2024-10-11 to 2024-10-16)</sub>
 - Updated input [`lspkind-nvim`](https://github.com/onsails/lspkind.nvim): [`59c3f419` ➡️ `a700f143`](https://github.com/onsails/lspkind.nvim/compare/59c3f419af48a2ffb2320cea85e44e5a95f71664...a700f1436d4a938b1a1a93c9962dc796afbaef4d) <sub>(2024-09-26 to 2024-10-25)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`86390363` ➡️ `ee7634ab`](https://github.com/lewis6991/gitsigns.nvim/compare/863903631e676b33e8be2acb17512fdc1b80b4fb...ee7634ab4f0a6606438fe13e16cbf2065589a5ed) <sub>(2024-09-27 to 2024-10-20)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`7881fbfd` ➡️ `41dea553`](https://github.com/nixos/nixpkgs/compare/7881fbfd2e3ed1dfa315fca889b2cfd94be39337...41dea55321e5a999b17033296ac05fe8a8b5a257) <sub>(2024-10-15 to 2024-10-25)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`b69de56f` ➡️ `d4f247e8`](https://github.com/NixOS/nixpkgs/compare/b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221...d4f247e89f6e10120f911e2e2d2254a050d0f732) <sub>(2024-10-10 to 2024-10-13)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks`](https://github.com/cachix/git-hooks.nix): [`4ebefcac` ➡️ `3c3e88f0`](https://github.com/cachix/git-hooks.nix/compare/4ebefcac44b5116cf5741be858245db769ddedd1...3c3e88f0f544d6bb54329832616af7eb971b6be6) <sub>(2024-10-10 to 2024-10-16)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`09a0c0c0` ➡️ `0c0268a3`](https://github.com/nix-community/home-manager/compare/09a0c0c02953318bf94425738c7061ffdc4cba75...0c0268a3c80d30b989d0aadbd65f38d4fa27a9a0) <sub>(2024-10-18 to 2024-10-25)</sub>