### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -441,11 +441,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1725670815,
-        "narHash": "sha256-ArYerBws+MBY4BpKh16J5TfVTrA0OFKPoZq7c2YQjp0=",
+        "lastModified": 1732036604,
+        "narHash": "sha256-RGS2T6tHuFPZROU0W4Z6j6wMEiJmd8xuKv3qqM3XHPI=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "d4877e54cef67f5af4f950935b1ade19ed6b7370",
+        "rev": "320b18fba2a4f2fe3c8225c778c687e0d2620384",
         "type": "github"
       },
       "original": {
@@ -521,11 +521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731363552,
-        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
+        "lastModified": 1732021966,
+        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
         "type": "github"
       },
       "original": {
@@ -567,11 +567,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1730814269,
-        "narHash": "sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF+06nOg=",
+        "lastModified": 1731363552,
+        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
+        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
         "type": "github"
       },
       "original": {
@@ -598,11 +598,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730814269,
-        "narHash": "sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF+06nOg=",
+        "lastModified": 1731363552,
+        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
+        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
         "type": "github"
       },
       "original": {
@@ -843,11 +843,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731604581,
-        "narHash": "sha256-Qq2YZZaDTB3FZLWU/Hgh1uuWlUBl3cMLGB99bm7rFUM=",
+        "lastModified": 1732303962,
+        "narHash": "sha256-5Umjb5AdtxV5jSJd5jxoCckh5mlg+FBQDsyAilu637g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d0862ee2d7c6f6cd720d6f32213fa425004be10",
+        "rev": "8cf9cb2ee78aa129e5b8220135a511a2be254c0c",
         "type": "github"
       },
       "original": {
@@ -974,11 +974,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1731421019,
-        "narHash": "sha256-EBhlTaMs5ugDdA6WUcOWI2VL68BOruRUoiaMei4ECPQ=",
+        "lastModified": 1731918376,
+        "narHash": "sha256-Yl95znL076u6cuSigMQpUOOBw9ZXfqy1a3JF0fL8+KI=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "659c4479529a05cc9b05ef762639a09d366cc690",
+        "rev": "0f7bbce41ea152a94d12aea286f2ce98e63c0f58",
         "type": "github"
       },
       "original": {
@@ -1028,11 +1028,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1731129910,
-        "narHash": "sha256-oyDV65S7QY7uhzb2sADIvwPPkw2vwhqV8CIv0WAt1Kg=",
+        "lastModified": 1731648623,
+        "narHash": "sha256-kL0qF6ETmWSeN0Nzjg7GtSbe/7AcNmuX2U6Mb7xLIOA=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "c1b3c1188de859d12a610a1c46d03558cc763634",
+        "rev": "b82f112cb43020ab23a2816dfc7a3453aafd754f",
         "type": "github"
       },
       "original": {
@@ -1051,11 +1051,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1731111231,
-        "narHash": "sha256-8u8k3hnU5OxlXfhDLD3XEwAqv/M9Tb5USLCEPvXCPcM=",
+        "lastModified": 1731629313,
+        "narHash": "sha256-rCTdc6oHM4Ostt6IR66QiDrPQNjCsxC2r00GfU0bADU=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "702364e6ec794961483eba5220ca531917d03784",
+        "rev": "81a983160c1acae623482e082a94a46c931d0261",
         "type": "github"
       },
       "original": {
@@ -1076,11 +1076,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731629313,
-        "narHash": "sha256-rCTdc6oHM4Ostt6IR66QiDrPQNjCsxC2r00GfU0bADU=",
+        "lastModified": 1732234033,
+        "narHash": "sha256-94yZ7eJiLvW+UknI5RZBCV6OMHtoSv1oWyOwKjTmS88=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "81a983160c1acae623482e082a94a46c931d0261",
+        "rev": "10e11c32a4f4f7c9d64f45413642ded11fc538b6",
         "type": "github"
       },
       "original": {
@@ -1092,11 +1092,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1731607016,
-        "narHash": "sha256-EjIQ7ok02IfDHDMKdKELuvFRHlZhzhymDGGx3jg6nvQ=",
+        "lastModified": 1732229552,
+        "narHash": "sha256-7tA7IeOjx1wgDQnY7RxIhIuwcFeSZu4Yc3WtLh+22TE=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "05d354e2165c2c331a33949d49095eef3503a32f",
+        "rev": "ff75f345ab5fa57c6560db021e8eb099aff90472",
         "type": "github"
       },
       "original": {
@@ -1108,11 +1108,11 @@
     "neovim-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1731083384,
-        "narHash": "sha256-0uH8SSP6/eqCuDvUCV+s1ZwjLg6512Vj9dgKKO0iEmE=",
+        "lastModified": 1731607016,
+        "narHash": "sha256-EjIQ7ok02IfDHDMKdKELuvFRHlZhzhymDGGx3jg6nvQ=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "ad3472e291694b6c589d8a664459b03962eaac95",
+        "rev": "05d354e2165c2c331a33949d49095eef3503a32f",
         "type": "github"
       },
       "original": {
@@ -1283,11 +1283,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1731531548,
-        "narHash": "sha256-sz8/v17enkYmfpgeeuyzniGJU0QQBfmAjlemAUYhfy8=",
+        "lastModified": 1731890469,
+        "narHash": "sha256-D1FNZ70NmQEwNxpSSdTXCSklBH1z2isPR84J6DQrJGs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "24f0d4acd634792badd6470134c387a3b039dace",
+        "rev": "5083ec887760adfe12af64830a66807423a859a7",
         "type": "github"
       },
       "original": {
@@ -1347,11 +1347,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1730958623,
-        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
+        "lastModified": 1731531548,
+        "narHash": "sha256-sz8/v17enkYmfpgeeuyzniGJU0QQBfmAjlemAUYhfy8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
+        "rev": "24f0d4acd634792badd6470134c387a3b039dace",
         "type": "github"
       },
       "original": {
@@ -1363,11 +1363,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1730958623,
-        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
+        "lastModified": 1731531548,
+        "narHash": "sha256-sz8/v17enkYmfpgeeuyzniGJU0QQBfmAjlemAUYhfy8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
+        "rev": "24f0d4acd634792badd6470134c387a3b039dace",
         "type": "github"
       },
       "original": {
@@ -1379,11 +1379,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1730958623,
-        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
+        "lastModified": 1731763621,
+        "narHash": "sha256-ddcX4lQL0X05AYkrkV2LMFgGdRvgap7Ho8kgon3iWZk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
+        "rev": "c69a9bffbecde46b4b939465422ddc59493d3e4d",
         "type": "github"
       },
       "original": {
@@ -1412,11 +1412,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1730523275,
-        "narHash": "sha256-iNEoMl/X0nh2sAio1h+dkuobeOXRBXKFJCcElUyyW54=",
+        "lastModified": 1732179089,
+        "narHash": "sha256-1vVqYltWM67yAzDmoqovFRhvuWit0MoSSnqd6PwVolk=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "f17d9b4394027ff4442b298398dfcaab97e40c4f",
+        "rev": "be7bd4c5f860c79da97af3a26d489af50babfd4b",
         "type": "github"
       },
       "original": {
@@ -1428,11 +1428,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1731651852,
-        "narHash": "sha256-enldOaHszQH7fUxUEWFNcWedH9zatrNp/Dh7vHGBz/o=",
+        "lastModified": 1732268459,
+        "narHash": "sha256-6KGLT//JZrj/9fz21ZykGTQaSs+qawZxLcwx2rUx9ao=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "87c7c83ce62971e0bdb29bb32b8ad2b19c8f95d0",
+        "rev": "c646154d6e4db9b2979eeb517d0b817ad00c9c47",
         "type": "github"
       },
       "original": {
@@ -1487,11 +1487,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1730814269,
-        "narHash": "sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF+06nOg=",
+        "lastModified": 1731363552,
+        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
+        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
         "type": "github"
       },
       "original": {
@@ -1503,11 +1503,11 @@
     "resty-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1731609783,
-        "narHash": "sha256-H96bV+dt1SYocArafBJms5uIqLvEeBFlvGuNQszeQY8=",
+        "lastModified": 1732280155,
+        "narHash": "sha256-oKZpq0V0p2vHEWrf+yAGQa0bXIphr9Y5fXzB2xLcT0M=",
         "owner": "lima1909",
         "repo": "resty.nvim",
-        "rev": "d7d22f26e82b357c274754ed0a10593d00b7ce00",
+        "rev": "79973eb9f8c1ec96f83296f757bcb6f94f2938f3",
         "type": "github"
       },
       "original": {
@@ -1584,11 +1584,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1731403165,
-        "narHash": "sha256-W4gVCEneDgtLq/6n+iyxu2lULpjAy/aaBbMEosDGF9w=",
+        "lastModified": 1731964536,
+        "narHash": "sha256-QgvFKV9QdfQ8Lh3EhXbwFcOQXTvaBE88EtbmJdJS9gk=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "8ece53be36515cb9e76f3d03511643636469502d",
+        "rev": "6e742b9fc6a37e46181879f6c32cecfa8cd2cebf",
         "type": "github"
       },
       "original": {
@@ -1729,11 +1729,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1728608318,
-        "narHash": "sha256-SUWEOp+QcfHjYaqqr4Zwvh0x91IAJXvrdMkQtuWMlGc=",
+        "lastModified": 1732225809,
+        "narHash": "sha256-PvQ6Q4+08uf4gVH5tsVRB+7AuDSubDUUbPiUDyNAbzc=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "19d257cf889f79f4022163c3fbb5e08639077bd8",
+        "rev": "f09be61d05bebcba85bb47be1931322d51b95644",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/d4877e54cef67f5af4f950935b1ade19ed6b7370' (2024-09-07)
  → 'github:tpope/vim-fugitive/320b18fba2a4f2fe3c8225c778c687e0d2620384' (2024-11-19)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1d0862ee2d7c6f6cd720d6f32213fa425004be10' (2024-11-14)
  → 'github:nix-community/home-manager/8cf9cb2ee78aa129e5b8220135a511a2be254c0c' (2024-11-22)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/659c4479529a05cc9b05ef762639a09d366cc690' (2024-11-12)
  → 'github:L3MON4D3/LuaSnip/0f7bbce41ea152a94d12aea286f2ce98e63c0f58' (2024-11-18)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/81a983160c1acae623482e082a94a46c931d0261' (2024-11-15)
  → 'github:nix-community/neovim-nightly-overlay/10e11c32a4f4f7c9d64f45413642ded11fc538b6' (2024-11-22)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0' (2024-11-11)
  → 'github:cachix/git-hooks.nix/3308484d1a443fc5bc92012435d79e80458fe43c' (2024-11-19)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/05d354e2165c2c331a33949d49095eef3503a32f' (2024-11-14)
  → 'github:neovim/neovim/ff75f345ab5fa57c6560db021e8eb099aff90472' (2024-11-21)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/24f0d4acd634792badd6470134c387a3b039dace' (2024-11-13)
  → 'github:nixos/nixpkgs/5083ec887760adfe12af64830a66807423a859a7' (2024-11-18)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/f17d9b4394027ff4442b298398dfcaab97e40c4f' (2024-11-02)
  → 'github:hrsh7th/nvim-cmp/be7bd4c5f860c79da97af3a26d489af50babfd4b' (2024-11-21)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/87c7c83ce62971e0bdb29bb32b8ad2b19c8f95d0' (2024-11-15)
  → 'github:neovim/nvim-lspconfig/c646154d6e4db9b2979eeb517d0b817ad00c9c47' (2024-11-22)
• Updated input 'resty-vim':
    'github:lima1909/resty.nvim/d7d22f26e82b357c274754ed0a10593d00b7ce00' (2024-11-14)
  → 'github:lima1909/resty.nvim/79973eb9f8c1ec96f83296f757bcb6f94f2938f3' (2024-11-22)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/8ece53be36515cb9e76f3d03511643636469502d' (2024-11-12)
  → 'github:mrcjkb/rustaceanvim/6e742b9fc6a37e46181879f6c32cecfa8cd2cebf' (2024-11-18)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/c1b3c1188de859d12a610a1c46d03558cc763634' (2024-11-09)
  → 'github:nvim-neorocks/neorocks/b82f112cb43020ab23a2816dfc7a3453aafd754f' (2024-11-15)
• Updated input 'rustacean-nvim/neorocks/git-hooks':
    'github:cachix/git-hooks.nix/d70155fdc00df4628446352fc58adc640cd705c2' (2024-11-05)
  → 'github:cachix/git-hooks.nix/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0' (2024-11-11)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/702364e6ec794961483eba5220ca531917d03784' (2024-11-09)
  → 'github:nix-community/neovim-nightly-overlay/81a983160c1acae623482e082a94a46c931d0261' (2024-11-15)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks':
    'github:cachix/git-hooks.nix/d70155fdc00df4628446352fc58adc640cd705c2' (2024-11-05)
  → 'github:cachix/git-hooks.nix/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0' (2024-11-11)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/ad3472e291694b6c589d8a664459b03962eaac95' (2024-11-08)
  → 'github:neovim/neovim/05d354e2165c2c331a33949d49095eef3503a32f' (2024-11-14)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/85f7e662eda4fa3a995556527c87b2524b691933' (2024-11-07)
  → 'github:NixOS/nixpkgs/24f0d4acd634792badd6470134c387a3b039dace' (2024-11-13)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/85f7e662eda4fa3a995556527c87b2524b691933' (2024-11-07)
  → 'github:nixos/nixpkgs/24f0d4acd634792badd6470134c387a3b039dace' (2024-11-13)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/85f7e662eda4fa3a995556527c87b2524b691933' (2024-11-07)
  → 'github:nixos/nixpkgs/c69a9bffbecde46b4b939465422ddc59493d3e4d' (2024-11-16)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/d70155fdc00df4628446352fc58adc640cd705c2' (2024-11-05)
  → 'github:cachix/pre-commit-hooks.nix/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0' (2024-11-11)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/19d257cf889f79f4022163c3fbb5e08639077bd8' (2024-10-11)
  → 'github:nvim-tree/nvim-web-devicons/f09be61d05bebcba85bb47be1931322d51b95644' (2024-11-21)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`702364e6` ➡️ `81a98316`](https://github.com/nix-community/neovim-nightly-overlay/compare/702364e6ec794961483eba5220ca531917d03784...81a983160c1acae623482e082a94a46c931d0261) <sub>(2024-11-09 to 2024-11-15)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`8ece53be` ➡️ `6e742b9f`](https://github.com/mrcjkb/rustaceanvim/compare/8ece53be36515cb9e76f3d03511643636469502d...6e742b9fc6a37e46181879f6c32cecfa8cd2cebf) <sub>(2024-11-12 to 2024-11-18)</sub>
 - Updated input [`resty-vim`](https://github.com/lima1909/resty.nvim): [`d7d22f26` ➡️ `79973eb9`](https://github.com/lima1909/resty.nvim/compare/d7d22f26e82b357c274754ed0a10593d00b7ce00...79973eb9f8c1ec96f83296f757bcb6f94f2938f3) <sub>(2024-11-14 to 2024-11-22)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`85f7e662` ➡️ `24f0d4ac`](https://github.com/nixos/nixpkgs/compare/85f7e662eda4fa3a995556527c87b2524b691933...24f0d4acd634792badd6470134c387a3b039dace) <sub>(2024-11-07 to 2024-11-13)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`c1b3c118` ➡️ `b82f112c`](https://github.com/nvim-neorocks/neorocks/compare/c1b3c1188de859d12a610a1c46d03558cc763634...b82f112cb43020ab23a2816dfc7a3453aafd754f) <sub>(2024-11-09 to 2024-11-15)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`d4877e54` ➡️ `320b18fb`](https://github.com/tpope/vim-fugitive/compare/d4877e54cef67f5af4f950935b1ade19ed6b7370...320b18fba2a4f2fe3c8225c778c687e0d2620384) <sub>(2024-09-07 to 2024-11-19)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [`ad3472e2` ➡️ `05d354e2`](https://github.com/neovim/neovim/compare/ad3472e291694b6c589d8a664459b03962eaac95...05d354e2165c2c331a33949d49095eef3503a32f) <sub>(2024-11-08 to 2024-11-14)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`81a98316` ➡️ `10e11c32`](https://github.com/nix-community/neovim-nightly-overlay/compare/81a983160c1acae623482e082a94a46c931d0261...10e11c32a4f4f7c9d64f45413642ded11fc538b6) <sub>(2024-11-15 to 2024-11-22)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`659c4479` ➡️ `0f7bbce4`](https://github.com/L3MON4D3/LuaSnip/compare/659c4479529a05cc9b05ef762639a09d366cc690...0f7bbce41ea152a94d12aea286f2ce98e63c0f58) <sub>(2024-11-12 to 2024-11-18)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`87c7c83c` ➡️ `c646154d`](https://github.com/neovim/nvim-lspconfig/compare/87c7c83ce62971e0bdb29bb32b8ad2b19c8f95d0...c646154d6e4db9b2979eeb517d0b817ad00c9c47) <sub>(2024-11-15 to 2024-11-22)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`f17d9b43` ➡️ `be7bd4c5`](https://github.com/hrsh7th/nvim-cmp/compare/f17d9b4394027ff4442b298398dfcaab97e40c4f...be7bd4c5f860c79da97af3a26d489af50babfd4b) <sub>(2024-11-02 to 2024-11-21)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`d70155fd` ➡️ `cd1af27a`](https://github.com/cachix/pre-commit-hooks.nix/compare/d70155fdc00df4628446352fc58adc640cd705c2...cd1af27aa85026ac759d5d3fccf650abe7e1bbf0) <sub>(2024-11-05 to 2024-11-11)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`85f7e662` ➡️ `c69a9bff`](https://github.com/nixos/nixpkgs/compare/85f7e662eda4fa3a995556527c87b2524b691933...c69a9bffbecde46b4b939465422ddc59493d3e4d) <sub>(2024-11-07 to 2024-11-16)</sub>
 - Updated input [`rustacean-nvim/neorocks/git-hooks`](https://github.com/cachix/git-hooks.nix): [`d70155fd` ➡️ `cd1af27a`](https://github.com/cachix/git-hooks.nix/compare/d70155fdc00df4628446352fc58adc640cd705c2...cd1af27aa85026ac759d5d3fccf650abe7e1bbf0) <sub>(2024-11-05 to 2024-11-11)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`24f0d4ac` ➡️ `5083ec88`](https://github.com/nixos/nixpkgs/compare/24f0d4acd634792badd6470134c387a3b039dace...5083ec887760adfe12af64830a66807423a859a7) <sub>(2024-11-13 to 2024-11-18)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`cd1af27a` ➡️ `3308484d`](https://github.com/cachix/git-hooks.nix/compare/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0...3308484d1a443fc5bc92012435d79e80458fe43c) <sub>(2024-11-11 to 2024-11-19)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`85f7e662` ➡️ `24f0d4ac`](https://github.com/NixOS/nixpkgs/compare/85f7e662eda4fa3a995556527c87b2524b691933...24f0d4acd634792badd6470134c387a3b039dace) <sub>(2024-11-07 to 2024-11-13)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`19d257cf` ➡️ `f09be61d`](https://github.com/nvim-tree/nvim-web-devicons/compare/19d257cf889f79f4022163c3fbb5e08639077bd8...f09be61d05bebcba85bb47be1931322d51b95644) <sub>(2024-10-11 to 2024-11-21)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks`](https://github.com/cachix/git-hooks.nix): [`d70155fd` ➡️ `cd1af27a`](https://github.com/cachix/git-hooks.nix/compare/d70155fdc00df4628446352fc58adc640cd705c2...cd1af27aa85026ac759d5d3fccf650abe7e1bbf0) <sub>(2024-11-05 to 2024-11-11)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`1d0862ee` ➡️ `8cf9cb2e`](https://github.com/nix-community/home-manager/compare/1d0862ee2d7c6f6cd720d6f32213fa425004be10...8cf9cb2ee78aa129e5b8220135a511a2be254c0c) <sub>(2024-11-14 to 2024-11-22)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`05d354e2` ➡️ `ff75f345`](https://github.com/neovim/neovim/compare/05d354e2165c2c331a33949d49095eef3503a32f...ff75f345ab5fa57c6560db021e8eb099aff90472) <sub>(2024-11-14 to 2024-11-21)</sub>