### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
     "flake-compat_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1732722421,
+        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
     "flake-compat_6": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1732722421,
+        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730504689,
-        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -521,11 +521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732021966,
-        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
+        "lastModified": 1733318908,
+        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
+        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
         "type": "github"
       },
       "original": {
@@ -567,11 +567,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1731363552,
-        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
+        "lastModified": 1732021966,
+        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
         "type": "github"
       },
       "original": {
@@ -598,11 +598,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731363552,
-        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
+        "lastModified": 1732021966,
+        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
         "type": "github"
       },
       "original": {
@@ -777,11 +777,11 @@
     "gitsigns-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1731605154,
-        "narHash": "sha256-8vWilpsVw22+nAEAjhGOvZniRRj5r1UITcW9YeuDH8o=",
+        "lastModified": 1732361574,
+        "narHash": "sha256-H7A+AxioiedSuC+jqRwP4c7DjZR/0j4o/fTUasT2urc=",
         "owner": "lewis6991",
         "repo": "gitsigns.nvim",
-        "rev": "ac5aba6dce8c06ea22bea2c9016f51a2dbf90dc7",
+        "rev": "5f808b5e4fef30bd8aca1b803b4e555da07fc412",
         "type": "github"
       },
       "original": {
@@ -799,11 +799,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730903510,
-        "narHash": "sha256-mnynlrPeiW0nUQ8KGZHb3WyxAxA3Ye/BH8gMjdoKP6E=",
+        "lastModified": 1733333617,
+        "narHash": "sha256-nMMQXREGvLOLvUa0ByhYFdaL0Jov0t1wzLbKjr05P2w=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "b89ac4d66d618b915b1f0a408e2775fe3821d141",
+        "rev": "56f8ea8d502c87cf62444bec4ee04512e8ea24ea",
         "type": "github"
       },
       "original": {
@@ -843,11 +843,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732303962,
-        "narHash": "sha256-5Umjb5AdtxV5jSJd5jxoCckh5mlg+FBQDsyAilu637g=",
+        "lastModified": 1733484277,
+        "narHash": "sha256-i5ay20XsvpW91N4URET/nOc0VQWOAd4c4vbqYtcH8Rc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8cf9cb2ee78aa129e5b8220135a511a2be254c0c",
+        "rev": "d00c6f6d0ad16d598bf7e2956f52c1d9d5de3c3a",
         "type": "github"
       },
       "original": {
@@ -859,11 +859,11 @@
     "hop-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1729186441,
-        "narHash": "sha256-lvNKCzuje6lO8IRc4flKO2ePOpuGlsdNP6yfPiprvh4=",
+        "lastModified": 1733390754,
+        "narHash": "sha256-gqgH3boyxX509NadCSvkvgLnF2RSHsRUvXNlgjqIQug=",
         "owner": "smoka7",
         "repo": "hop.nvim",
-        "rev": "08ddca799089ab96a6d1763db0b8adc5320bf050",
+        "rev": "efe58182f71fbe592f82fb211ab026f2819e855d",
         "type": "github"
       },
       "original": {
@@ -877,11 +877,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1730743354,
-        "narHash": "sha256-gU4NySYyXeAzVaF5bI6BKmj2CdgiwGFnuPjXUId3Dx0=",
+        "lastModified": 1733056338,
+        "narHash": "sha256-sp14z0mrqrtmouz1+bU4Jh8/0xi+xwQHF2l7mhGSSVU=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "792f6b83dc719214e0e2a0b380c34f147b28ece2",
+        "rev": "d7c55140f1785b8d9fef351f1cd2a4c9e1eaa466",
         "type": "github"
       },
       "original": {
@@ -942,11 +942,11 @@
     "lspkind-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1729872608,
-        "narHash": "sha256-/ifgjqqCQw67l3+gUs00tt860pa92M1WYdjdZ0lhxak=",
+        "lastModified": 1733408701,
+        "narHash": "sha256-OCvKUBGuzwy8OWOL1x3Z3fo+0+GyBMI9TX41xSveqvE=",
         "owner": "onsails",
         "repo": "lspkind.nvim",
-        "rev": "a700f1436d4a938b1a1a93c9962dc796afbaef4d",
+        "rev": "d79a1c3299ad0ef94e255d045bed9fa26025dab6",
         "type": "github"
       },
       "original": {
@@ -974,11 +974,11 @@
     "luasnip-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1731918376,
-        "narHash": "sha256-Yl95znL076u6cuSigMQpUOOBw9ZXfqy1a3JF0fL8+KI=",
+        "lastModified": 1733162004,
+        "narHash": "sha256-efDe3RXncnNVkj37AmIv8oj0DKurB50Dziao5FGTLP4=",
         "owner": "L3MON4D3",
         "repo": "LuaSnip",
-        "rev": "0f7bbce41ea152a94d12aea286f2ce98e63c0f58",
+        "rev": "33b06d72d220aa56a7ce80a0dd6f06c70cd82b9d",
         "type": "github"
       },
       "original": {
@@ -1028,11 +1028,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1731648623,
-        "narHash": "sha256-kL0qF6ETmWSeN0Nzjg7GtSbe/7AcNmuX2U6Mb7xLIOA=",
+        "lastModified": 1732944430,
+        "narHash": "sha256-RxJyXmeLMxwlkkDynaHOy/rrYNuIK61R/nbzoUH2xlM=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "b82f112cb43020ab23a2816dfc7a3453aafd754f",
+        "rev": "f7fe2c43b5bf0c8840963d96dda1fe65e963ade8",
         "type": "github"
       },
       "original": {
@@ -1051,11 +1051,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1731629313,
-        "narHash": "sha256-rCTdc6oHM4Ostt6IR66QiDrPQNjCsxC2r00GfU0bADU=",
+        "lastModified": 1732925246,
+        "narHash": "sha256-MjqyzOEa6s9OGO8SMh5C2kqo57+iSNsgDbzPBbpi4QU=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "81a983160c1acae623482e082a94a46c931d0261",
+        "rev": "7461a0b228bb48bb02af086f8b9ee9a83583120b",
         "type": "github"
       },
       "original": {
@@ -1076,11 +1076,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732234033,
-        "narHash": "sha256-94yZ7eJiLvW+UknI5RZBCV6OMHtoSv1oWyOwKjTmS88=",
+        "lastModified": 1733467025,
+        "narHash": "sha256-JEYJs0VuT+1opPNEXM5Fttk5axtbz40/FKbKIzKvu6Q=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "10e11c32a4f4f7c9d64f45413642ded11fc538b6",
+        "rev": "1dc88a9c89328a398b026568095839463aea2343",
         "type": "github"
       },
       "original": {
@@ -1092,11 +1092,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1732229552,
-        "narHash": "sha256-7tA7IeOjx1wgDQnY7RxIhIuwcFeSZu4Yc3WtLh+22TE=",
+        "lastModified": 1733440964,
+        "narHash": "sha256-HBpTQrhP4DzPXl0M39i3tDbCTNdMyWXRRNPMcfuPGlw=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "ff75f345ab5fa57c6560db021e8eb099aff90472",
+        "rev": "bf5c1346c52f801636d55b9077d26231409e4d76",
         "type": "github"
       },
       "original": {
@@ -1108,11 +1108,11 @@
     "neovim-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1731607016,
-        "narHash": "sha256-EjIQ7ok02IfDHDMKdKELuvFRHlZhzhymDGGx3jg6nvQ=",
+        "lastModified": 1732903628,
+        "narHash": "sha256-JF8zmoLdqmbKCSS5Smf/Yj0jEl5f+qKhSubhPo/BvUM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "05d354e2165c2c331a33949d49095eef3503a32f",
+        "rev": "2833925cfc688786759d6a980a1ad62b62d20570",
         "type": "github"
       },
       "original": {
@@ -1283,11 +1283,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1731890469,
-        "narHash": "sha256-D1FNZ70NmQEwNxpSSdTXCSklBH1z2isPR84J6DQrJGs=",
+        "lastModified": 1733229606,
+        "narHash": "sha256-FLYY5M0rpa5C2QAE3CKLYAM6TwbKicdRK6qNrSHlNrE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5083ec887760adfe12af64830a66807423a859a7",
+        "rev": "566e53c2ad750c84f6d31f9ccb9d00f823165550",
         "type": "github"
       },
       "original": {
@@ -1347,11 +1347,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1731531548,
-        "narHash": "sha256-sz8/v17enkYmfpgeeuyzniGJU0QQBfmAjlemAUYhfy8=",
+        "lastModified": 1732617236,
+        "narHash": "sha256-PYkz6U0bSEaEB1al7O1XsqVNeSNS+s3NVclJw7YC43w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "24f0d4acd634792badd6470134c387a3b039dace",
+        "rev": "af51545ec9a44eadf3fe3547610a5cdd882bc34e",
         "type": "github"
       },
       "original": {
@@ -1363,11 +1363,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1731531548,
-        "narHash": "sha256-sz8/v17enkYmfpgeeuyzniGJU0QQBfmAjlemAUYhfy8=",
+        "lastModified": 1732780316,
+        "narHash": "sha256-NskLIz0ue4Uqbza+1+8UGHuPVr8DrUiLfZu5VS4VQxw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "24f0d4acd634792badd6470134c387a3b039dace",
+        "rev": "226216574ada4c3ecefcbbec41f39ce4655f78ef",
         "type": "github"
       },
       "original": {
@@ -1379,11 +1379,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1731763621,
-        "narHash": "sha256-ddcX4lQL0X05AYkrkV2LMFgGdRvgap7Ho8kgon3iWZk=",
+        "lastModified": 1732937961,
+        "narHash": "sha256-B5pYT+IVaqcrfOekkwKvx/iToDnuQWzc2oyDxzzBDc4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c69a9bffbecde46b4b939465422ddc59493d3e4d",
+        "rev": "4703b8d2c708e13a8cab03d865f90973536dcdf5",
         "type": "github"
       },
       "original": {
@@ -1412,11 +1412,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1732179089,
-        "narHash": "sha256-1vVqYltWM67yAzDmoqovFRhvuWit0MoSSnqd6PwVolk=",
+        "lastModified": 1732948484,
+        "narHash": "sha256-+0nflL0WCaxPuJgUviELhbXASNYYl/SKZ+nz70sEAXU=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "be7bd4c5f860c79da97af3a26d489af50babfd4b",
+        "rev": "ca4d3330d386e76967e53b85953c170658255ecb",
         "type": "github"
       },
       "original": {
@@ -1428,11 +1428,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1732268459,
-        "narHash": "sha256-6KGLT//JZrj/9fz21ZykGTQaSs+qawZxLcwx2rUx9ao=",
+        "lastModified": 1733483979,
+        "narHash": "sha256-d6ZDRmEiURBGpkyeSPNzV1JXbT3kv1GV4b3teofEtIQ=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "c646154d6e4db9b2979eeb517d0b817ad00c9c47",
+        "rev": "64073cbed0ce23e988160bfd1a148a75b6af94cc",
         "type": "github"
       },
       "original": {
@@ -1487,11 +1487,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1731363552,
-        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
+        "lastModified": 1732021966,
+        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
         "type": "github"
       },
       "original": {
@@ -1503,11 +1503,11 @@
     "resty-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1732280155,
-        "narHash": "sha256-oKZpq0V0p2vHEWrf+yAGQa0bXIphr9Y5fXzB2xLcT0M=",
+        "lastModified": 1732807282,
+        "narHash": "sha256-Zxvc/KS1UADbC4l0n3dq6NUYxfrY/xxXLmM8XgjOUF0=",
         "owner": "lima1909",
         "repo": "resty.nvim",
-        "rev": "79973eb9f8c1ec96f83296f757bcb6f94f2938f3",
+        "rev": "a3a105cff1f77a26d7fa33ff5f64a29f57452f8e",
         "type": "github"
       },
       "original": {
@@ -1584,11 +1584,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1731964536,
-        "narHash": "sha256-QgvFKV9QdfQ8Lh3EhXbwFcOQXTvaBE88EtbmJdJS9gk=",
+        "lastModified": 1733312834,
+        "narHash": "sha256-AIWHuxGX8GMz7jhzb4eHMeb5qd9t/YAmWLnnMNO+npc=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "6e742b9fc6a37e46181879f6c32cecfa8cd2cebf",
+        "rev": "bf3d8c7bcbf20a7e7f4af36c2d5390ca6ad43281",
         "type": "github"
       },
       "original": {
@@ -1677,11 +1677,11 @@
     "telescope-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1730164948,
-        "narHash": "sha256-Qa/f+0asQvA8mhIUajC4BGZCI92OqA6ySVoQSC3ZY3s=",
+        "lastModified": 1732884846,
+        "narHash": "sha256-npb61MZYAotz71Co5G1dUeIqWt7GVeqZNz0A2Yz2dy4=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "85922dde3767e01d42a08e750a773effbffaea3e",
+        "rev": "2eca9ba22002184ac05eddbe47a7fe2d5a384dfc",
         "type": "github"
       },
       "original": {
@@ -1729,11 +1729,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1732225809,
-        "narHash": "sha256-PvQ6Q4+08uf4gVH5tsVRB+7AuDSubDUUbPiUDyNAbzc=",
+        "lastModified": 1732925137,
+        "narHash": "sha256-Sh+r54pTI60j5tOmSyEkTVS6MzMIt52nqjNdtMp8kpI=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "f09be61d05bebcba85bb47be1931322d51b95644",
+        "rev": "203da76ecfbb4b192cf830665b03eb651b635c94",
         "type": "github"
       },
       "original": {

--- a/home/common/default.nix
+++ b/home/common/default.nix
@@ -22,7 +22,7 @@
     pkgs.procs
     # fonts
     pkgs.fontconfig
-    (pkgs.nerdfonts.override { fonts = [ "UbuntuMono" "ZedMono" ]; })
+    pkgs.nerd-fonts.zed-mono
   ];
 
   programs.direnv = {

--- a/system/nixos/hosts/nixos/home.nix
+++ b/system/nixos/hosts/nixos/home.nix
@@ -19,7 +19,7 @@
     alacritty = {
       enable = true;
       font_size = 12.0;
-      font_normal = "Zed Mono Nerd Font";
+      font_normal = "ZedMono Nerd Font";
     };
     osh.enable = true;
     zen.enable = true;


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'gitsigns-nvim':
    'github:lewis6991/gitsigns.nvim/ac5aba6dce8c06ea22bea2c9016f51a2dbf90dc7' (2024-11-14)
  → 'github:lewis6991/gitsigns.nvim/5f808b5e4fef30bd8aca1b803b4e555da07fc412' (2024-11-23)
• Updated input 'home-manager':
    'github:nix-community/home-manager/8cf9cb2ee78aa129e5b8220135a511a2be254c0c' (2024-11-22)
  → 'github:nix-community/home-manager/d00c6f6d0ad16d598bf7e2956f52c1d9d5de3c3a' (2024-12-06)
• Updated input 'hop-nvim':
    'github:smoka7/hop.nvim/08ddca799089ab96a6d1763db0b8adc5320bf050' (2024-10-17)
  → 'github:smoka7/hop.nvim/efe58182f71fbe592f82fb211ab026f2819e855d' (2024-12-05)
• Updated input 'hypr-contrib':
    'github:hyprwm/contrib/792f6b83dc719214e0e2a0b380c34f147b28ece2' (2024-11-04)
  → 'github:hyprwm/contrib/d7c55140f1785b8d9fef351f1cd2a4c9e1eaa466' (2024-12-01)
• Updated input 'lspkind-nvim':
    'github:onsails/lspkind.nvim/a700f1436d4a938b1a1a93c9962dc796afbaef4d' (2024-10-25)
  → 'github:onsails/lspkind.nvim/d79a1c3299ad0ef94e255d045bed9fa26025dab6' (2024-12-05)
• Updated input 'luasnip-nvim':
    'github:L3MON4D3/LuaSnip/0f7bbce41ea152a94d12aea286f2ce98e63c0f58' (2024-11-18)
  → 'github:L3MON4D3/LuaSnip/33b06d72d220aa56a7ce80a0dd6f06c70cd82b9d' (2024-12-02)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/10e11c32a4f4f7c9d64f45413642ded11fc538b6' (2024-11-22)
  → 'github:nix-community/neovim-nightly-overlay/1dc88a9c89328a398b026568095839463aea2343' (2024-12-06)
• Updated input 'neovim-nightly-overlay/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
  → 'github:edolstra/flake-compat/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec' (2024-12-04)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/506278e768c2a08bec68eb62932193e341f55c90' (2024-11-01)
  → 'github:hercules-ci/flake-parts/205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9' (2024-12-04)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/3308484d1a443fc5bc92012435d79e80458fe43c' (2024-11-19)
  → 'github:cachix/git-hooks.nix/6f4e2a2112050951a314d2733a994fbab94864c6' (2024-12-04)
• Updated input 'neovim-nightly-overlay/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/b89ac4d66d618b915b1f0a408e2775fe3821d141' (2024-11-06)
  → 'github:hercules-ci/hercules-ci-effects/56f8ea8d502c87cf62444bec4ee04512e8ea24ea' (2024-12-04)
• Updated input 'neovim-nightly-overlay/hercules-ci-effects/flake-parts':
    'github:hercules-ci/flake-parts/9126214d0a59633752a136528f5f3b9aa8565b7d' (2024-04-01)
  → 'github:hercules-ci/flake-parts/205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9' (2024-12-04)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/ff75f345ab5fa57c6560db021e8eb099aff90472' (2024-11-21)
  → 'github:neovim/neovim/bf5c1346c52f801636d55b9077d26231409e4d76' (2024-12-05)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5083ec887760adfe12af64830a66807423a859a7' (2024-11-18)
  → 'github:nixos/nixpkgs/566e53c2ad750c84f6d31f9ccb9d00f823165550' (2024-12-03)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/be7bd4c5f860c79da97af3a26d489af50babfd4b' (2024-11-21)
  → 'github:hrsh7th/nvim-cmp/ca4d3330d386e76967e53b85953c170658255ecb' (2024-11-30)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/c646154d6e4db9b2979eeb517d0b817ad00c9c47' (2024-11-22)
  → 'github:neovim/nvim-lspconfig/64073cbed0ce23e988160bfd1a148a75b6af94cc' (2024-12-06)
• Updated input 'resty-vim':
    'github:lima1909/resty.nvim/79973eb9f8c1ec96f83296f757bcb6f94f2938f3' (2024-11-22)
  → 'github:lima1909/resty.nvim/a3a105cff1f77a26d7fa33ff5f64a29f57452f8e' (2024-11-28)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/6e742b9fc6a37e46181879f6c32cecfa8cd2cebf' (2024-11-18)
  → 'github:mrcjkb/rustaceanvim/bf3d8c7bcbf20a7e7f4af36c2d5390ca6ad43281' (2024-12-04)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/b82f112cb43020ab23a2816dfc7a3453aafd754f' (2024-11-15)
  → 'github:nvim-neorocks/neorocks/f7fe2c43b5bf0c8840963d96dda1fe65e963ade8' (2024-11-30)
• Updated input 'rustacean-nvim/neorocks/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
  → 'github:edolstra/flake-compat/9ed2ac151eada2306ca8c418ebd97807bb08f6ac' (2024-11-27)
• Updated input 'rustacean-nvim/neorocks/git-hooks':
    'github:cachix/git-hooks.nix/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0' (2024-11-11)
  → 'github:cachix/git-hooks.nix/3308484d1a443fc5bc92012435d79e80458fe43c' (2024-11-19)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/81a983160c1acae623482e082a94a46c931d0261' (2024-11-15)
  → 'github:nix-community/neovim-nightly-overlay/7461a0b228bb48bb02af086f8b9ee9a83583120b' (2024-11-30)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/flake-compat':
    'github:edolstra/flake-compat/0f9255e01c2351cc7d116c072cb317785dd33b33' (2023-10-04)
  → 'github:edolstra/flake-compat/9ed2ac151eada2306ca8c418ebd97807bb08f6ac' (2024-11-27)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks':
    'github:cachix/git-hooks.nix/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0' (2024-11-11)
  → 'github:cachix/git-hooks.nix/3308484d1a443fc5bc92012435d79e80458fe43c' (2024-11-19)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/05d354e2165c2c331a33949d49095eef3503a32f' (2024-11-14)
  → 'github:neovim/neovim/2833925cfc688786759d6a980a1ad62b62d20570' (2024-11-29)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/24f0d4acd634792badd6470134c387a3b039dace' (2024-11-13)
  → 'github:NixOS/nixpkgs/af51545ec9a44eadf3fe3547610a5cdd882bc34e' (2024-11-26)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/24f0d4acd634792badd6470134c387a3b039dace' (2024-11-13)
  → 'github:nixos/nixpkgs/226216574ada4c3ecefcbbec41f39ce4655f78ef' (2024-11-28)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/c69a9bffbecde46b4b939465422ddc59493d3e4d' (2024-11-16)
  → 'github:nixos/nixpkgs/4703b8d2c708e13a8cab03d865f90973536dcdf5' (2024-11-30)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0' (2024-11-11)
  → 'github:cachix/pre-commit-hooks.nix/3308484d1a443fc5bc92012435d79e80458fe43c' (2024-11-19)
• Updated input 'telescope-nvim':
    'github:nvim-telescope/telescope.nvim/85922dde3767e01d42a08e750a773effbffaea3e' (2024-10-29)
  → 'github:nvim-telescope/telescope.nvim/2eca9ba22002184ac05eddbe47a7fe2d5a384dfc' (2024-11-29)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/f09be61d05bebcba85bb47be1931322d51b95644' (2024-11-21)
  → 'github:nvim-tree/nvim-web-devicons/203da76ecfbb4b192cf830665b03eb651b635c94' (2024-11-30)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`81a98316` ➡️ `7461a0b2`](https://github.com/nix-community/neovim-nightly-overlay/compare/81a983160c1acae623482e082a94a46c931d0261...7461a0b228bb48bb02af086f8b9ee9a83583120b) <sub>(2024-11-15 to 2024-11-30)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`6e742b9f` ➡️ `bf3d8c7b`](https://github.com/mrcjkb/rustaceanvim/compare/6e742b9fc6a37e46181879f6c32cecfa8cd2cebf...bf3d8c7bcbf20a7e7f4af36c2d5390ca6ad43281) <sub>(2024-11-18 to 2024-12-04)</sub>
 - Updated input [`resty-vim`](https://github.com/lima1909/resty.nvim): [`79973eb9` ➡️ `a3a105cf`](https://github.com/lima1909/resty.nvim/compare/79973eb9f8c1ec96f83296f757bcb6f94f2938f3...a3a105cff1f77a26d7fa33ff5f64a29f57452f8e) <sub>(2024-11-22 to 2024-11-28)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`24f0d4ac` ➡️ `22621657`](https://github.com/nixos/nixpkgs/compare/24f0d4acd634792badd6470134c387a3b039dace...226216574ada4c3ecefcbbec41f39ce4655f78ef) <sub>(2024-11-13 to 2024-11-28)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`b82f112c` ➡️ `f7fe2c43`](https://github.com/nvim-neorocks/neorocks/compare/b82f112cb43020ab23a2816dfc7a3453aafd754f...f7fe2c43b5bf0c8840963d96dda1fe65e963ade8) <sub>(2024-11-15 to 2024-11-30)</sub>
 - Updated input [`neovim-nightly-overlay/hercules-ci-effects/flake-parts`](https://github.com/hercules-ci/flake-parts): [`9126214d` ➡️ `205b12d8`](https://github.com/hercules-ci/flake-parts/compare/9126214d0a59633752a136528f5f3b9aa8565b7d...205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9) <sub>(2024-04-01 to 2024-12-04)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [`05d354e2` ➡️ `2833925c`](https://github.com/neovim/neovim/compare/05d354e2165c2c331a33949d49095eef3503a32f...2833925cfc688786759d6a980a1ad62b62d20570) <sub>(2024-11-14 to 2024-11-29)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/flake-compat`](https://github.com/edolstra/flake-compat): [`0f9255e0` ➡️ `9ed2ac15`](https://github.com/edolstra/flake-compat/compare/0f9255e01c2351cc7d116c072cb317785dd33b33...9ed2ac151eada2306ca8c418ebd97807bb08f6ac) <sub>(2023-10-04 to 2024-11-27)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`10e11c32` ➡️ `1dc88a9c`](https://github.com/nix-community/neovim-nightly-overlay/compare/10e11c32a4f4f7c9d64f45413642ded11fc538b6...1dc88a9c89328a398b026568095839463aea2343) <sub>(2024-11-22 to 2024-12-06)</sub>
 - Updated input [`luasnip-nvim`](https://github.com/L3MON4D3/LuaSnip): [`0f7bbce4` ➡️ `33b06d72`](https://github.com/L3MON4D3/LuaSnip/compare/0f7bbce41ea152a94d12aea286f2ce98e63c0f58...33b06d72d220aa56a7ce80a0dd6f06c70cd82b9d) <sub>(2024-11-18 to 2024-12-02)</sub>
 - Updated input [`hypr-contrib`](https://github.com/hyprwm/contrib): [`792f6b83` ➡️ `d7c55140`](https://github.com/hyprwm/contrib/compare/792f6b83dc719214e0e2a0b380c34f147b28ece2...d7c55140f1785b8d9fef351f1cd2a4c9e1eaa466) <sub>(2024-11-04 to 2024-12-01)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`c646154d` ➡️ `64073cbe`](https://github.com/neovim/nvim-lspconfig/compare/c646154d6e4db9b2979eeb517d0b817ad00c9c47...64073cbed0ce23e988160bfd1a148a75b6af94cc) <sub>(2024-11-22 to 2024-12-06)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`be7bd4c5` ➡️ `ca4d3330`](https://github.com/hrsh7th/nvim-cmp/compare/be7bd4c5f860c79da97af3a26d489af50babfd4b...ca4d3330d386e76967e53b85953c170658255ecb) <sub>(2024-11-21 to 2024-11-30)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`cd1af27a` ➡️ `3308484d`](https://github.com/cachix/pre-commit-hooks.nix/compare/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0...3308484d1a443fc5bc92012435d79e80458fe43c) <sub>(2024-11-11 to 2024-11-19)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`c69a9bff` ➡️ `4703b8d2`](https://github.com/nixos/nixpkgs/compare/c69a9bffbecde46b4b939465422ddc59493d3e4d...4703b8d2c708e13a8cab03d865f90973536dcdf5) <sub>(2024-11-16 to 2024-11-30)</sub>
 - Updated input [`neovim-nightly-overlay/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`b89ac4d6` ➡️ `56f8ea8d`](https://github.com/hercules-ci/hercules-ci-effects/compare/b89ac4d66d618b915b1f0a408e2775fe3821d141...56f8ea8d502c87cf62444bec4ee04512e8ea24ea) <sub>(2024-11-06 to 2024-12-04)</sub>
 - Updated input [`rustacean-nvim/neorocks/git-hooks`](https://github.com/cachix/git-hooks.nix): [`cd1af27a` ➡️ `3308484d`](https://github.com/cachix/git-hooks.nix/compare/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0...3308484d1a443fc5bc92012435d79e80458fe43c) <sub>(2024-11-11 to 2024-11-19)</sub>
 - Updated input [`lspkind-nvim`](https://github.com/onsails/lspkind.nvim): [`a700f143` ➡️ `d79a1c32`](https://github.com/onsails/lspkind.nvim/compare/a700f1436d4a938b1a1a93c9962dc796afbaef4d...d79a1c3299ad0ef94e255d045bed9fa26025dab6) <sub>(2024-10-25 to 2024-12-05)</sub>
 - Updated input [`gitsigns-nvim`](https://github.com/lewis6991/gitsigns.nvim): [`ac5aba6d` ➡️ `5f808b5e`](https://github.com/lewis6991/gitsigns.nvim/compare/ac5aba6dce8c06ea22bea2c9016f51a2dbf90dc7...5f808b5e4fef30bd8aca1b803b4e555da07fc412) <sub>(2024-11-14 to 2024-11-23)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`5083ec88` ➡️ `566e53c2`](https://github.com/nixos/nixpkgs/compare/5083ec887760adfe12af64830a66807423a859a7...566e53c2ad750c84f6d31f9ccb9d00f823165550) <sub>(2024-11-18 to 2024-12-03)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`3308484d` ➡️ `6f4e2a21`](https://github.com/cachix/git-hooks.nix/compare/3308484d1a443fc5bc92012435d79e80458fe43c...6f4e2a2112050951a314d2733a994fbab94864c6) <sub>(2024-11-19 to 2024-12-04)</sub>
 - Updated input [`telescope-nvim`](https://github.com/nvim-telescope/telescope.nvim): [`85922dde` ➡️ `2eca9ba2`](https://github.com/nvim-telescope/telescope.nvim/compare/85922dde3767e01d42a08e750a773effbffaea3e...2eca9ba22002184ac05eddbe47a7fe2d5a384dfc) <sub>(2024-10-29 to 2024-11-29)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`24f0d4ac` ➡️ `af51545e`](https://github.com/NixOS/nixpkgs/compare/24f0d4acd634792badd6470134c387a3b039dace...af51545ec9a44eadf3fe3547610a5cdd882bc34e) <sub>(2024-11-13 to 2024-11-26)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`f09be61d` ➡️ `203da76e`](https://github.com/nvim-tree/nvim-web-devicons/compare/f09be61d05bebcba85bb47be1931322d51b95644...203da76ecfbb4b192cf830665b03eb651b635c94) <sub>(2024-11-21 to 2024-11-30)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks`](https://github.com/cachix/git-hooks.nix): [`cd1af27a` ➡️ `3308484d`](https://github.com/cachix/git-hooks.nix/compare/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0...3308484d1a443fc5bc92012435d79e80458fe43c) <sub>(2024-11-11 to 2024-11-19)</sub>
 - Updated input [`hop-nvim`](https://github.com/smoka7/hop.nvim): [`08ddca79` ➡️ `efe58182`](https://github.com/smoka7/hop.nvim/compare/08ddca799089ab96a6d1763db0b8adc5320bf050...efe58182f71fbe592f82fb211ab026f2819e855d) <sub>(2024-10-17 to 2024-12-05)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`8cf9cb2e` ➡️ `d00c6f6d`](https://github.com/nix-community/home-manager/compare/8cf9cb2ee78aa129e5b8220135a511a2be254c0c...d00c6f6d0ad16d598bf7e2956f52c1d9d5de3c3a) <sub>(2024-11-22 to 2024-12-06)</sub>
 - Updated input [`rustacean-nvim/neorocks/flake-compat`](https://github.com/edolstra/flake-compat): [`0f9255e0` ➡️ `9ed2ac15`](https://github.com/edolstra/flake-compat/compare/0f9255e01c2351cc7d116c072cb317785dd33b33...9ed2ac151eada2306ca8c418ebd97807bb08f6ac) <sub>(2023-10-04 to 2024-11-27)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`ff75f345` ➡️ `bf5c1346`](https://github.com/neovim/neovim/compare/ff75f345ab5fa57c6560db021e8eb099aff90472...bf5c1346c52f801636d55b9077d26231409e4d76) <sub>(2024-11-21 to 2024-12-05)</sub>
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`506278e7` ➡️ `205b12d8`](https://github.com/hercules-ci/flake-parts/compare/506278e768c2a08bec68eb62932193e341f55c90...205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9) <sub>(2024-11-01 to 2024-12-04)</sub>
 - Updated input [`neovim-nightly-overlay/flake-compat`](https://github.com/edolstra/flake-compat): [`0f9255e0` ➡️ `ff81ac96`](https://github.com/edolstra/flake-compat/compare/0f9255e01c2351cc7d116c072cb317785dd33b33...ff81ac966bb2cae68946d5ed5fc4994f96d0ffec) <sub>(2023-10-04 to 2024-12-04)</sub>