### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     "cmp-luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1696878902,
-        "narHash": "sha256-nUJJl2zyK/oSwz5RzI9j3gf9zpDfCImCYbPbVsyXgz8=",
+        "lastModified": 1730707109,
+        "narHash": "sha256-86lKQPPyqFz8jzuLajjHMKHrYnwW6+QOcPyQEx6B+gw=",
         "owner": "saadparwaiz1",
         "repo": "cmp_luasnip",
-        "rev": "05a9ab28b53f71d1aece421ef32fee2cb857a843",
+        "rev": "98d9cb5c2c38532bd9bdb481067b20fea8f32e90",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -521,11 +521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729104314,
-        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
+        "lastModified": 1730814269,
+        "narHash": "sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF+06nOg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
+        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
         "type": "github"
       },
       "original": {
@@ -567,11 +567,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1729104314,
-        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
+        "lastModified": 1730302582,
+        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
+        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
         "type": "github"
       },
       "original": {
@@ -777,11 +777,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1730304882,
-        "narHash": "sha256-Z4KALX2NRdxykfW3OzSbz17+kuloU4kX8Qz9Wphrnmc=",
+        "lastModified": 1730713501,
+        "narHash": "sha256-FHzufzeVrPnbU5j3UabVTCYXP+QNcb7gMgef0BmuclA=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "7c27a30450130cd59c4994a6755e3c5d74d83e76",
+        "rev": "4daf7022f1481edf1e8fb9947df13bb07c18e89a",
         "type": "github"
       },
       "original": {
@@ -799,11 +799,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724947644,
-        "narHash": "sha256-MHHrHasTngp7EYQOObHJ1a/IsRF+wodHqOckhH6uZbk=",
+        "lastModified": 1730903510,
+        "narHash": "sha256-mnynlrPeiW0nUQ8KGZHb3WyxAxA3Ye/BH8gMjdoKP6E=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "dba4367b9a9d9615456c430a6d6af716f6e84cef",
+        "rev": "b89ac4d66d618b915b1f0a408e2775fe3821d141",
         "type": "github"
       },
       "original": {
@@ -843,11 +843,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730450782,
-        "narHash": "sha256-0AfApF8aexgB6o34qqLW2cCX4LaWJajBVdU6ddiWZBM=",
+        "lastModified": 1730837930,
+        "narHash": "sha256-0kZL4m+bKBJUBQse0HanewWO0g8hDdCvBhudzxgehqc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8ca921e5a806b5b6171add542defe7bdac79d189",
+        "rev": "2f607e07f3ac7e53541120536708e824acccfaa8",
         "type": "github"
       },
       "original": {
@@ -877,11 +877,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1729224425,
-        "narHash": "sha256-w9dNUedNe2qnhHuhcRf7A1l29+/6DxdMfwN6g4U3c/w=",
+        "lastModified": 1730743354,
+        "narHash": "sha256-gU4NySYyXeAzVaF5bI6BKmj2CdgiwGFnuPjXUId3Dx0=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "d72bc8b1cd30d448bd438e8328f8eeb4c0f2ddb6",
+        "rev": "792f6b83dc719214e0e2a0b380c34f147b28ece2",
         "type": "github"
       },
       "original": {
@@ -974,11 +974,11 @@
     "lualine-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1730473938,
-        "narHash": "sha256-BLqmjS24Tsgz0uAvEdn8tAiKkhlvk0Iiylq93+uxqW0=",
+        "lastModified": 1731050126,
+        "narHash": "sha256-IN6Qz3jGxUcylYiRTyd8j6me3pAoqJsJXtFUvph/6EI=",
         "owner": "nvim-lualine",
         "repo": "lualine.nvim",
-        "rev": "640260d7c2d98779cab89b1e7088ab14ea354a02",
+        "rev": "2a5bae925481f999263d6f5ed8361baef8df4f83",
         "type": "github"
       },
       "original": {
@@ -990,11 +990,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1730313308,
-        "narHash": "sha256-gDCmhOoTnLDrv0owOqaqa0e4wkA2rvuatVBsepaMEyI=",
+        "lastModified": 1730895001,
+        "narHash": "sha256-Vb4unHnhppcM1HZtd8oohJHPlkUHORoYUjKUWyhRM6g=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "8d7aa7a7b7c0875e4878d1d2590924bc1c229305",
+        "rev": "2737edc9e674e537dc0a97e3405658d57d2d31ed",
         "type": "github"
       },
       "original": {
@@ -1044,11 +1044,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1729920196,
-        "narHash": "sha256-wjo8ZF3hAGWm0L8S90VLsvSObdSZTsCzg7PyR26+WoU=",
+        "lastModified": 1730525028,
+        "narHash": "sha256-50Brt47i3P1DE/3mXw5NQZnW2ObI86xMwWOT7V+a1ck=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "df27c6f473c2945b148d3243000466f546939d72",
+        "rev": "d7d0bac66ca4712d40bf8ad30a79ba2353bcde7a",
         "type": "github"
       },
       "original": {
@@ -1067,11 +1067,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1729147490,
-        "narHash": "sha256-F0/iQVbbIFctMPwK4JEd4fxVzNwaq7NnD5oen59S24s=",
+        "lastModified": 1730088025,
+        "narHash": "sha256-FIdIaN7f6karwtDV65VXTV8VThNrR63nwykfgXpm4p4=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "e2047498667aeb24e8493ff430a20cff713915f4",
+        "rev": "f35afbe60a4ff71fd65fec3839fc38943f961951",
         "type": "github"
       },
       "original": {
@@ -1092,11 +1092,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730088025,
-        "narHash": "sha256-FIdIaN7f6karwtDV65VXTV8VThNrR63nwykfgXpm4p4=",
+        "lastModified": 1731052353,
+        "narHash": "sha256-UjH4ED1gEpHW6jsanwBWPevKq/hgA0UXMXpTYOolh5U=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "f35afbe60a4ff71fd65fec3839fc38943f961951",
+        "rev": "4edacffe41dcb1e23e56731fa97c1acce3768146",
         "type": "github"
       },
       "original": {
@@ -1108,11 +1108,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1729121305,
-        "narHash": "sha256-c94xkA/RuszC4PfmB+MWqOo2vbO66GTO6XKer0mbltA=",
+        "lastModified": 1730973210,
+        "narHash": "sha256-7IdIvOaDeiTJMNPcX94ts8U5V44nu2YtQh8VT8ua4XY=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "852954ff6d96adce0158f74ca494fdcef3aa1921",
+        "rev": "5a86360400691e55fae66d60485b61360a1d3d6c",
         "type": "github"
       },
       "original": {
@@ -1171,14 +1171,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1727825735,
-        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
+        "lastModified": 1730504152,
+        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       }
     },
     "nixpkgs-lib_2": {
@@ -1195,14 +1195,14 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1727825735,
-        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
+        "lastModified": 1730504152,
+        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       }
     },
     "nixpkgs-lib_4": {
@@ -1299,11 +1299,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1730272153,
-        "narHash": "sha256-B5WRZYsRlJgwVHIV6DvidFN7VX7Fg9uuwkRW9Ha8z+w=",
+        "lastModified": 1730958623,
+        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53",
+        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
         "type": "github"
       },
       "original": {
@@ -1379,11 +1379,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1729850857,
-        "narHash": "sha256-WvLXzNNnnw+qpFOmgaM3JUlNEH+T4s22b5i2oyyCpXE=",
+        "lastModified": 1730272153,
+        "narHash": "sha256-B5WRZYsRlJgwVHIV6DvidFN7VX7Fg9uuwkRW9Ha8z+w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "41dea55321e5a999b17033296ac05fe8a8b5a257",
+        "rev": "2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53",
         "type": "github"
       },
       "original": {
@@ -1395,11 +1395,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1729850857,
-        "narHash": "sha256-WvLXzNNnnw+qpFOmgaM3JUlNEH+T4s22b5i2oyyCpXE=",
+        "lastModified": 1730272153,
+        "narHash": "sha256-B5WRZYsRlJgwVHIV6DvidFN7VX7Fg9uuwkRW9Ha8z+w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "41dea55321e5a999b17033296ac05fe8a8b5a257",
+        "rev": "2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53",
         "type": "github"
       },
       "original": {
@@ -1428,11 +1428,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1729519807,
-        "narHash": "sha256-dAsXxv1RtgMc1i5QrR2xqOeK6aRgYNqdYyTXVBXhVJ4=",
+        "lastModified": 1730523275,
+        "narHash": "sha256-iNEoMl/X0nh2sAio1h+dkuobeOXRBXKFJCcElUyyW54=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "29fb4854573355792df9e156cb779f0d31308796",
+        "rev": "f17d9b4394027ff4442b298398dfcaab97e40c4f",
         "type": "github"
       },
       "original": {
@@ -1444,11 +1444,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1730352738,
-        "narHash": "sha256-dtxOSupsrxOUTLhizKNcGHKR9oa7EZySvjONfrdBvcM=",
+        "lastModified": 1730978746,
+        "narHash": "sha256-N1vqosgHHVUWoszhdGImH//mb7hiSWWsG1Pq9WNnQxk=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "54617a18f4cf46f0c2f6d024fa6feb7515fe036d",
+        "rev": "d01864641c6e43c681c3e9f6cf4745c75fdd9dcc",
         "type": "github"
       },
       "original": {
@@ -1503,11 +1503,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1729104314,
-        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
+        "lastModified": 1730302582,
+        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
+        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
         "type": "github"
       },
       "original": {
@@ -1519,11 +1519,11 @@
     "resty-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1730484364,
-        "narHash": "sha256-hosiOhU3Xygtk7c3N5lT80EwK2J+j7FvP74kzFDDrNY=",
+        "lastModified": 1731082182,
+        "narHash": "sha256-YLNkmX8dGhIkJac/4L++uy8LUElKCV/NnpnbQ1J3B6s=",
         "owner": "lima1909",
         "repo": "resty.nvim",
-        "rev": "5351865bfaa15e120a7036608502777e676f0c9e",
+        "rev": "cc11b478db498a2994956d31b6fd5b241f32519d",
         "type": "github"
       },
       "original": {
@@ -1601,11 +1601,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1730388079,
-        "narHash": "sha256-1RkrJrSeRyF2WXSwstWtglSU72hvRFNUeaFz/ioW8ws=",
+        "lastModified": 1731003427,
+        "narHash": "sha256-Sobs/ybL7VPsyh2c0EED0U5kl/tGtFcaj76k9DYLuhw=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "7405d2d84ce96e460d548cf7e8def332ac6e19f0",
+        "rev": "1c174224784973d782767197d73aecd9a0825753",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'cmp-luasnip-nvim':
    'github:saadparwaiz1/cmp_luasnip/05a9ab28b53f71d1aece421ef32fee2cb857a843' (2023-10-09)
  → 'github:saadparwaiz1/cmp_luasnip/98d9cb5c2c38532bd9bdb481067b20fea8f32e90' (2024-11-04)
• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/7c27a30450130cd59c4994a6755e3c5d74d83e76' (2024-10-30)
  → 'github:lewis6991/gitsigns.nvim/4daf7022f1481edf1e8fb9947df13bb07c18e89a' (2024-11-04)
• Updated input 'home-manager':
    'github:nix-community/home-manager/8ca921e5a806b5b6171add542defe7bdac79d189' (2024-11-01)
  → 'github:nix-community/home-manager/2f607e07f3ac7e53541120536708e824acccfaa8' (2024-11-05)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/d72bc8b1cd30d448bd438e8328f8eeb4c0f2ddb6' (2024-10-18)
  → 'github:hyprwm/contrib/792f6b83dc719214e0e2a0b380c34f147b28ece2' (2024-11-04)
• Updated input 'lualine-nvim':
    'github:nvim-lualine/lualine.nvim/640260d7c2d98779cab89b1e7088ab14ea354a02' (2024-11-01)
  → 'github:nvim-lualine/lualine.nvim/2a5bae925481f999263d6f5ed8361baef8df4f83' (2024-11-08)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/8d7aa7a7b7c0875e4878d1d2590924bc1c229305' (2024-10-30)
  → 'github:L3MON4D3/LuaSnip/2737edc9e674e537dc0a97e3405658d57d2d31ed' (2024-11-06)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/f35afbe60a4ff71fd65fec3839fc38943f961951' (2024-10-28)
  → 'github:nix-community/neovim-nightly-overlay/4edacffe41dcb1e23e56731fa97c1acce3768146' (2024-11-08)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/3d04084d54bedc3d6b8b736c70ef449225c361b1' (2024-10-01)
  → 'github:hercules-ci/flake-parts/506278e768c2a08bec68eb62932193e341f55c90' (2024-11-01)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/3c3e88f0f544d6bb54329832616af7eb971b6be6' (2024-10-16)
  → 'github:cachix/git-hooks.nix/d70155fdc00df4628446352fc58adc640cd705c2' (2024-11-05)
• Updated input 'neovim-nightly-overlay/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/dba4367b9a9d9615456c430a6d6af716f6e84cef' (2024-08-29)
  → 'github:hercules-ci/hercules-ci-effects/b89ac4d66d618b915b1f0a408e2775fe3821d141' (2024-11-06)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/852954ff6d96adce0158f74ca494fdcef3aa1921' (2024-10-16)
  → 'github:neovim/neovim/5a86360400691e55fae66d60485b61360a1d3d6c' (2024-11-07)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53' (2024-10-30)
  → 'github:nixos/nixpkgs/85f7e662eda4fa3a995556527c87b2524b691933' (2024-11-07)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/29fb4854573355792df9e156cb779f0d31308796' (2024-10-21)
  → 'github:hrsh7th/nvim-cmp/f17d9b4394027ff4442b298398dfcaab97e40c4f' (2024-11-02)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/54617a18f4cf46f0c2f6d024fa6feb7515fe036d' (2024-10-31)
  → 'github:neovim/nvim-lspconfig/d01864641c6e43c681c3e9f6cf4745c75fdd9dcc' (2024-11-07)
• Updated input 'resty-vim':
    'github:lima1909/resty.nvim/5351865bfaa15e120a7036608502777e676f0c9e' (2024-11-01)
  → 'github:lima1909/resty.nvim/cc11b478db498a2994956d31b6fd5b241f32519d' (2024-11-08)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/7405d2d84ce96e460d548cf7e8def332ac6e19f0' (2024-10-31)
  → 'github:mrcjkb/rustaceanvim/1c174224784973d782767197d73aecd9a0825753' (2024-11-07)
• Updated input 'rustacean-nvim/flake-parts':
    'github:hercules-ci/flake-parts/3d04084d54bedc3d6b8b736c70ef449225c361b1' (2024-10-01)
  → 'github:hercules-ci/flake-parts/506278e768c2a08bec68eb62932193e341f55c90' (2024-11-01)
• Updated input 'rustacean-nvim/flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz?narHash=sha256-0xHYkMkeLVQAMa7gvkddbPqpxph%2BhDzdu1XdGPJR%2BOs%3D' (2024-10-01)
  → 'https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz?narHash=sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s%3D' (2024-11-01)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/df27c6f473c2945b148d3243000466f546939d72' (2024-10-26)
  → 'github:nvim-neorocks/neorocks/d7d0bac66ca4712d40bf8ad30a79ba2353bcde7a' (2024-11-02)
• Updated input 'rustacean-nvim/neorocks/flake-parts':
    'github:hercules-ci/flake-parts/3d04084d54bedc3d6b8b736c70ef449225c361b1' (2024-10-01)
  → 'github:hercules-ci/flake-parts/506278e768c2a08bec68eb62932193e341f55c90' (2024-11-01)
• Updated input 'rustacean-nvim/neorocks/flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz?narHash=sha256-0xHYkMkeLVQAMa7gvkddbPqpxph%2BhDzdu1XdGPJR%2BOs%3D' (2024-10-01)
  → 'https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz?narHash=sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s%3D' (2024-11-01)
• Updated input 'rustacean-nvim/neorocks/git-hooks':
    'github:cachix/git-hooks.nix/3c3e88f0f544d6bb54329832616af7eb971b6be6' (2024-10-16)
  → 'github:cachix/git-hooks.nix/af8a16fe5c264f5e9e18bcee2859b40a656876cf' (2024-10-30)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/e2047498667aeb24e8493ff430a20cff713915f4' (2024-10-17)
  → 'github:nix-community/neovim-nightly-overlay/f35afbe60a4ff71fd65fec3839fc38943f961951' (2024-10-28)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/41dea55321e5a999b17033296ac05fe8a8b5a257' (2024-10-25)
  → 'github:nixos/nixpkgs/2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53' (2024-10-30)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/41dea55321e5a999b17033296ac05fe8a8b5a257' (2024-10-25)
  → 'github:nixos/nixpkgs/2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53' (2024-10-30)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/3c3e88f0f544d6bb54329832616af7eb971b6be6' (2024-10-16)
  → 'github:cachix/pre-commit-hooks.nix/af8a16fe5c264f5e9e18bcee2859b40a656876cf' (2024-10-30)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`e2047498` ➡️ `f35afbe6`](https://github.com/nix-community/neovim-nightly-overlay/compare/e2047498667aeb24e8493ff430a20cff713915f4...f35afbe60a4ff71fd65fec3839fc38943f961951) <sub>(2024-10-17 to 2024-10-28)</sub>
 - Updated input `rustacean-nvim/flake-parts/nixpkgs-lib`: `fb192fec` ➡️ `cc2f2800` <sub>(2024-10-01 to 2024-11-01)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`7405d2d8` ➡️ `1c174224`](https://github.com/mrcjkb/rustaceanvim/compare/7405d2d84ce96e460d548cf7e8def332ac6e19f0...1c174224784973d782767197d73aecd9a0825753) <sub>(2024-10-31 to 2024-11-07)</sub>
 - Updated input [`resty-vim`](https://github.com/lima1909/resty.nvim): [`5351865b` ➡️ `cc11b478`](https://github.com/lima1909/resty.nvim/compare/5351865bfaa15e120a7036608502777e676f0c9e...cc11b478db498a2994956d31b6fd5b241f32519d) <sub>(2024-11-01 to 2024-11-08)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`41dea553` ➡️ `2d2a9ddb`](https://github.com/nixos/nixpkgs/compare/41dea55321e5a999b17033296ac05fe8a8b5a257...2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53) <sub>(2024-10-25 to 2024-10-30)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`df27c6f4` ➡️ `d7d0bac6`](https://github.com/nvim-neorocks/neorocks/compare/df27c6f473c2945b148d3243000466f546939d72...d7d0bac66ca4712d40bf8ad30a79ba2353bcde7a) <sub>(2024-10-26 to 2024-11-02)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`f35afbe6` ➡️ `4edacffe`](https://github.com/nix-community/neovim-nightly-overlay/compare/f35afbe60a4ff71fd65fec3839fc38943f961951...4edacffe41dcb1e23e56731fa97c1acce3768146) <sub>(2024-10-28 to 2024-11-08)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`8d7aa7a7` ➡️ `2737edc9`](https://github.com/L3MON4D3/LuaSnip/compare/8d7aa7a7b7c0875e4878d1d2590924bc1c229305...2737edc9e674e537dc0a97e3405658d57d2d31ed) <sub>(2024-10-30 to 2024-11-06)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`d72bc8b1` ➡️ `792f6b83`](https://github.com/hyprwm/contrib/compare/d72bc8b1cd30d448bd438e8328f8eeb4c0f2ddb6...792f6b83dc719214e0e2a0b380c34f147b28ece2) <sub>(2024-10-18 to 2024-11-04)</sub>
 - Updated input `rustacean-nvim/neorocks/flake-parts/nixpkgs-lib`: `fb192fec` ➡️ `cc2f2800` <sub>(2024-10-01 to 2024-11-01)</sub>
 - Updated input [`rustacean-nvim/flake-parts`](https://github.com/hercules-ci/flake-parts): [`3d04084d` ➡️ `506278e7`](https://github.com/hercules-ci/flake-parts/compare/3d04084d54bedc3d6b8b736c70ef449225c361b1...506278e768c2a08bec68eb62932193e341f55c90) <sub>(2024-10-01 to 2024-11-01)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`54617a18` ➡️ `d0186464`](https://github.com/neovim/nvim-lspconfig/compare/54617a18f4cf46f0c2f6d024fa6feb7515fe036d...d01864641c6e43c681c3e9f6cf4745c75fdd9dcc) <sub>(2024-10-31 to 2024-11-07)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`29fb4854` ➡️ `f17d9b43`](https://github.com/hrsh7th/nvim-cmp/compare/29fb4854573355792df9e156cb779f0d31308796...f17d9b4394027ff4442b298398dfcaab97e40c4f) <sub>(2024-10-21 to 2024-11-02)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`3c3e88f0` ➡️ `af8a16fe`](https://github.com/cachix/pre-commit-hooks.nix/compare/3c3e88f0f544d6bb54329832616af7eb971b6be6...af8a16fe5c264f5e9e18bcee2859b40a656876cf) <sub>(2024-10-16 to 2024-10-30)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`41dea553` ➡️ `2d2a9ddb`](https://github.com/nixos/nixpkgs/compare/41dea55321e5a999b17033296ac05fe8a8b5a257...2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53) <sub>(2024-10-25 to 2024-10-30)</sub>
 - Updated input [`neovim-nightly-overlay/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`dba4367b` ➡️ `b89ac4d6`](https://github.com/hercules-ci/hercules-ci-effects/compare/dba4367b9a9d9615456c430a6d6af716f6e84cef...b89ac4d66d618b915b1f0a408e2775fe3821d141) <sub>(2024-08-29 to 2024-11-06)</sub>
 - Updated input [`rustacean-nvim/neorocks/git-hooks`](https://github.com/cachix/git-hooks.nix): [`3c3e88f0` ➡️ `af8a16fe`](https://github.com/cachix/git-hooks.nix/compare/3c3e88f0f544d6bb54329832616af7eb971b6be6...af8a16fe5c264f5e9e18bcee2859b40a656876cf) <sub>(2024-10-16 to 2024-10-30)</sub>
 - Updated input [`lualine-nvim`](https://github.com/nvim-lualine/lualine.nvim): [`640260d7` ➡️ `2a5bae92`](https://github.com/nvim-lualine/lualine.nvim/compare/640260d7c2d98779cab89b1e7088ab14ea354a02...2a5bae925481f999263d6f5ed8361baef8df4f83) <sub>(2024-11-01 to 2024-11-08)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`7c27a304` ➡️ `4daf7022`](https://github.com/lewis6991/gitsigns.nvim/compare/7c27a30450130cd59c4994a6755e3c5d74d83e76...4daf7022f1481edf1e8fb9947df13bb07c18e89a) <sub>(2024-10-30 to 2024-11-04)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`2d2a9ddb` ➡️ `85f7e662`](https://github.com/nixos/nixpkgs/compare/2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53...85f7e662eda4fa3a995556527c87b2524b691933) <sub>(2024-10-30 to 2024-11-07)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`3c3e88f0` ➡️ `d70155fd`](https://github.com/cachix/git-hooks.nix/compare/3c3e88f0f544d6bb54329832616af7eb971b6be6...d70155fdc00df4628446352fc58adc640cd705c2) <sub>(2024-10-16 to 2024-11-05)</sub>
 - Updated input [`rustacean-nvim/neorocks/flake-parts`](https://github.com/hercules-ci/flake-parts): [`3d04084d` ➡️ `506278e7`](https://github.com/hercules-ci/flake-parts/compare/3d04084d54bedc3d6b8b736c70ef449225c361b1...506278e768c2a08bec68eb62932193e341f55c90) <sub>(2024-10-01 to 2024-11-01)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`8ca921e5` ➡️ `2f607e07`](https://github.com/nix-community/home-manager/compare/8ca921e5a806b5b6171add542defe7bdac79d189...2f607e07f3ac7e53541120536708e824acccfaa8) <sub>(2024-11-01 to 2024-11-05)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`852954ff` ➡️ `5a863604`](https://github.com/neovim/neovim/compare/852954ff6d96adce0158f74ca494fdcef3aa1921...5a86360400691e55fae66d60485b61360a1d3d6c) <sub>(2024-10-16 to 2024-11-07)</sub>
 - Updated input [`cmp-luasnip-nvim`](https://github.com/saadparwaiz1/cmp_luasnip): [`05a9ab28` ➡️ `98d9cb5c`](https://github.com/saadparwaiz1/cmp_luasnip/compare/05a9ab28b53f71d1aece421ef32fee2cb857a843...98d9cb5c2c38532bd9bdb481067b20fea8f32e90) <sub>(2023-10-09 to 2024-11-04)</sub>
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`3d04084d` ➡️ `506278e7`](https://github.com/hercules-ci/flake-parts/compare/3d04084d54bedc3d6b8b736c70ef449225c361b1...506278e768c2a08bec68eb62932193e341f55c90) <sub>(2024-10-01 to 2024-11-01)</sub>