### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -521,11 +521,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734425854,
-        "narHash": "sha256-nzE5UbJ41aPEKf8R2ZFYtLkqPmF7EIUbNEdHMBLg0Ig=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {
@@ -567,11 +567,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1733665616,
-        "narHash": "sha256-+XTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd+lh2A=",
+        "lastModified": 1734425854,
+        "narHash": "sha256-nzE5UbJ41aPEKf8R2ZFYtLkqPmF7EIUbNEdHMBLg0Ig=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
+        "rev": "0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d",
         "type": "github"
       },
       "original": {
@@ -598,11 +598,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733665616,
-        "narHash": "sha256-+XTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd+lh2A=",
+        "lastModified": 1734425854,
+        "narHash": "sha256-nzE5UbJ41aPEKf8R2ZFYtLkqPmF7EIUbNEdHMBLg0Ig=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
+        "rev": "0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d",
         "type": "github"
       },
       "original": {
@@ -843,11 +843,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734622215,
-        "narHash": "sha256-OOfI0XhSJGHblfdNDhfnn8QnZxng63rWk9eeJ2tCbiI=",
+        "lastModified": 1735053786,
+        "narHash": "sha256-Gm+0DcbUS338vvkwyYWms5jsWlx8z8MeQBzcnIDuIkw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1395379a7a36e40f2a76e7b9936cc52950baa1be",
+        "rev": "35b98d20ca8f4ca1f6a2c30b8a2c8bb305a36d84",
         "type": "github"
       },
       "original": {
@@ -1028,11 +1028,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1734153874,
-        "narHash": "sha256-u0REO55voOXuKad6jlAc6ZODL+kfxCr38NVk1PwKOBk=",
+        "lastModified": 1734758731,
+        "narHash": "sha256-lF/z3uRS3KtIkSu8sgbRvvGKqwvl3sgk1/iFBEcSKpI=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "48fb0be836b8b845afb30c7e11104e02307aff10",
+        "rev": "cc315e249b2df015eb2929bc7c4080a7f372001b",
         "type": "github"
       },
       "original": {
@@ -1052,11 +1052,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734048484,
-        "narHash": "sha256-EtSEYNx19xzuEBJsT7yXG+nVx11CM3rvrAQAXcvG/5Q=",
+        "lastModified": 1734740039,
+        "narHash": "sha256-hXt72ZmJeu7gv3cCIEDwY892xe0U9bin6LIXwjXlQ7U=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "044f9a36ad620a119ebe154c26ec571a09f75039",
+        "rev": "57e5021f82590f4c6ac0a220ac8787bc28e0a94d",
         "type": "github"
       },
       "original": {
@@ -1078,11 +1078,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1734679226,
-        "narHash": "sha256-suZLxqPd9+Eg3/aWSWmVEwDi4uMOd6c2CeseZu9Nw5M=",
+        "lastModified": 1735172062,
+        "narHash": "sha256-Ru+5fwMqXEoc6G1PbuTppAzxtqvj0322cBAWCb0Yhbo=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "d3963249e534e247041862b8162fb738c8604d3a",
+        "rev": "d05e1d754812bcd89925d845992f377faf6c4944",
         "type": "github"
       },
       "original": {
@@ -1094,11 +1094,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1734620824,
-        "narHash": "sha256-1DYP7gnHmD841k+JbHv9HfyBsB8Eq5M9VmAvbPpOK0U=",
+        "lastModified": 1735157560,
+        "narHash": "sha256-ndlWdGm61W3uObi8cowWqnPdJwq2FsH4GHGOQYeNSOM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "8ef41f590224dfeea2e51d9fec150e363fd72ee0",
+        "rev": "487c48ec8689b865bad04fdb87b61f5ada25da97",
         "type": "github"
       },
       "original": {
@@ -1110,11 +1110,11 @@
     "neovim-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1734000357,
-        "narHash": "sha256-8FO5Ca9bLEiD649b5gkQCdjpTmbPenJHpN0JBhtLpjE=",
+        "lastModified": 1734709720,
+        "narHash": "sha256-isblUJ6somE7siX9YVZuy6FNLJTBtkgK1shmEqrm7dI=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "17383870dd3b7f04eddd48ed929cc25c7e102277",
+        "rev": "e1c2179dd93ed2cd787b1cd016606b1901a1acfe",
         "type": "github"
       },
       "original": {
@@ -1285,11 +1285,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1734435836,
-        "narHash": "sha256-kMBQ5PRiFLagltK0sH+08aiNt3zGERC2297iB6vrvlU=",
+        "lastModified": 1735268880,
+        "narHash": "sha256-7QEFnKkzD13SPxs+UFR5bUFN2fRw+GlL0am72ZjNre4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4989a246d7a390a859852baddb1013f825435cee",
+        "rev": "7cc0bff31a3a705d3ac4fdceb030a17239412210",
         "type": "github"
       },
       "original": {
@@ -1349,11 +1349,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1733749988,
-        "narHash": "sha256-+5qdtgXceqhK5ZR1YbP1fAUsweBIrhL38726oIEAtDs=",
+        "lastModified": 1734435836,
+        "narHash": "sha256-kMBQ5PRiFLagltK0sH+08aiNt3zGERC2297iB6vrvlU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc27f0fde01ce4e1bfec1ab122d72b7380278e68",
+        "rev": "4989a246d7a390a859852baddb1013f825435cee",
         "type": "github"
       },
       "original": {
@@ -1365,11 +1365,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1733935885,
-        "narHash": "sha256-xyiHLs6KJ1fxeGmcCxKjJE4yJknVJxbC8Y/ZRYyC8WE=",
+        "lastModified": 1734435836,
+        "narHash": "sha256-kMBQ5PRiFLagltK0sH+08aiNt3zGERC2297iB6vrvlU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5a48e3c2e435e95103d56590188cfed7b70e108c",
+        "rev": "4989a246d7a390a859852baddb1013f825435cee",
         "type": "github"
       },
       "original": {
@@ -1381,11 +1381,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1733935885,
-        "narHash": "sha256-xyiHLs6KJ1fxeGmcCxKjJE4yJknVJxbC8Y/ZRYyC8WE=",
+        "lastModified": 1734435836,
+        "narHash": "sha256-kMBQ5PRiFLagltK0sH+08aiNt3zGERC2297iB6vrvlU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5a48e3c2e435e95103d56590188cfed7b70e108c",
+        "rev": "4989a246d7a390a859852baddb1013f825435cee",
         "type": "github"
       },
       "original": {
@@ -1430,11 +1430,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1734604437,
-        "narHash": "sha256-meOwqxkFgEbxa8nWo7CiV547gFOyUqB74oYTPKYHaJg=",
+        "lastModified": 1735123035,
+        "narHash": "sha256-1W8ktjIeaPXhmWzYpWKxjYNGKlOWBf4GTA6p0o2nugw=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "040001d85e9190a904d0e35ef5774633e14d8475",
+        "rev": "ff2b85abaa810f6611233dbe6d31c07510ebf43d",
         "type": "github"
       },
       "original": {
@@ -1489,11 +1489,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1734190932,
-        "narHash": "sha256-nIweyhgHbDMJSH6zlciTe2abEzDKWkW28B6/qM9UWOU=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c2b3567b03baf0999a1dd14f7e7ab34b46297d68",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {
@@ -1587,11 +1587,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1734471043,
-        "narHash": "sha256-qmd1yVOG2s5/5ygWF9J6RCmDseI3N72zzW+3uIG/qs8=",
+        "lastModified": 1735065143,
+        "narHash": "sha256-jUSCVtUGD1qlUVJcli73sdlp3j2LXXqoSyw9dhC4B/8=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "0a618c1d1c05a8059880076feccb15301da6993d",
+        "rev": "6db1fe9e3f005b2e0921c7302d2c195eeb90a451",
         "type": "github"
       },
       "original": {
@@ -1717,11 +1717,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734543842,
-        "narHash": "sha256-/QceWozrNg915Db9x/Ie5k67n9wKgGdTFng+Z1Qw0kE=",
+        "lastModified": 1735135567,
+        "narHash": "sha256-8T3K5amndEavxnludPyfj3Z1IkcFdRpR23q+T0BVeZE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "76159fc74eeac0599c3618e3601ac2b980a29263",
+        "rev": "9e09d30a644c57257715902efbb3adc56c79cf28",
         "type": "github"
       },
       "original": {
@@ -1740,11 +1740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733761991,
-        "narHash": "sha256-s4DalCDepD22jtKL5Nw6f4LP5UwoMcPzPZgHWjAfqbQ=",
+        "lastModified": 1734704479,
+        "narHash": "sha256-MMi74+WckoyEWBRcg/oaGRvXC9BVVxDZNRMpL+72wBI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "0ce9d149d99bc383d1f2d85f31f6ebd146e46085",
+        "rev": "65712f5af67234dad91a5a4baee986a8b62dbf8f",
         "type": "github"
       },
       "original": {
@@ -1776,11 +1776,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1734330868,
-        "narHash": "sha256-OULD8dLI3Oakg9rgs4h8zXozOmX0aiovBNk8kD0nDXY=",
+        "lastModified": 1735224684,
+        "narHash": "sha256-YvUQEelrUFqDSDokxGhQAl1ARVHNvUT7owSs9H9B2RM=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "0eb18da56e2ba6ba24de7130a12bcc4e31ad11cb",
+        "rev": "63f552a7f59badc6e6b6d22e603150f0d5abebb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/1395379a7a36e40f2a76e7b9936cc52950baa1be' (2024-12-19)
  → 'github:nix-community/home-manager/35b98d20ca8f4ca1f6a2c30b8a2c8bb305a36d84' (2024-12-24)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/d3963249e534e247041862b8162fb738c8604d3a' (2024-12-20)
  → 'github:nix-community/neovim-nightly-overlay/d05e1d754812bcd89925d845992f377faf6c4944' (2024-12-26)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d' (2024-12-17)
  → 'github:cachix/git-hooks.nix/f0f0dc4920a903c3e08f5bdb9246bb572fcae498' (2024-12-21)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/8ef41f590224dfeea2e51d9fec150e363fd72ee0' (2024-12-19)
  → 'github:neovim/neovim/487c48ec8689b865bad04fdb87b61f5ada25da97' (2024-12-25)
• Updated input 'neovim-nightly-overlay/treefmt-nix':
    'github:numtide/treefmt-nix/76159fc74eeac0599c3618e3601ac2b980a29263' (2024-12-18)
  → 'github:numtide/treefmt-nix/9e09d30a644c57257715902efbb3adc56c79cf28' (2024-12-25)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/4989a246d7a390a859852baddb1013f825435cee' (2024-12-17)
  → 'github:nixos/nixpkgs/7cc0bff31a3a705d3ac4fdceb030a17239412210' (2024-12-27)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/040001d85e9190a904d0e35ef5774633e14d8475' (2024-12-19)
  → 'github:neovim/nvim-lspconfig/ff2b85abaa810f6611233dbe6d31c07510ebf43d' (2024-12-25)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/0a618c1d1c05a8059880076feccb15301da6993d' (2024-12-17)
  → 'github:mrcjkb/rustaceanvim/6db1fe9e3f005b2e0921c7302d2c195eeb90a451' (2024-12-24)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/48fb0be836b8b845afb30c7e11104e02307aff10' (2024-12-14)
  → 'github:nvim-neorocks/neorocks/cc315e249b2df015eb2929bc7c4080a7f372001b' (2024-12-21)
• Updated input 'rustacean-nvim/neorocks/git-hooks':
    'github:cachix/git-hooks.nix/d8c02f0ffef0ef39f6063731fc539d8c71eb463a' (2024-12-08)
  → 'github:cachix/git-hooks.nix/0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d' (2024-12-17)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/044f9a36ad620a119ebe154c26ec571a09f75039' (2024-12-13)
  → 'github:nix-community/neovim-nightly-overlay/57e5021f82590f4c6ac0a220ac8787bc28e0a94d' (2024-12-21)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks':
    'github:cachix/git-hooks.nix/d8c02f0ffef0ef39f6063731fc539d8c71eb463a' (2024-12-08)
  → 'github:cachix/git-hooks.nix/0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d' (2024-12-17)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/17383870dd3b7f04eddd48ed929cc25c7e102277' (2024-12-12)
  → 'github:neovim/neovim/e1c2179dd93ed2cd787b1cd016606b1901a1acfe' (2024-12-20)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/bc27f0fde01ce4e1bfec1ab122d72b7380278e68' (2024-12-09)
  → 'github:NixOS/nixpkgs/4989a246d7a390a859852baddb1013f825435cee' (2024-12-17)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/treefmt-nix':
    'github:numtide/treefmt-nix/0ce9d149d99bc383d1f2d85f31f6ebd146e46085' (2024-12-09)
  → 'github:numtide/treefmt-nix/65712f5af67234dad91a5a4baee986a8b62dbf8f' (2024-12-20)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/5a48e3c2e435e95103d56590188cfed7b70e108c' (2024-12-11)
  → 'github:nixos/nixpkgs/4989a246d7a390a859852baddb1013f825435cee' (2024-12-17)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/5a48e3c2e435e95103d56590188cfed7b70e108c' (2024-12-11)
  → 'github:nixos/nixpkgs/4989a246d7a390a859852baddb1013f825435cee' (2024-12-17)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/c2b3567b03baf0999a1dd14f7e7ab34b46297d68' (2024-12-14)
  → 'github:cachix/pre-commit-hooks.nix/f0f0dc4920a903c3e08f5bdb9246bb572fcae498' (2024-12-21)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/0eb18da56e2ba6ba24de7130a12bcc4e31ad11cb' (2024-12-16)
  → 'github:nvim-tree/nvim-web-devicons/63f552a7f59badc6e6b6d22e603150f0d5abebb7' (2024-12-26)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`044f9a36` ➡️ `57e5021f`](https://github.com/nix-community/neovim-nightly-overlay/compare/044f9a36ad620a119ebe154c26ec571a09f75039...57e5021f82590f4c6ac0a220ac8787bc28e0a94d) <sub>(2024-12-13 to 2024-12-21)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`0a618c1d` ➡️ `6db1fe9e`](https://github.com/mrcjkb/rustaceanvim/compare/0a618c1d1c05a8059880076feccb15301da6993d...6db1fe9e3f005b2e0921c7302d2c195eeb90a451) <sub>(2024-12-17 to 2024-12-24)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`5a48e3c2` ➡️ `4989a246`](https://github.com/nixos/nixpkgs/compare/5a48e3c2e435e95103d56590188cfed7b70e108c...4989a246d7a390a859852baddb1013f825435cee) <sub>(2024-12-11 to 2024-12-17)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`48fb0be8` ➡️ `cc315e24`](https://github.com/nvim-neorocks/neorocks/compare/48fb0be836b8b845afb30c7e11104e02307aff10...cc315e249b2df015eb2929bc7c4080a7f372001b) <sub>(2024-12-14 to 2024-12-21)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [`17383870` ➡️ `e1c2179d`](https://github.com/neovim/neovim/compare/17383870dd3b7f04eddd48ed929cc25c7e102277...e1c2179dd93ed2cd787b1cd016606b1901a1acfe) <sub>(2024-12-12 to 2024-12-20)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`d3963249` ➡️ `d05e1d75`](https://github.com/nix-community/neovim-nightly-overlay/compare/d3963249e534e247041862b8162fb738c8604d3a...d05e1d754812bcd89925d845992f377faf6c4944) <sub>(2024-12-20 to 2024-12-26)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`040001d8` ➡️ `ff2b85ab`](https://github.com/neovim/nvim-lspconfig/compare/040001d85e9190a904d0e35ef5774633e14d8475...ff2b85abaa810f6611233dbe6d31c07510ebf43d) <sub>(2024-12-19 to 2024-12-25)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`c2b3567b` ➡️ `f0f0dc49`](https://github.com/cachix/pre-commit-hooks.nix/compare/c2b3567b03baf0999a1dd14f7e7ab34b46297d68...f0f0dc4920a903c3e08f5bdb9246bb572fcae498) <sub>(2024-12-14 to 2024-12-21)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`5a48e3c2` ➡️ `4989a246`](https://github.com/nixos/nixpkgs/compare/5a48e3c2e435e95103d56590188cfed7b70e108c...4989a246d7a390a859852baddb1013f825435cee) <sub>(2024-12-11 to 2024-12-17)</sub>
 - Updated input [`rustacean-nvim/neorocks/git-hooks`](https://github.com/cachix/git-hooks.nix): [`d8c02f0f` ➡️ `0ddd26d0`](https://github.com/cachix/git-hooks.nix/compare/d8c02f0ffef0ef39f6063731fc539d8c71eb463a...0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d) <sub>(2024-12-08 to 2024-12-17)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`4989a246` ➡️ `7cc0bff3`](https://github.com/nixos/nixpkgs/compare/4989a246d7a390a859852baddb1013f825435cee...7cc0bff31a3a705d3ac4fdceb030a17239412210) <sub>(2024-12-17 to 2024-12-27)</sub>
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`0ddd26d0` ➡️ `f0f0dc49`](https://github.com/cachix/git-hooks.nix/compare/0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d...f0f0dc4920a903c3e08f5bdb9246bb572fcae498) <sub>(2024-12-17 to 2024-12-21)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/treefmt-nix`](https://github.com/numtide/treefmt-nix): [`0ce9d149` ➡️ `65712f5a`](https://github.com/numtide/treefmt-nix/compare/0ce9d149d99bc383d1f2d85f31f6ebd146e46085...65712f5af67234dad91a5a4baee986a8b62dbf8f) <sub>(2024-12-09 to 2024-12-20)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`bc27f0fd` ➡️ `4989a246`](https://github.com/NixOS/nixpkgs/compare/bc27f0fde01ce4e1bfec1ab122d72b7380278e68...4989a246d7a390a859852baddb1013f825435cee) <sub>(2024-12-09 to 2024-12-17)</sub>
 - Updated input [`neovim-nightly-overlay/treefmt-nix`](https://github.com/numtide/treefmt-nix): [`76159fc7` ➡️ `9e09d30a`](https://github.com/numtide/treefmt-nix/compare/76159fc74eeac0599c3618e3601ac2b980a29263...9e09d30a644c57257715902efbb3adc56c79cf28) <sub>(2024-12-18 to 2024-12-25)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`0eb18da5` ➡️ `63f552a7`](https://github.com/nvim-tree/nvim-web-devicons/compare/0eb18da56e2ba6ba24de7130a12bcc4e31ad11cb...63f552a7f59badc6e6b6d22e603150f0d5abebb7) <sub>(2024-12-16 to 2024-12-26)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks`](https://github.com/cachix/git-hooks.nix): [`d8c02f0f` ➡️ `0ddd26d0`](https://github.com/cachix/git-hooks.nix/compare/d8c02f0ffef0ef39f6063731fc539d8c71eb463a...0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d) <sub>(2024-12-08 to 2024-12-17)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`1395379a` ➡️ `35b98d20`](https://github.com/nix-community/home-manager/compare/1395379a7a36e40f2a76e7b9936cc52950baa1be...35b98d20ca8f4ca1f6a2c30b8a2c8bb305a36d84) <sub>(2024-12-19 to 2024-12-24)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`8ef41f59` ➡️ `487c48ec`](https://github.com/neovim/neovim/compare/8ef41f590224dfeea2e51d9fec150e363fd72ee0...487c48ec8689b865bad04fdb87b61f5ada25da97) <sub>(2024-12-19 to 2024-12-25)</sub>