### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "cmp-lsp-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1715931395,
-        "narHash": "sha256-CT1+Z4XJBVsl/RqvJeGmyitD6x7So0ylXvvef5jh7I8=",
+        "lastModified": 1733823748,
+        "narHash": "sha256-iaihXNCF5bB5MdeoosD/kc3QtpA/QaIDZVLiLIurBSM=",
         "owner": "hrsh7th",
         "repo": "cmp-nvim-lsp",
-        "rev": "39e2eda76828d88b773cc27a3f61d2ad782c922d",
+        "rev": "99290b3ec1322070bcfb9e846450a46f6efa50f0",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
     "flake-compat_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1732722421,
-        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
     "flake-compat_6": {
       "flake": false,
       "locked": {
-        "lastModified": 1732722421,
-        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -271,11 +271,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1730504689,
-        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -307,11 +307,11 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1730504689,
-        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -330,11 +330,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730504689,
-        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -354,11 +354,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -521,11 +521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733318908,
-        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
+        "lastModified": 1733665616,
+        "narHash": "sha256-+XTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd+lh2A=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
+        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
         "type": "github"
       },
       "original": {
@@ -567,11 +567,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1732021966,
-        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
+        "lastModified": 1733318908,
+        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
+        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
         "type": "github"
       },
       "original": {
@@ -598,11 +598,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732021966,
-        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
+        "lastModified": 1733318908,
+        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
+        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
         "type": "github"
       },
       "original": {
@@ -823,11 +823,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730903510,
-        "narHash": "sha256-mnynlrPeiW0nUQ8KGZHb3WyxAxA3Ye/BH8gMjdoKP6E=",
+        "lastModified": 1733333617,
+        "narHash": "sha256-nMMQXREGvLOLvUa0ByhYFdaL0Jov0t1wzLbKjr05P2w=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "b89ac4d66d618b915b1f0a408e2775fe3821d141",
+        "rev": "56f8ea8d502c87cf62444bec4ee04512e8ea24ea",
         "type": "github"
       },
       "original": {
@@ -843,11 +843,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733484277,
-        "narHash": "sha256-i5ay20XsvpW91N4URET/nOc0VQWOAd4c4vbqYtcH8Rc=",
+        "lastModified": 1734093295,
+        "narHash": "sha256-hSwgGpcZtdDsk1dnzA0xj5cNaHgN9A99hRF/mxMtwS4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d00c6f6d0ad16d598bf7e2956f52c1d9d5de3c3a",
+        "rev": "66c5d8b62818ec4c1edb3e941f55ef78df8141a8",
         "type": "github"
       },
       "original": {
@@ -1028,11 +1028,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1732944430,
-        "narHash": "sha256-RxJyXmeLMxwlkkDynaHOy/rrYNuIK61R/nbzoUH2xlM=",
+        "lastModified": 1733549590,
+        "narHash": "sha256-h/DM/lMd+MWrMa45ieEw0BzcIh+RXyWoVKCzOh3sKPc=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "f7fe2c43b5bf0c8840963d96dda1fe65e963ade8",
+        "rev": "48a4927d78cb67cbc56f112d713d3cfe1edc15c1",
         "type": "github"
       },
       "original": {
@@ -1051,11 +1051,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1732925246,
-        "narHash": "sha256-MjqyzOEa6s9OGO8SMh5C2kqo57+iSNsgDbzPBbpi4QU=",
+        "lastModified": 1733530506,
+        "narHash": "sha256-x8slAzUe1gopASFNhnHO9DmWXvnF7u27YMSwTmIY8bU=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "7461a0b228bb48bb02af086f8b9ee9a83583120b",
+        "rev": "3930a71f90bacc656e8bdf19cc0faa9ebf10353a",
         "type": "github"
       },
       "original": {
@@ -1073,14 +1073,15 @@
         "neovim-src": "neovim-src",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1733467025,
-        "narHash": "sha256-JEYJs0VuT+1opPNEXM5Fttk5axtbz40/FKbKIzKvu6Q=",
+        "lastModified": 1734048484,
+        "narHash": "sha256-EtSEYNx19xzuEBJsT7yXG+nVx11CM3rvrAQAXcvG/5Q=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "1dc88a9c89328a398b026568095839463aea2343",
+        "rev": "044f9a36ad620a119ebe154c26ec571a09f75039",
         "type": "github"
       },
       "original": {
@@ -1092,11 +1093,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1733440964,
-        "narHash": "sha256-HBpTQrhP4DzPXl0M39i3tDbCTNdMyWXRRNPMcfuPGlw=",
+        "lastModified": 1734000357,
+        "narHash": "sha256-8FO5Ca9bLEiD649b5gkQCdjpTmbPenJHpN0JBhtLpjE=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "bf5c1346c52f801636d55b9077d26231409e4d76",
+        "rev": "17383870dd3b7f04eddd48ed929cc25c7e102277",
         "type": "github"
       },
       "original": {
@@ -1108,11 +1109,11 @@
     "neovim-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1732903628,
-        "narHash": "sha256-JF8zmoLdqmbKCSS5Smf/Yj0jEl5f+qKhSubhPo/BvUM=",
+        "lastModified": 1733517821,
+        "narHash": "sha256-QjFVx/zMyutuW1TWzOKEe5cY7YGqvPkRhi9wQHY52Yo=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "2833925cfc688786759d6a980a1ad62b62d20570",
+        "rev": "517ecb85f58ed6ac8b4d5443931612e75e7c7dc2",
         "type": "github"
       },
       "original": {
@@ -1155,14 +1156,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1730504152,
-        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
+        "lastModified": 1733096140,
+        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
       }
     },
     "nixpkgs-lib_2": {
@@ -1179,14 +1180,14 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1730504152,
-        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
+        "lastModified": 1733096140,
+        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
       }
     },
     "nixpkgs-lib_4": {
@@ -1283,11 +1284,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1733229606,
-        "narHash": "sha256-FLYY5M0rpa5C2QAE3CKLYAM6TwbKicdRK6qNrSHlNrE=",
+        "lastModified": 1733935885,
+        "narHash": "sha256-xyiHLs6KJ1fxeGmcCxKjJE4yJknVJxbC8Y/ZRYyC8WE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "566e53c2ad750c84f6d31f9ccb9d00f823165550",
+        "rev": "5a48e3c2e435e95103d56590188cfed7b70e108c",
         "type": "github"
       },
       "original": {
@@ -1347,11 +1348,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1732617236,
-        "narHash": "sha256-PYkz6U0bSEaEB1al7O1XsqVNeSNS+s3NVclJw7YC43w=",
+        "lastModified": 1733229606,
+        "narHash": "sha256-FLYY5M0rpa5C2QAE3CKLYAM6TwbKicdRK6qNrSHlNrE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "af51545ec9a44eadf3fe3547610a5cdd882bc34e",
+        "rev": "566e53c2ad750c84f6d31f9ccb9d00f823165550",
         "type": "github"
       },
       "original": {
@@ -1363,11 +1364,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1732780316,
-        "narHash": "sha256-NskLIz0ue4Uqbza+1+8UGHuPVr8DrUiLfZu5VS4VQxw=",
+        "lastModified": 1733229606,
+        "narHash": "sha256-FLYY5M0rpa5C2QAE3CKLYAM6TwbKicdRK6qNrSHlNrE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "226216574ada4c3ecefcbbec41f39ce4655f78ef",
+        "rev": "566e53c2ad750c84f6d31f9ccb9d00f823165550",
         "type": "github"
       },
       "original": {
@@ -1379,11 +1380,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1732937961,
-        "narHash": "sha256-B5pYT+IVaqcrfOekkwKvx/iToDnuQWzc2oyDxzzBDc4=",
+        "lastModified": 1733376361,
+        "narHash": "sha256-aLJxoTDDSqB+/3orsulE6/qdlX6MzDLIITLZqdgMpqo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4703b8d2c708e13a8cab03d865f90973536dcdf5",
+        "rev": "929116e316068c7318c54eb4d827f7d9756d5e9c",
         "type": "github"
       },
       "original": {
@@ -1412,11 +1413,11 @@
     "nvim-cmp": {
       "flake": false,
       "locked": {
-        "lastModified": 1732948484,
-        "narHash": "sha256-+0nflL0WCaxPuJgUviELhbXASNYYl/SKZ+nz70sEAXU=",
+        "lastModified": 1733799872,
+        "narHash": "sha256-Aht1m2V+yRvmrLoBC4QGYG/p/tmDbnZe1nT3V5k7S58=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "ca4d3330d386e76967e53b85953c170658255ecb",
+        "rev": "3403e2e9391ed0a28c3afddd8612701b647c8e26",
         "type": "github"
       },
       "original": {
@@ -1428,11 +1429,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1733483979,
-        "narHash": "sha256-d6ZDRmEiURBGpkyeSPNzV1JXbT3kv1GV4b3teofEtIQ=",
+        "lastModified": 1734118245,
+        "narHash": "sha256-Bs/3WqEAEpbv8GPGvUpn2jM9NojRVM7GnlTi9YungBQ=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "64073cbed0ce23e988160bfd1a148a75b6af94cc",
+        "rev": "4761665b4be82c46612cdfb4ea9c90de25875c4f",
         "type": "github"
       },
       "original": {
@@ -1487,11 +1488,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1732021966,
-        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
+        "lastModified": 1733318908,
+        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
+        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
         "type": "github"
       },
       "original": {
@@ -1503,11 +1504,11 @@
     "resty-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1732807282,
-        "narHash": "sha256-Zxvc/KS1UADbC4l0n3dq6NUYxfrY/xxXLmM8XgjOUF0=",
+        "lastModified": 1733945077,
+        "narHash": "sha256-fDmiPbxM7CxYWaYM++ieqoEIk5Edn6O9GIJKSeIj9GM=",
         "owner": "lima1909",
         "repo": "resty.nvim",
-        "rev": "a3a105cff1f77a26d7fa33ff5f64a29f57452f8e",
+        "rev": "3987bcc2da37bd28442ad94917cf91d604a35f9b",
         "type": "github"
       },
       "original": {
@@ -1584,11 +1585,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1733312834,
-        "narHash": "sha256-AIWHuxGX8GMz7jhzb4eHMeb5qd9t/YAmWLnnMNO+npc=",
+        "lastModified": 1733693806,
+        "narHash": "sha256-2t2fiqMlOWy48TXpqWbVJfwEQnT+G9BubOd7SVBQSWw=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "bf3d8c7bcbf20a7e7f4af36c2d5390ca6ad43281",
+        "rev": "a244210b28f9055c2b4cfa85c92c8a71c13671c9",
         "type": "github"
       },
       "original": {
@@ -1645,11 +1646,11 @@
     "telescope-fzf-native-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1719928246,
-        "narHash": "sha256-GEhPf1f0jkEuDlHNuxVko0ChvuF/zoQroLNUlk8N5EA=",
+        "lastModified": 1734022536,
+        "narHash": "sha256-ZBYZncCVtuks6tV4hhqWvQ3PlKElSHuWAEpo9o48pj4=",
         "owner": "nvim-telescope",
         "repo": "telescope-fzf-native.nvim",
-        "rev": "cf48d4dfce44e0b9a2e19a008d6ec6ea6f01a83b",
+        "rev": "dae2eac9d91464448b584c7949a31df8faefec56",
         "type": "github"
       },
       "original": {
@@ -1706,6 +1707,27 @@
         "type": "github"
       }
     },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "neovim-nightly-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733761991,
+        "narHash": "sha256-s4DalCDepD22jtKL5Nw6f4LP5UwoMcPzPZgHWjAfqbQ=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "0ce9d149d99bc383d1f2d85f31f6ebd146e46085",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
     "vimcats": {
       "inputs": {
         "flake-parts": "flake-parts_8",
@@ -1729,11 +1751,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1732925137,
-        "narHash": "sha256-Sh+r54pTI60j5tOmSyEkTVS6MzMIt52nqjNdtMp8kpI=",
+        "lastModified": 1734074368,
+        "narHash": "sha256-5FawlJPfi7dl/OMEzxhe9J2U6TXmdwKLy5XtM2sk/HM=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "203da76ecfbb4b192cf830665b03eb651b635c94",
+        "rev": "dd0c15170f9ab2ffac695d90212318c05078751d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'cmp-lsp-nvim':
    'github:hrsh7th/cmp-nvim-lsp/39e2eda76828d88b773cc27a3f61d2ad782c922d' (2024-05-17)
  → 'github:hrsh7th/cmp-nvim-lsp/99290b3ec1322070bcfb9e846450a46f6efa50f0' (2024-12-10)
• Updated input 'home-manager':
    'github:nix-community/home-manager/d00c6f6d0ad16d598bf7e2956f52c1d9d5de3c3a' (2024-12-06)
  → 'github:nix-community/home-manager/66c5d8b62818ec4c1edb3e941f55ef78df8141a8' (2024-12-13)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/1dc88a9c89328a398b026568095839463aea2343' (2024-12-06)
  → 'github:nix-community/neovim-nightly-overlay/044f9a36ad620a119ebe154c26ec571a09f75039' (2024-12-13)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/6f4e2a2112050951a314d2733a994fbab94864c6' (2024-12-04)
  → 'github:cachix/git-hooks.nix/d8c02f0ffef0ef39f6063731fc539d8c71eb463a' (2024-12-08)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/bf5c1346c52f801636d55b9077d26231409e4d76' (2024-12-05)
  → 'github:neovim/neovim/17383870dd3b7f04eddd48ed929cc25c7e102277' (2024-12-12)
• Added input 'neovim-nightly-overlay/treefmt-nix':
    'github:numtide/treefmt-nix/0ce9d149d99bc383d1f2d85f31f6ebd146e46085' (2024-12-09)
• Added input 'neovim-nightly-overlay/treefmt-nix/nixpkgs':
    follows 'neovim-nightly-overlay/nixpkgs'
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/566e53c2ad750c84f6d31f9ccb9d00f823165550' (2024-12-03)
  → 'github:nixos/nixpkgs/5a48e3c2e435e95103d56590188cfed7b70e108c' (2024-12-11)
• Updated input 'nvim-cmp':
    'github:hrsh7th/nvim-cmp/ca4d3330d386e76967e53b85953c170658255ecb' (2024-11-30)
  → 'github:hrsh7th/nvim-cmp/3403e2e9391ed0a28c3afddd8612701b647c8e26' (2024-12-10)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/64073cbed0ce23e988160bfd1a148a75b6af94cc' (2024-12-06)
  → 'github:neovim/nvim-lspconfig/4761665b4be82c46612cdfb4ea9c90de25875c4f' (2024-12-13)
• Updated input 'resty-vim':
    'github:lima1909/resty.nvim/a3a105cff1f77a26d7fa33ff5f64a29f57452f8e' (2024-11-28)
  → 'github:lima1909/resty.nvim/3987bcc2da37bd28442ad94917cf91d604a35f9b' (2024-12-11)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/bf3d8c7bcbf20a7e7f4af36c2d5390ca6ad43281' (2024-12-04)
  → 'github:mrcjkb/rustaceanvim/a244210b28f9055c2b4cfa85c92c8a71c13671c9' (2024-12-08)
• Updated input 'rustacean-nvim/flake-parts':
    'github:hercules-ci/flake-parts/506278e768c2a08bec68eb62932193e341f55c90' (2024-11-01)
  → 'github:hercules-ci/flake-parts/205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9' (2024-12-04)
• Updated input 'rustacean-nvim/flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz?narHash=sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s%3D' (2024-11-01)
  → 'https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz?narHash=sha256-1qRH7uAUsyQI7R1Uwl4T%2BXvdNv778H0Nb5njNrqvylY%3D' (2024-12-01)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/f7fe2c43b5bf0c8840963d96dda1fe65e963ade8' (2024-11-30)
  → 'github:nvim-neorocks/neorocks/48a4927d78cb67cbc56f112d713d3cfe1edc15c1' (2024-12-07)
• Updated input 'rustacean-nvim/neorocks/flake-compat':
    'github:edolstra/flake-compat/9ed2ac151eada2306ca8c418ebd97807bb08f6ac' (2024-11-27)
  → 'github:edolstra/flake-compat/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec' (2024-12-04)
• Updated input 'rustacean-nvim/neorocks/flake-parts':
    'github:hercules-ci/flake-parts/506278e768c2a08bec68eb62932193e341f55c90' (2024-11-01)
  → 'github:hercules-ci/flake-parts/205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9' (2024-12-04)
• Updated input 'rustacean-nvim/neorocks/flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz?narHash=sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s%3D' (2024-11-01)
  → 'https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz?narHash=sha256-1qRH7uAUsyQI7R1Uwl4T%2BXvdNv778H0Nb5njNrqvylY%3D' (2024-12-01)
• Updated input 'rustacean-nvim/neorocks/git-hooks':
    'github:cachix/git-hooks.nix/3308484d1a443fc5bc92012435d79e80458fe43c' (2024-11-19)
  → 'github:cachix/git-hooks.nix/6f4e2a2112050951a314d2733a994fbab94864c6' (2024-12-04)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/7461a0b228bb48bb02af086f8b9ee9a83583120b' (2024-11-30)
  → 'github:nix-community/neovim-nightly-overlay/3930a71f90bacc656e8bdf19cc0faa9ebf10353a' (2024-12-07)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/flake-compat':
    'github:edolstra/flake-compat/9ed2ac151eada2306ca8c418ebd97807bb08f6ac' (2024-11-27)
  → 'github:edolstra/flake-compat/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec' (2024-12-04)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/flake-parts':
    'github:hercules-ci/flake-parts/506278e768c2a08bec68eb62932193e341f55c90' (2024-11-01)
  → 'github:hercules-ci/flake-parts/205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9' (2024-12-04)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks':
    'github:cachix/git-hooks.nix/3308484d1a443fc5bc92012435d79e80458fe43c' (2024-11-19)
  → 'github:cachix/git-hooks.nix/6f4e2a2112050951a314d2733a994fbab94864c6' (2024-12-04)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/b89ac4d66d618b915b1f0a408e2775fe3821d141' (2024-11-06)
  → 'github:hercules-ci/hercules-ci-effects/56f8ea8d502c87cf62444bec4ee04512e8ea24ea' (2024-12-04)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects/flake-parts':
    'github:hercules-ci/flake-parts/9126214d0a59633752a136528f5f3b9aa8565b7d' (2024-04-01)
  → 'github:hercules-ci/flake-parts/205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9' (2024-12-04)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/2833925cfc688786759d6a980a1ad62b62d20570' (2024-11-29)
  → 'github:neovim/neovim/517ecb85f58ed6ac8b4d5443931612e75e7c7dc2' (2024-12-06)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/af51545ec9a44eadf3fe3547610a5cdd882bc34e' (2024-11-26)
  → 'github:NixOS/nixpkgs/566e53c2ad750c84f6d31f9ccb9d00f823165550' (2024-12-03)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/226216574ada4c3ecefcbbec41f39ce4655f78ef' (2024-11-28)
  → 'github:nixos/nixpkgs/566e53c2ad750c84f6d31f9ccb9d00f823165550' (2024-12-03)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/4703b8d2c708e13a8cab03d865f90973536dcdf5' (2024-11-30)
  → 'github:nixos/nixpkgs/929116e316068c7318c54eb4d827f7d9756d5e9c' (2024-12-05)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/3308484d1a443fc5bc92012435d79e80458fe43c' (2024-11-19)
  → 'github:cachix/pre-commit-hooks.nix/6f4e2a2112050951a314d2733a994fbab94864c6' (2024-12-04)
• Updated input 'telescope-fzf-native-nvim':
    'github:nvim-telescope/telescope-fzf-native.nvim/cf48d4dfce44e0b9a2e19a008d6ec6ea6f01a83b' (2024-07-02)
  → 'github:nvim-telescope/telescope-fzf-native.nvim/dae2eac9d91464448b584c7949a31df8faefec56' (2024-12-12)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/203da76ecfbb4b192cf830665b03eb651b635c94' (2024-11-30)
  → 'github:nvim-tree/nvim-web-devicons/dd0c15170f9ab2ffac695d90212318c05078751d' (2024-12-13)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`7461a0b2` ➡️ `3930a71f`](https://github.com/nix-community/neovim-nightly-overlay/compare/7461a0b228bb48bb02af086f8b9ee9a83583120b...3930a71f90bacc656e8bdf19cc0faa9ebf10353a) <sub>(2024-11-30 to 2024-12-07)</sub>
 - Updated input `rustacean-nvim/flake-parts/nixpkgs-lib`: `cc2f2800` ➡️ `5487e69d` <sub>(2024-11-01 to 2024-12-01)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`bf3d8c7b` ➡️ `a244210b`](https://github.com/mrcjkb/rustaceanvim/compare/bf3d8c7bcbf20a7e7f4af36c2d5390ca6ad43281...a244210b28f9055c2b4cfa85c92c8a71c13671c9) <sub>(2024-12-04 to 2024-12-08)</sub>
 - Updated input [`resty-vim`](https://github.com/lima1909/resty.nvim): [`a3a105cf` ➡️ `3987bcc2`](https://github.com/lima1909/resty.nvim/compare/a3a105cff1f77a26d7fa33ff5f64a29f57452f8e...3987bcc2da37bd28442ad94917cf91d604a35f9b) <sub>(2024-11-28 to 2024-12-11)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`22621657` ➡️ `566e53c2`](https://github.com/nixos/nixpkgs/compare/226216574ada4c3ecefcbbec41f39ce4655f78ef...566e53c2ad750c84f6d31f9ccb9d00f823165550) <sub>(2024-11-28 to 2024-12-03)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`f7fe2c43` ➡️ `48a4927d`](https://github.com/nvim-neorocks/neorocks/compare/f7fe2c43b5bf0c8840963d96dda1fe65e963ade8...48a4927d78cb67cbc56f112d713d3cfe1edc15c1) <sub>(2024-11-30 to 2024-12-07)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [`2833925c` ➡️ `517ecb85`](https://github.com/neovim/neovim/compare/2833925cfc688786759d6a980a1ad62b62d20570...517ecb85f58ed6ac8b4d5443931612e75e7c7dc2) <sub>(2024-11-29 to 2024-12-06)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`b89ac4d6` ➡️ `56f8ea8d`](https://github.com/hercules-ci/hercules-ci-effects/compare/b89ac4d66d618b915b1f0a408e2775fe3821d141...56f8ea8d502c87cf62444bec4ee04512e8ea24ea) <sub>(2024-11-06 to 2024-12-04)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/flake-compat`](https://github.com/edolstra/flake-compat): [`9ed2ac15` ➡️ `ff81ac96`](https://github.com/edolstra/flake-compat/compare/9ed2ac151eada2306ca8c418ebd97807bb08f6ac...ff81ac966bb2cae68946d5ed5fc4994f96d0ffec) <sub>(2024-11-27 to 2024-12-04)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`1dc88a9c` ➡️ `044f9a36`](https://github.com/nix-community/neovim-nightly-overlay/compare/1dc88a9c89328a398b026568095839463aea2343...044f9a36ad620a119ebe154c26ec571a09f75039) <sub>(2024-12-06 to 2024-12-13)</sub>
 - Updated input `rustacean-nvim/neorocks/flake-parts/nixpkgs-lib`: `cc2f2800` ➡️ `5487e69d` <sub>(2024-11-01 to 2024-12-01)</sub>
 - Updated input [`rustacean-nvim/flake-parts`](https://github.com/hercules-ci/flake-parts): [`506278e7` ➡️ `205b12d8`](https://github.com/hercules-ci/flake-parts/compare/506278e768c2a08bec68eb62932193e341f55c90...205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9) <sub>(2024-11-01 to 2024-12-04)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`64073cbe` ➡️ `4761665b`](https://github.com/neovim/nvim-lspconfig/compare/64073cbed0ce23e988160bfd1a148a75b6af94cc...4761665b4be82c46612cdfb4ea9c90de25875c4f) <sub>(2024-12-06 to 2024-12-13)</sub>
 - Updated input [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp): [`ca4d3330` ➡️ `3403e2e9`](https://github.com/hrsh7th/nvim-cmp/compare/ca4d3330d386e76967e53b85953c170658255ecb...3403e2e9391ed0a28c3afddd8612701b647c8e26) <sub>(2024-11-30 to 2024-12-10)</sub>
 - Updated input [`telescope-fzf-native-nvim`](https://github.com/nvim-telescope/telescope-fzf-native.nvim): [`cf48d4df` ➡️ `dae2eac9`](https://github.com/nvim-telescope/telescope-fzf-native.nvim/compare/cf48d4dfce44e0b9a2e19a008d6ec6ea6f01a83b...dae2eac9d91464448b584c7949a31df8faefec56) <sub>(2024-07-02 to 2024-12-12)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`3308484d` ➡️ `6f4e2a21`](https://github.com/cachix/pre-commit-hooks.nix/compare/3308484d1a443fc5bc92012435d79e80458fe43c...6f4e2a2112050951a314d2733a994fbab94864c6) <sub>(2024-11-19 to 2024-12-04)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`4703b8d2` ➡️ `929116e3`](https://github.com/nixos/nixpkgs/compare/4703b8d2c708e13a8cab03d865f90973536dcdf5...929116e316068c7318c54eb4d827f7d9756d5e9c) <sub>(2024-11-30 to 2024-12-05)</sub>
 - Added input `neovim-nightly-overlay/treefmt-nix/nixpkgs`: ``
 - Updated input [`rustacean-nvim/neorocks/git-hooks`](https://github.com/cachix/git-hooks.nix): [`3308484d` ➡️ `6f4e2a21`](https://github.com/cachix/git-hooks.nix/compare/3308484d1a443fc5bc92012435d79e80458fe43c...6f4e2a2112050951a314d2733a994fbab94864c6) <sub>(2024-11-19 to 2024-12-04)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/hercules-ci-effects/flake-parts`](https://github.com/hercules-ci/flake-parts): [`9126214d` ➡️ `205b12d8`](https://github.com/hercules-ci/flake-parts/compare/9126214d0a59633752a136528f5f3b9aa8565b7d...205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9) <sub>(2024-04-01 to 2024-12-04)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`566e53c2` ➡️ `5a48e3c2`](https://github.com/nixos/nixpkgs/compare/566e53c2ad750c84f6d31f9ccb9d00f823165550...5a48e3c2e435e95103d56590188cfed7b70e108c) <sub>(2024-12-03 to 2024-12-11)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`6f4e2a21` ➡️ `d8c02f0f`](https://github.com/cachix/git-hooks.nix/compare/6f4e2a2112050951a314d2733a994fbab94864c6...d8c02f0ffef0ef39f6063731fc539d8c71eb463a) <sub>(2024-12-04 to 2024-12-08)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`af51545e` ➡️ `566e53c2`](https://github.com/NixOS/nixpkgs/compare/af51545ec9a44eadf3fe3547610a5cdd882bc34e...566e53c2ad750c84f6d31f9ccb9d00f823165550) <sub>(2024-11-26 to 2024-12-03)</sub>
 - Updated input [`rustacean-nvim/neorocks/flake-parts`](https://github.com/hercules-ci/flake-parts): [`506278e7` ➡️ `205b12d8`](https://github.com/hercules-ci/flake-parts/compare/506278e768c2a08bec68eb62932193e341f55c90...205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9) <sub>(2024-11-01 to 2024-12-04)</sub>
 - Added input [`neovim-nightly-overlay/treefmt-nix`](https://github.com/numtide/treefmt-nix): [github.com/numtide/treefmt-nix](https://github.com/numtide/treefmt-nix/tree/0ce9d149d99bc383d1f2d85f31f6ebd146e46085/)
 - Updated input [`cmp-lsp-nvim`](https://github.com/hrsh7th/cmp-nvim-lsp): [`39e2eda7` ➡️ `99290b3e`](https://github.com/hrsh7th/cmp-nvim-lsp/compare/39e2eda76828d88b773cc27a3f61d2ad782c922d...99290b3ec1322070bcfb9e846450a46f6efa50f0) <sub>(2024-05-17 to 2024-12-10)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`203da76e` ➡️ `dd0c1517`](https://github.com/nvim-tree/nvim-web-devicons/compare/203da76ecfbb4b192cf830665b03eb651b635c94...dd0c15170f9ab2ffac695d90212318c05078751d) <sub>(2024-11-30 to 2024-12-13)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks`](https://github.com/cachix/git-hooks.nix): [`3308484d` ➡️ `6f4e2a21`](https://github.com/cachix/git-hooks.nix/compare/3308484d1a443fc5bc92012435d79e80458fe43c...6f4e2a2112050951a314d2733a994fbab94864c6) <sub>(2024-11-19 to 2024-12-04)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`d00c6f6d` ➡️ `66c5d8b6`](https://github.com/nix-community/home-manager/compare/d00c6f6d0ad16d598bf7e2956f52c1d9d5de3c3a...66c5d8b62818ec4c1edb3e941f55ef78df8141a8) <sub>(2024-12-06 to 2024-12-13)</sub>
 - Updated input [`rustacean-nvim/neorocks/flake-compat`](https://github.com/edolstra/flake-compat): [`9ed2ac15` ➡️ `ff81ac96`](https://github.com/edolstra/flake-compat/compare/9ed2ac151eada2306ca8c418ebd97807bb08f6ac...ff81ac966bb2cae68946d5ed5fc4994f96d0ffec) <sub>(2024-11-27 to 2024-12-04)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`bf5c1346` ➡️ `17383870`](https://github.com/neovim/neovim/compare/bf5c1346c52f801636d55b9077d26231409e4d76...17383870dd3b7f04eddd48ed929cc25c7e102277) <sub>(2024-12-05 to 2024-12-12)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/flake-parts`](https://github.com/hercules-ci/flake-parts): [`506278e7` ➡️ `205b12d8`](https://github.com/hercules-ci/flake-parts/compare/506278e768c2a08bec68eb62932193e341f55c90...205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9) <sub>(2024-11-01 to 2024-12-04)</sub>