### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -330,11 +330,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -389,11 +389,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -521,11 +521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730814269,
-        "narHash": "sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF+06nOg=",
+        "lastModified": 1731363552,
+        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
+        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
         "type": "github"
       },
       "original": {
@@ -567,11 +567,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1730302582,
-        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
+        "lastModified": 1730814269,
+        "narHash": "sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF+06nOg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
+        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
         "type": "github"
       },
       "original": {
@@ -598,11 +598,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729104314,
-        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
+        "lastModified": 1730814269,
+        "narHash": "sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF+06nOg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
+        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
         "type": "github"
       },
       "original": {
@@ -777,11 +777,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1730713501,
-        "narHash": "sha256-FHzufzeVrPnbU5j3UabVTCYXP+QNcb7gMgef0BmuclA=",
+        "lastModified": 1731605154,
+        "narHash": "sha256-8vWilpsVw22+nAEAjhGOvZniRRj5r1UITcW9YeuDH8o=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "4daf7022f1481edf1e8fb9947df13bb07c18e89a",
+        "rev": "ac5aba6dce8c06ea22bea2c9016f51a2dbf90dc7",
         "type": "github"
       },
       "original": {
@@ -823,11 +823,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724947644,
-        "narHash": "sha256-MHHrHasTngp7EYQOObHJ1a/IsRF+wodHqOckhH6uZbk=",
+        "lastModified": 1730903510,
+        "narHash": "sha256-mnynlrPeiW0nUQ8KGZHb3WyxAxA3Ye/BH8gMjdoKP6E=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "dba4367b9a9d9615456c430a6d6af716f6e84cef",
+        "rev": "b89ac4d66d618b915b1f0a408e2775fe3821d141",
         "type": "github"
       },
       "original": {
@@ -843,11 +843,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730837930,
-        "narHash": "sha256-0kZL4m+bKBJUBQse0HanewWO0g8hDdCvBhudzxgehqc=",
+        "lastModified": 1731604581,
+        "narHash": "sha256-Qq2YZZaDTB3FZLWU/Hgh1uuWlUBl3cMLGB99bm7rFUM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f607e07f3ac7e53541120536708e824acccfaa8",
+        "rev": "1d0862ee2d7c6f6cd720d6f32213fa425004be10",
         "type": "github"
       },
       "original": {
@@ -990,11 +990,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1730895001,
-        "narHash": "sha256-Vb4unHnhppcM1HZtd8oohJHPlkUHORoYUjKUWyhRM6g=",
+        "lastModified": 1731421019,
+        "narHash": "sha256-EBhlTaMs5ugDdA6WUcOWI2VL68BOruRUoiaMei4ECPQ=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "2737edc9e674e537dc0a97e3405658d57d2d31ed",
+        "rev": "659c4479529a05cc9b05ef762639a09d366cc690",
         "type": "github"
       },
       "original": {
@@ -1044,11 +1044,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1730525028,
-        "narHash": "sha256-50Brt47i3P1DE/3mXw5NQZnW2ObI86xMwWOT7V+a1ck=",
+        "lastModified": 1731129910,
+        "narHash": "sha256-oyDV65S7QY7uhzb2sADIvwPPkw2vwhqV8CIv0WAt1Kg=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "d7d0bac66ca4712d40bf8ad30a79ba2353bcde7a",
+        "rev": "c1b3c1188de859d12a610a1c46d03558cc763634",
         "type": "github"
       },
       "original": {
@@ -1067,11 +1067,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1730088025,
-        "narHash": "sha256-FIdIaN7f6karwtDV65VXTV8VThNrR63nwykfgXpm4p4=",
+        "lastModified": 1731111231,
+        "narHash": "sha256-8u8k3hnU5OxlXfhDLD3XEwAqv/M9Tb5USLCEPvXCPcM=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "f35afbe60a4ff71fd65fec3839fc38943f961951",
+        "rev": "702364e6ec794961483eba5220ca531917d03784",
         "type": "github"
       },
       "original": {
@@ -1092,11 +1092,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731052353,
-        "narHash": "sha256-UjH4ED1gEpHW6jsanwBWPevKq/hgA0UXMXpTYOolh5U=",
+        "lastModified": 1731629313,
+        "narHash": "sha256-rCTdc6oHM4Ostt6IR66QiDrPQNjCsxC2r00GfU0bADU=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "4edacffe41dcb1e23e56731fa97c1acce3768146",
+        "rev": "81a983160c1acae623482e082a94a46c931d0261",
         "type": "github"
       },
       "original": {
@@ -1108,11 +1108,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1730973210,
-        "narHash": "sha256-7IdIvOaDeiTJMNPcX94ts8U5V44nu2YtQh8VT8ua4XY=",
+        "lastModified": 1731607016,
+        "narHash": "sha256-EjIQ7ok02IfDHDMKdKELuvFRHlZhzhymDGGx3jg6nvQ=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "5a86360400691e55fae66d60485b61360a1d3d6c",
+        "rev": "05d354e2165c2c331a33949d49095eef3503a32f",
         "type": "github"
       },
       "original": {
@@ -1124,11 +1124,11 @@
     "neovim-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1729121305,
-        "narHash": "sha256-c94xkA/RuszC4PfmB+MWqOo2vbO66GTO6XKer0mbltA=",
+        "lastModified": 1731083384,
+        "narHash": "sha256-0uH8SSP6/eqCuDvUCV+s1ZwjLg6512Vj9dgKKO0iEmE=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "852954ff6d96adce0158f74ca494fdcef3aa1921",
+        "rev": "ad3472e291694b6c589d8a664459b03962eaac95",
         "type": "github"
       },
       "original": {
@@ -1235,11 +1235,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
         "type": "github"
       },
       "original": {
@@ -1251,11 +1251,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
         "type": "github"
       },
       "original": {
@@ -1299,11 +1299,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1730958623,
-        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
+        "lastModified": 1731531548,
+        "narHash": "sha256-sz8/v17enkYmfpgeeuyzniGJU0QQBfmAjlemAUYhfy8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
+        "rev": "24f0d4acd634792badd6470134c387a3b039dace",
         "type": "github"
       },
       "original": {
@@ -1347,11 +1347,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1719082008,
-        "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
+        "lastModified": 1730768919,
+        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9693852a2070b398ee123a329e68f0dab5526681",
+        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
         "type": "github"
       },
       "original": {
@@ -1363,11 +1363,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1728863046,
-        "narHash": "sha256-DZBO2465PL5V89e8hFSJewyH4QbCPpW3ssws7ckT/0A=",
+        "lastModified": 1730958623,
+        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d4f247e89f6e10120f911e2e2d2254a050d0f732",
+        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
         "type": "github"
       },
       "original": {
@@ -1379,11 +1379,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1730272153,
-        "narHash": "sha256-B5WRZYsRlJgwVHIV6DvidFN7VX7Fg9uuwkRW9Ha8z+w=",
+        "lastModified": 1730958623,
+        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53",
+        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
         "type": "github"
       },
       "original": {
@@ -1395,11 +1395,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1730272153,
-        "narHash": "sha256-B5WRZYsRlJgwVHIV6DvidFN7VX7Fg9uuwkRW9Ha8z+w=",
+        "lastModified": 1730958623,
+        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53",
+        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
         "type": "github"
       },
       "original": {
@@ -1411,11 +1411,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1719082008,
-        "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
+        "lastModified": 1730768919,
+        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9693852a2070b398ee123a329e68f0dab5526681",
+        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
         "type": "github"
       },
       "original": {
@@ -1444,11 +1444,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1730978746,
-        "narHash": "sha256-N1vqosgHHVUWoszhdGImH//mb7hiSWWsG1Pq9WNnQxk=",
+        "lastModified": 1731651852,
+        "narHash": "sha256-enldOaHszQH7fUxUEWFNcWedH9zatrNp/Dh7vHGBz/o=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "d01864641c6e43c681c3e9f6cf4745c75fdd9dcc",
+        "rev": "87c7c83ce62971e0bdb29bb32b8ad2b19c8f95d0",
         "type": "github"
       },
       "original": {
@@ -1503,11 +1503,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1730302582,
-        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
+        "lastModified": 1730814269,
+        "narHash": "sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF+06nOg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
+        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
         "type": "github"
       },
       "original": {
@@ -1519,11 +1519,11 @@
     "resty-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1731082182,
-        "narHash": "sha256-YLNkmX8dGhIkJac/4L++uy8LUElKCV/NnpnbQ1J3B6s=",
+        "lastModified": 1731609783,
+        "narHash": "sha256-H96bV+dt1SYocArafBJms5uIqLvEeBFlvGuNQszeQY8=",
         "owner": "lima1909",
         "repo": "resty.nvim",
-        "rev": "cc11b478db498a2994956d31b6fd5b241f32519d",
+        "rev": "d7d22f26e82b357c274754ed0a10593d00b7ce00",
         "type": "github"
       },
       "original": {
@@ -1601,11 +1601,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1731003427,
-        "narHash": "sha256-Sobs/ybL7VPsyh2c0EED0U5kl/tGtFcaj76k9DYLuhw=",
+        "lastModified": 1731403165,
+        "narHash": "sha256-W4gVCEneDgtLq/6n+iyxu2lULpjAy/aaBbMEosDGF9w=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "1c174224784973d782767197d73aecd9a0825753",
+        "rev": "8ece53be36515cb9e76f3d03511643636469502d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'flake-utils':
    'github:numtide/flake-utils/c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a' (2024-09-17)
  → 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b' (2024-11-13)
• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/4daf7022f1481edf1e8fb9947df13bb07c18e89a' (2024-11-04)
  → 'github:lewis6991/gitsigns.nvim/ac5aba6dce8c06ea22bea2c9016f51a2dbf90dc7' (2024-11-14)
• Updated input 'home-manager':
    'github:nix-community/home-manager/2f607e07f3ac7e53541120536708e824acccfaa8' (2024-11-05)
  → 'github:nix-community/home-manager/1d0862ee2d7c6f6cd720d6f32213fa425004be10' (2024-11-14)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/2737edc9e674e537dc0a97e3405658d57d2d31ed' (2024-11-06)
  → 'github:L3MON4D3/LuaSnip/659c4479529a05cc9b05ef762639a09d366cc690' (2024-11-12)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/4edacffe41dcb1e23e56731fa97c1acce3768146' (2024-11-08)
  → 'github:nix-community/neovim-nightly-overlay/81a983160c1acae623482e082a94a46c931d0261' (2024-11-15)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/d70155fdc00df4628446352fc58adc640cd705c2' (2024-11-05)
  → 'github:cachix/git-hooks.nix/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0' (2024-11-11)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/5a86360400691e55fae66d60485b61360a1d3d6c' (2024-11-07)
  → 'github:neovim/neovim/05d354e2165c2c331a33949d49095eef3503a32f' (2024-11-14)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/85f7e662eda4fa3a995556527c87b2524b691933' (2024-11-07)
  → 'github:nixos/nixpkgs/24f0d4acd634792badd6470134c387a3b039dace' (2024-11-13)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/d01864641c6e43c681c3e9f6cf4745c75fdd9dcc' (2024-11-07)
  → 'github:neovim/nvim-lspconfig/87c7c83ce62971e0bdb29bb32b8ad2b19c8f95d0' (2024-11-15)
• Updated input 'resty-vim':
    'github:lima1909/resty.nvim/cc11b478db498a2994956d31b6fd5b241f32519d' (2024-11-08)
  → 'github:lima1909/resty.nvim/d7d22f26e82b357c274754ed0a10593d00b7ce00' (2024-11-14)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/1c174224784973d782767197d73aecd9a0825753' (2024-11-07)
  → 'github:mrcjkb/rustaceanvim/8ece53be36515cb9e76f3d03511643636469502d' (2024-11-12)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/d7d0bac66ca4712d40bf8ad30a79ba2353bcde7a' (2024-11-02)
  → 'github:nvim-neorocks/neorocks/c1b3c1188de859d12a610a1c46d03558cc763634' (2024-11-09)
• Updated input 'rustacean-nvim/neorocks/git-hooks':
    'github:cachix/git-hooks.nix/af8a16fe5c264f5e9e18bcee2859b40a656876cf' (2024-10-30)
  → 'github:cachix/git-hooks.nix/d70155fdc00df4628446352fc58adc640cd705c2' (2024-11-05)
• Updated input 'rustacean-nvim/neorocks/git-hooks/nixpkgs':
    'github:NixOS/nixpkgs/9693852a2070b398ee123a329e68f0dab5526681' (2024-06-22)
  → 'github:NixOS/nixpkgs/a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc' (2024-11-05)
• Updated input 'rustacean-nvim/neorocks/git-hooks/nixpkgs-stable':
    'github:NixOS/nixpkgs/194846768975b7ad2c4988bdb82572c00222c0d7' (2024-07-07)
  → 'github:NixOS/nixpkgs/d063c1dd113c91ab27959ba540c0d9753409edf3' (2024-11-04)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/f35afbe60a4ff71fd65fec3839fc38943f961951' (2024-10-28)
  → 'github:nix-community/neovim-nightly-overlay/702364e6ec794961483eba5220ca531917d03784' (2024-11-09)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/flake-parts':
    'github:hercules-ci/flake-parts/3d04084d54bedc3d6b8b736c70ef449225c361b1' (2024-10-01)
  → 'github:hercules-ci/flake-parts/506278e768c2a08bec68eb62932193e341f55c90' (2024-11-01)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks':
    'github:cachix/git-hooks.nix/3c3e88f0f544d6bb54329832616af7eb971b6be6' (2024-10-16)
  → 'github:cachix/git-hooks.nix/d70155fdc00df4628446352fc58adc640cd705c2' (2024-11-05)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/dba4367b9a9d9615456c430a6d6af716f6e84cef' (2024-08-29)
  → 'github:hercules-ci/hercules-ci-effects/b89ac4d66d618b915b1f0a408e2775fe3821d141' (2024-11-06)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/852954ff6d96adce0158f74ca494fdcef3aa1921' (2024-10-16)
  → 'github:neovim/neovim/ad3472e291694b6c589d8a664459b03962eaac95' (2024-11-08)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/d4f247e89f6e10120f911e2e2d2254a050d0f732' (2024-10-13)
  → 'github:NixOS/nixpkgs/85f7e662eda4fa3a995556527c87b2524b691933' (2024-11-07)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53' (2024-10-30)
  → 'github:nixos/nixpkgs/85f7e662eda4fa3a995556527c87b2524b691933' (2024-11-07)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53' (2024-10-30)
  → 'github:nixos/nixpkgs/85f7e662eda4fa3a995556527c87b2524b691933' (2024-11-07)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/af8a16fe5c264f5e9e18bcee2859b40a656876cf' (2024-10-30)
  → 'github:cachix/pre-commit-hooks.nix/d70155fdc00df4628446352fc58adc640cd705c2' (2024-11-05)
• Updated input 'rustacean-nvim/pre-commit-hooks/nixpkgs':
    'github:NixOS/nixpkgs/9693852a2070b398ee123a329e68f0dab5526681' (2024-06-22)
  → 'github:NixOS/nixpkgs/a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc' (2024-11-05)
• Updated input 'rustacean-nvim/pre-commit-hooks/nixpkgs-stable':
    'github:NixOS/nixpkgs/194846768975b7ad2c4988bdb82572c00222c0d7' (2024-07-07)
  → 'github:NixOS/nixpkgs/d063c1dd113c91ab27959ba540c0d9753409edf3' (2024-11-04)

```

</p></details>

 - Updated input [`rustacean-nvim/pre-commit-hooks/nixpkgs`](https://github.com/NixOS/nixpkgs): [`9693852a` ➡️ `a04d33c0`](https://github.com/NixOS/nixpkgs/compare/9693852a2070b398ee123a329e68f0dab5526681...a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc) <sub>(2024-06-22 to 2024-11-05)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`f35afbe6` ➡️ `702364e6`](https://github.com/nix-community/neovim-nightly-overlay/compare/f35afbe60a4ff71fd65fec3839fc38943f961951...702364e6ec794961483eba5220ca531917d03784) <sub>(2024-10-28 to 2024-11-09)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`1c174224` ➡️ `8ece53be`](https://github.com/mrcjkb/rustaceanvim/compare/1c174224784973d782767197d73aecd9a0825753...8ece53be36515cb9e76f3d03511643636469502d) <sub>(2024-11-07 to 2024-11-12)</sub>
 - Updated input [`resty-vim`](https://github.com/lima1909/resty.nvim): [`cc11b478` ➡️ `d7d22f26`](https://github.com/lima1909/resty.nvim/compare/cc11b478db498a2994956d31b6fd5b241f32519d...d7d22f26e82b357c274754ed0a10593d00b7ce00) <sub>(2024-11-08 to 2024-11-14)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`2d2a9ddb` ➡️ `85f7e662`](https://github.com/nixos/nixpkgs/compare/2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53...85f7e662eda4fa3a995556527c87b2524b691933) <sub>(2024-10-30 to 2024-11-07)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`d7d0bac6` ➡️ `c1b3c118`](https://github.com/nvim-neorocks/neorocks/compare/d7d0bac66ca4712d40bf8ad30a79ba2353bcde7a...c1b3c1188de859d12a610a1c46d03558cc763634) <sub>(2024-11-02 to 2024-11-09)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [`852954ff` ➡️ `ad3472e2`](https://github.com/neovim/neovim/compare/852954ff6d96adce0158f74ca494fdcef3aa1921...ad3472e291694b6c589d8a664459b03962eaac95) <sub>(2024-10-16 to 2024-11-08)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`dba4367b` ➡️ `b89ac4d6`](https://github.com/hercules-ci/hercules-ci-effects/compare/dba4367b9a9d9615456c430a6d6af716f6e84cef...b89ac4d66d618b915b1f0a408e2775fe3821d141) <sub>(2024-08-29 to 2024-11-06)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`4edacffe` ➡️ `81a98316`](https://github.com/nix-community/neovim-nightly-overlay/compare/4edacffe41dcb1e23e56731fa97c1acce3768146...81a983160c1acae623482e082a94a46c931d0261) <sub>(2024-11-08 to 2024-11-15)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`2737edc9` ➡️ `659c4479`](https://github.com/L3MON4D3/LuaSnip/compare/2737edc9e674e537dc0a97e3405658d57d2d31ed...659c4479529a05cc9b05ef762639a09d366cc690) <sub>(2024-11-06 to 2024-11-12)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`d0186464` ➡️ `87c7c83c`](https://github.com/neovim/nvim-lspconfig/compare/d01864641c6e43c681c3e9f6cf4745c75fdd9dcc...87c7c83ce62971e0bdb29bb32b8ad2b19c8f95d0) <sub>(2024-11-07 to 2024-11-15)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`af8a16fe` ➡️ `d70155fd`](https://github.com/cachix/pre-commit-hooks.nix/compare/af8a16fe5c264f5e9e18bcee2859b40a656876cf...d70155fdc00df4628446352fc58adc640cd705c2) <sub>(2024-10-30 to 2024-11-05)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`2d2a9ddb` ➡️ `85f7e662`](https://github.com/nixos/nixpkgs/compare/2d2a9ddbe3f2c00747398f3dc9b05f7f2ebb0f53...85f7e662eda4fa3a995556527c87b2524b691933) <sub>(2024-10-30 to 2024-11-07)</sub>
 - Updated input [`rustacean-nvim/neorocks/git-hooks`](https://github.com/cachix/git-hooks.nix): [`af8a16fe` ➡️ `d70155fd`](https://github.com/cachix/git-hooks.nix/compare/af8a16fe5c264f5e9e18bcee2859b40a656876cf...d70155fdc00df4628446352fc58adc640cd705c2) <sub>(2024-10-30 to 2024-11-05)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`4daf7022` ➡️ `ac5aba6d`](https://github.com/lewis6991/gitsigns.nvim/compare/4daf7022f1481edf1e8fb9947df13bb07c18e89a...ac5aba6dce8c06ea22bea2c9016f51a2dbf90dc7) <sub>(2024-11-04 to 2024-11-14)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`85f7e662` ➡️ `24f0d4ac`](https://github.com/nixos/nixpkgs/compare/85f7e662eda4fa3a995556527c87b2524b691933...24f0d4acd634792badd6470134c387a3b039dace) <sub>(2024-11-07 to 2024-11-13)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`d70155fd` ➡️ `cd1af27a`](https://github.com/cachix/git-hooks.nix/compare/d70155fdc00df4628446352fc58adc640cd705c2...cd1af27aa85026ac759d5d3fccf650abe7e1bbf0) <sub>(2024-11-05 to 2024-11-11)</sub>
 - Updated input [`rustacean-nvim/neorocks/git-hooks/nixpkgs-stable`](https://github.com/NixOS/nixpkgs): [`19484676` ➡️ `d063c1dd`](https://github.com/NixOS/nixpkgs/compare/194846768975b7ad2c4988bdb82572c00222c0d7...d063c1dd113c91ab27959ba540c0d9753409edf3) <sub>(2024-07-07 to 2024-11-04)</sub>
 - Updated input [`rustacean-nvim/neorocks/git-hooks/nixpkgs`](https://github.com/NixOS/nixpkgs): [`9693852a` ➡️ `a04d33c0`](https://github.com/NixOS/nixpkgs/compare/9693852a2070b398ee123a329e68f0dab5526681...a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc) <sub>(2024-06-22 to 2024-11-05)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`d4f247e8` ➡️ `85f7e662`](https://github.com/NixOS/nixpkgs/compare/d4f247e89f6e10120f911e2e2d2254a050d0f732...85f7e662eda4fa3a995556527c87b2524b691933) <sub>(2024-10-13 to 2024-11-07)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks`](https://github.com/cachix/git-hooks.nix): [`3c3e88f0` ➡️ `d70155fd`](https://github.com/cachix/git-hooks.nix/compare/3c3e88f0f544d6bb54329832616af7eb971b6be6...d70155fdc00df4628446352fc58adc640cd705c2) <sub>(2024-10-16 to 2024-11-05)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`2f607e07` ➡️ `1d0862ee`](https://github.com/nix-community/home-manager/compare/2f607e07f3ac7e53541120536708e824acccfaa8...1d0862ee2d7c6f6cd720d6f32213fa425004be10) <sub>(2024-11-05 to 2024-11-14)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks/nixpkgs-stable`](https://github.com/NixOS/nixpkgs): [`19484676` ➡️ `d063c1dd`](https://github.com/NixOS/nixpkgs/compare/194846768975b7ad2c4988bdb82572c00222c0d7...d063c1dd113c91ab27959ba540c0d9753409edf3) <sub>(2024-07-07 to 2024-11-04)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`5a863604` ➡️ `05d354e2`](https://github.com/neovim/neovim/compare/5a86360400691e55fae66d60485b61360a1d3d6c...05d354e2165c2c331a33949d49095eef3503a32f) <sub>(2024-11-07 to 2024-11-14)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/flake-parts`](https://github.com/hercules-ci/flake-parts): [`3d04084d` ➡️ `506278e7`](https://github.com/hercules-ci/flake-parts/compare/3d04084d54bedc3d6b8b736c70ef449225c361b1...506278e768c2a08bec68eb62932193e341f55c90) <sub>(2024-10-01 to 2024-11-01)</sub>
 - Updated input [`flake-utils`](https://github.com/numtide/flake-utils): [`c1dfcf08` ➡️ `11707dc2`](https://github.com/numtide/flake-utils/compare/c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a...11707dc2f618dd54ca8739b309ec4fc024de578b) <sub>(2024-09-17 to 2024-11-13)</sub>