### PR TITLE
flake: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -232,11 +232,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1735774679,
+        "narHash": "sha256-soePLBazJk0qQdDVhdbM98vYdssfs3WFedcq+raipRI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "f2f7418ce0ab4a5309a4596161d154cfc877af66",
         "type": "github"
       },
       "original": {
@@ -441,11 +441,11 @@
     "fugitive-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1734306248,
-        "narHash": "sha256-PJewEivZ1sAn2vBhwxfIHE+rAmY+9GYPNqID5zsey8c=",
+        "lastModified": 1735457366,
+        "narHash": "sha256-45zsqKavWoclA67MC54bAel1nE8CLHtSdullHByiRS8=",
         "owner": "tpope",
         "repo": "vim-fugitive",
-        "rev": "fcb4db52e7f65b95705aa58f0f2df1312c1f2df2",
+        "rev": "174230d6a7f2df94705a7ffd8d5413e27ec10a80",
         "type": "github"
       },
       "original": {
@@ -514,18 +514,14 @@
         "nixpkgs": [
           "neovim-nightly-overlay",
           "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "neovim-nightly-overlay",
-          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1734425854,
-        "narHash": "sha256-nzE5UbJ41aPEKf8R2ZFYtLkqPmF7EIUbNEdHMBLg0Ig=",
+        "lastModified": 1735882644,
+        "narHash": "sha256-3FZAG+pGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d",
+        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
         "type": "github"
       },
       "original": {
@@ -567,11 +563,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1733665616,
-        "narHash": "sha256-+XTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd+lh2A=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {
@@ -598,11 +594,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733665616,
-        "narHash": "sha256-+XTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd+lh2A=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {
@@ -799,11 +795,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733333617,
-        "narHash": "sha256-nMMQXREGvLOLvUa0ByhYFdaL0Jov0t1wzLbKjr05P2w=",
+        "lastModified": 1735695978,
+        "narHash": "sha256-cwk53OX1S1bCFY09zydubZNmmwcx9l5XEba8mVYuNE4=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "56f8ea8d502c87cf62444bec4ee04512e8ea24ea",
+        "rev": "f6233b5cfbada692d93a73d6ed35bdbfd0fdb9c4",
         "type": "github"
       },
       "original": {
@@ -843,11 +839,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734622215,
-        "narHash": "sha256-OOfI0XhSJGHblfdNDhfnn8QnZxng63rWk9eeJ2tCbiI=",
+        "lastModified": 1735925111,
+        "narHash": "sha256-/NptDI4njO5hH0ZVQ2yzbvTXmBOabZaGYkjhnMJ37TY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1395379a7a36e40f2a76e7b9936cc52950baa1be",
+        "rev": "ef64efdbaca99f9960f75efab991e4c49e79a5f1",
         "type": "github"
       },
       "original": {
@@ -1028,11 +1024,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1734153874,
-        "narHash": "sha256-u0REO55voOXuKad6jlAc6ZODL+kfxCr38NVk1PwKOBk=",
+        "lastModified": 1735363388,
+        "narHash": "sha256-Ffj2hDeQYs/bdXGM0tUVEQJTpzMdbpEKqYdMndK5y/Y=",
         "owner": "nvim-neorocks",
         "repo": "neorocks",
-        "rev": "48fb0be836b8b845afb30c7e11104e02307aff10",
+        "rev": "b2c82e92a01750608be57b3c09bf4253f95c57ef",
         "type": "github"
       },
       "original": {
@@ -1052,11 +1048,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734048484,
-        "narHash": "sha256-EtSEYNx19xzuEBJsT7yXG+nVx11CM3rvrAQAXcvG/5Q=",
+        "lastModified": 1735172062,
+        "narHash": "sha256-Ru+5fwMqXEoc6G1PbuTppAzxtqvj0322cBAWCb0Yhbo=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "044f9a36ad620a119ebe154c26ec571a09f75039",
+        "rev": "d05e1d754812bcd89925d845992f377faf6c4944",
         "type": "github"
       },
       "original": {
@@ -1078,11 +1074,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1734679226,
-        "narHash": "sha256-suZLxqPd9+Eg3/aWSWmVEwDi4uMOd6c2CeseZu9Nw5M=",
+        "lastModified": 1735908283,
+        "narHash": "sha256-00Cd/KACX7Mr4ixz8rXksT4wteIStuExZIS22sA21ls=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "d3963249e534e247041862b8162fb738c8604d3a",
+        "rev": "54dd5a7c0384fdcd11830e52f9896e457f189cb6",
         "type": "github"
       },
       "original": {
@@ -1094,11 +1090,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1734620824,
-        "narHash": "sha256-1DYP7gnHmD841k+JbHv9HfyBsB8Eq5M9VmAvbPpOK0U=",
+        "lastModified": 1735903221,
+        "narHash": "sha256-VrmQyDyR8y7x8QHSnX+Szs2ywZa7butk6lUdiNX5U3s=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "8ef41f590224dfeea2e51d9fec150e363fd72ee0",
+        "rev": "c26951b1d6d4d7ff8fe431e8bfb16744ff56af1c",
         "type": "github"
       },
       "original": {
@@ -1110,11 +1106,11 @@
     "neovim-src_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1734000357,
-        "narHash": "sha256-8FO5Ca9bLEiD649b5gkQCdjpTmbPenJHpN0JBhtLpjE=",
+        "lastModified": 1735157560,
+        "narHash": "sha256-ndlWdGm61W3uObi8cowWqnPdJwq2FsH4GHGOQYeNSOM=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "17383870dd3b7f04eddd48ed929cc25c7e102277",
+        "rev": "487c48ec8689b865bad04fdb87b61f5ada25da97",
         "type": "github"
       },
       "original": {
@@ -1126,11 +1122,11 @@
     "nightfox-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1725836615,
-        "narHash": "sha256-fVHC3FfGeRGYtB1MKpmLSITk9TDBY/yDCOlQuKvAH5I=",
+        "lastModified": 1735500747,
+        "narHash": "sha256-bVRI77ikBRECJ9Y6UVgZVO+SH46LBU3MtZUDgAYqXBc=",
         "owner": "EdenEast",
         "repo": "nightfox.nvim",
-        "rev": "7557f26defd093c4e9bc17f28b08403f706f5a44",
+        "rev": "595ffb8f291fc4a9bef3201a28b7c0379a41cdee",
         "type": "github"
       },
       "original": {
@@ -1285,11 +1281,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1734435836,
-        "narHash": "sha256-kMBQ5PRiFLagltK0sH+08aiNt3zGERC2297iB6vrvlU=",
+        "lastModified": 1735821806,
+        "narHash": "sha256-cuNapx/uQeCgeuhUhdck3JKbgpsml259sjUQnWM7zW8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4989a246d7a390a859852baddb1013f825435cee",
+        "rev": "d6973081434f88088e5321f83ebafe9a1167c367",
         "type": "github"
       },
       "original": {
@@ -1349,11 +1345,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1733749988,
-        "narHash": "sha256-+5qdtgXceqhK5ZR1YbP1fAUsweBIrhL38726oIEAtDs=",
+        "lastModified": 1734988233,
+        "narHash": "sha256-Ucfnxq1rF/GjNP3kTL+uTfgdoE9a3fxDftSfeLIS8mA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc27f0fde01ce4e1bfec1ab122d72b7380278e68",
+        "rev": "de1864217bfa9b5845f465e771e0ecb48b30e02d",
         "type": "github"
       },
       "original": {
@@ -1365,11 +1361,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1733935885,
-        "narHash": "sha256-xyiHLs6KJ1fxeGmcCxKjJE4yJknVJxbC8Y/ZRYyC8WE=",
+        "lastModified": 1735268880,
+        "narHash": "sha256-7QEFnKkzD13SPxs+UFR5bUFN2fRw+GlL0am72ZjNre4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5a48e3c2e435e95103d56590188cfed7b70e108c",
+        "rev": "7cc0bff31a3a705d3ac4fdceb030a17239412210",
         "type": "github"
       },
       "original": {
@@ -1381,11 +1377,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1733935885,
-        "narHash": "sha256-xyiHLs6KJ1fxeGmcCxKjJE4yJknVJxbC8Y/ZRYyC8WE=",
+        "lastModified": 1735268880,
+        "narHash": "sha256-7QEFnKkzD13SPxs+UFR5bUFN2fRw+GlL0am72ZjNre4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5a48e3c2e435e95103d56590188cfed7b70e108c",
+        "rev": "7cc0bff31a3a705d3ac4fdceb030a17239412210",
         "type": "github"
       },
       "original": {
@@ -1430,11 +1426,11 @@
     "nvim-lspconfig": {
       "flake": false,
       "locked": {
-        "lastModified": 1734604437,
-        "narHash": "sha256-meOwqxkFgEbxa8nWo7CiV547gFOyUqB74oYTPKYHaJg=",
+        "lastModified": 1735893345,
+        "narHash": "sha256-byU5aewCFEztNVGqsFw/GAIwi3XAFee3V220vr4a6Z8=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "040001d85e9190a904d0e35ef5774633e14d8475",
+        "rev": "a8ef5e6e497b3ebeaaf35b939c07c211563b2e05",
         "type": "github"
       },
       "original": {
@@ -1489,11 +1485,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1734190932,
-        "narHash": "sha256-nIweyhgHbDMJSH6zlciTe2abEzDKWkW28B6/qM9UWOU=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c2b3567b03baf0999a1dd14f7e7ab34b46297d68",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {
@@ -1587,11 +1583,11 @@
         "vimcats": "vimcats"
       },
       "locked": {
-        "lastModified": 1734471043,
-        "narHash": "sha256-qmd1yVOG2s5/5ygWF9J6RCmDseI3N72zzW+3uIG/qs8=",
+        "lastModified": 1735827934,
+        "narHash": "sha256-2lAevRDoChYMGej6Yyx90rbAKorZ8ib7jGOV1Y10u3M=",
         "owner": "mrcjkb",
         "repo": "rustaceanvim",
-        "rev": "0a618c1d1c05a8059880076feccb15301da6993d",
+        "rev": "0a1876b970ab946be3f4d341e9d743a5d62d646a",
         "type": "github"
       },
       "original": {
@@ -1717,11 +1713,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734543842,
-        "narHash": "sha256-/QceWozrNg915Db9x/Ie5k67n9wKgGdTFng+Z1Qw0kE=",
+        "lastModified": 1735905407,
+        "narHash": "sha256-1hKMRIT+QZNWX46e4gIovoQ7H8QRb7803ZH4qSKI45o=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "76159fc74eeac0599c3618e3601ac2b980a29263",
+        "rev": "29806abab803e498df96d82dd6f34b32eb8dd2c8",
         "type": "github"
       },
       "original": {
@@ -1740,11 +1736,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733761991,
-        "narHash": "sha256-s4DalCDepD22jtKL5Nw6f4LP5UwoMcPzPZgHWjAfqbQ=",
+        "lastModified": 1735135567,
+        "narHash": "sha256-8T3K5amndEavxnludPyfj3Z1IkcFdRpR23q+T0BVeZE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "0ce9d149d99bc383d1f2d85f31f6ebd146e46085",
+        "rev": "9e09d30a644c57257715902efbb3adc56c79cf28",
         "type": "github"
       },
       "original": {
@@ -1776,11 +1772,11 @@
     "web-devicons-nvim": {
       "flake": false,
       "locked": {
-        "lastModified": 1734330868,
-        "narHash": "sha256-OULD8dLI3Oakg9rgs4h8zXozOmX0aiovBNk8kD0nDXY=",
+        "lastModified": 1735863050,
+        "narHash": "sha256-3kLih7OCroaoWcrcfOCvFICggQBWDsb8oyjzzKodFPA=",
         "owner": "nvim-tree",
         "repo": "nvim-web-devicons",
-        "rev": "0eb18da56e2ba6ba24de7130a12bcc4e31ad11cb",
+        "rev": "5740b7382429d20b6ed0bbdb0694185af9507d44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<details><summary>Raw output</summary><p>

```
Flake lock file updates:

• Updated input 'fugitive-nvim':
    'github:tpope/vim-fugitive/fcb4db52e7f65b95705aa58f0f2df1312c1f2df2' (2024-12-15)
  → 'github:tpope/vim-fugitive/174230d6a7f2df94705a7ffd8d5413e27ec10a80' (2024-12-29)
• Updated input 'home-manager':
    'github:nix-community/home-manager/1395379a7a36e40f2a76e7b9936cc52950baa1be' (2024-12-19)
  → 'github:nix-community/home-manager/ef64efdbaca99f9960f75efab991e4c49e79a5f1' (2025-01-03)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/d3963249e534e247041862b8162fb738c8604d3a' (2024-12-20)
  → 'github:nix-community/neovim-nightly-overlay/54dd5a7c0384fdcd11830e52f9896e457f189cb6' (2025-01-03)
• Updated input 'neovim-nightly-overlay/flake-parts':
    'github:hercules-ci/flake-parts/205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9' (2024-12-04)
  → 'github:hercules-ci/flake-parts/f2f7418ce0ab4a5309a4596161d154cfc877af66' (2025-01-01)
• Updated input 'neovim-nightly-overlay/git-hooks':
    'github:cachix/git-hooks.nix/0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d' (2024-12-17)
  → 'github:cachix/git-hooks.nix/a5a961387e75ae44cc20f0a57ae463da5e959656' (2025-01-03)
• Removed input 'neovim-nightly-overlay/git-hooks/nixpkgs-stable'
• Updated input 'neovim-nightly-overlay/hercules-ci-effects':
    'github:hercules-ci/hercules-ci-effects/56f8ea8d502c87cf62444bec4ee04512e8ea24ea' (2024-12-04)
  → 'github:hercules-ci/hercules-ci-effects/f6233b5cfbada692d93a73d6ed35bdbfd0fdb9c4' (2025-01-01)
• Updated input 'neovim-nightly-overlay/neovim-src':
    'github:neovim/neovim/8ef41f590224dfeea2e51d9fec150e363fd72ee0' (2024-12-19)
  → 'github:neovim/neovim/c26951b1d6d4d7ff8fe431e8bfb16744ff56af1c' (2025-01-03)
• Updated input 'neovim-nightly-overlay/treefmt-nix':
    'github:numtide/treefmt-nix/76159fc74eeac0599c3618e3601ac2b980a29263' (2024-12-18)
  → 'github:numtide/treefmt-nix/29806abab803e498df96d82dd6f34b32eb8dd2c8' (2025-01-03)
• Updated input 'nightfox-nvim':
    'github:EdenEast/nightfox.nvim/7557f26defd093c4e9bc17f28b08403f706f5a44' (2024-09-08)
  → 'github:EdenEast/nightfox.nvim/595ffb8f291fc4a9bef3201a28b7c0379a41cdee' (2024-12-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/4989a246d7a390a859852baddb1013f825435cee' (2024-12-17)
  → 'github:nixos/nixpkgs/d6973081434f88088e5321f83ebafe9a1167c367' (2025-01-02)
• Updated input 'nvim-lspconfig':
    'github:neovim/nvim-lspconfig/040001d85e9190a904d0e35ef5774633e14d8475' (2024-12-19)
  → 'github:neovim/nvim-lspconfig/a8ef5e6e497b3ebeaaf35b939c07c211563b2e05' (2025-01-03)
• Updated input 'rustacean-nvim':
    'github:mrcjkb/rustaceanvim/0a618c1d1c05a8059880076feccb15301da6993d' (2024-12-17)
  → 'github:mrcjkb/rustaceanvim/0a1876b970ab946be3f4d341e9d743a5d62d646a' (2025-01-02)
• Updated input 'rustacean-nvim/neorocks':
    'github:nvim-neorocks/neorocks/48fb0be836b8b845afb30c7e11104e02307aff10' (2024-12-14)
  → 'github:nvim-neorocks/neorocks/b2c82e92a01750608be57b3c09bf4253f95c57ef' (2024-12-28)
• Updated input 'rustacean-nvim/neorocks/git-hooks':
    'github:cachix/git-hooks.nix/d8c02f0ffef0ef39f6063731fc539d8c71eb463a' (2024-12-08)
  → 'github:cachix/git-hooks.nix/f0f0dc4920a903c3e08f5bdb9246bb572fcae498' (2024-12-21)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/044f9a36ad620a119ebe154c26ec571a09f75039' (2024-12-13)
  → 'github:nix-community/neovim-nightly-overlay/d05e1d754812bcd89925d845992f377faf6c4944' (2024-12-26)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/git-hooks':
    'github:cachix/git-hooks.nix/d8c02f0ffef0ef39f6063731fc539d8c71eb463a' (2024-12-08)
  → 'github:cachix/git-hooks.nix/f0f0dc4920a903c3e08f5bdb9246bb572fcae498' (2024-12-21)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/neovim-src':
    'github:neovim/neovim/17383870dd3b7f04eddd48ed929cc25c7e102277' (2024-12-12)
  → 'github:neovim/neovim/487c48ec8689b865bad04fdb87b61f5ada25da97' (2024-12-25)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/nixpkgs':
    'github:NixOS/nixpkgs/bc27f0fde01ce4e1bfec1ab122d72b7380278e68' (2024-12-09)
  → 'github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d' (2024-12-23)
• Updated input 'rustacean-nvim/neorocks/neovim-nightly/treefmt-nix':
    'github:numtide/treefmt-nix/0ce9d149d99bc383d1f2d85f31f6ebd146e46085' (2024-12-09)
  → 'github:numtide/treefmt-nix/9e09d30a644c57257715902efbb3adc56c79cf28' (2024-12-25)
• Updated input 'rustacean-nvim/neorocks/nixpkgs':
    'github:nixos/nixpkgs/5a48e3c2e435e95103d56590188cfed7b70e108c' (2024-12-11)
  → 'github:nixos/nixpkgs/7cc0bff31a3a705d3ac4fdceb030a17239412210' (2024-12-27)
• Updated input 'rustacean-nvim/nixpkgs':
    'github:nixos/nixpkgs/5a48e3c2e435e95103d56590188cfed7b70e108c' (2024-12-11)
  → 'github:nixos/nixpkgs/7cc0bff31a3a705d3ac4fdceb030a17239412210' (2024-12-27)
• Updated input 'rustacean-nvim/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/c2b3567b03baf0999a1dd14f7e7ab34b46297d68' (2024-12-14)
  → 'github:cachix/pre-commit-hooks.nix/f0f0dc4920a903c3e08f5bdb9246bb572fcae498' (2024-12-21)
• Updated input 'web-devicons-nvim':
    'github:nvim-tree/nvim-web-devicons/0eb18da56e2ba6ba24de7130a12bcc4e31ad11cb' (2024-12-16)
  → 'github:nvim-tree/nvim-web-devicons/5740b7382429d20b6ed0bbdb0694185af9507d44' (2025-01-03)

```

</p></details>

 - Updated input [`rustacean-nvim/neorocks/neovim-nightly`](https://github.com/nix-community/neovim-nightly-overlay): [`044f9a36` ➡️ `d05e1d75`](https://github.com/nix-community/neovim-nightly-overlay/compare/044f9a36ad620a119ebe154c26ec571a09f75039...d05e1d754812bcd89925d845992f377faf6c4944) <sub>(2024-12-13 to 2024-12-26)</sub>
 - Updated input [`rustacean-nvim`](https://github.com/mrcjkb/rustaceanvim): [`0a618c1d` ➡️ `0a1876b9`](https://github.com/mrcjkb/rustaceanvim/compare/0a618c1d1c05a8059880076feccb15301da6993d...0a1876b970ab946be3f4d341e9d743a5d62d646a) <sub>(2024-12-17 to 2025-01-02)</sub>
 - Updated input [`rustacean-nvim/neorocks/nixpkgs`](https://github.com/nixos/nixpkgs): [`5a48e3c2` ➡️ `7cc0bff3`](https://github.com/nixos/nixpkgs/compare/5a48e3c2e435e95103d56590188cfed7b70e108c...7cc0bff31a3a705d3ac4fdceb030a17239412210) <sub>(2024-12-11 to 2024-12-27)</sub>
 - Updated input [`rustacean-nvim/neorocks`](https://github.com/nvim-neorocks/neorocks): [`48fb0be8` ➡️ `b2c82e92`](https://github.com/nvim-neorocks/neorocks/compare/48fb0be836b8b845afb30c7e11104e02307aff10...b2c82e92a01750608be57b3c09bf4253f95c57ef) <sub>(2024-12-14 to 2024-12-28)</sub>
 - Updated input [`nightfox-nvim`](https://github.com/EdenEast/nightfox.nvim): [`7557f26d` ➡️ `595ffb8f`](https://github.com/EdenEast/nightfox.nvim/compare/7557f26defd093c4e9bc17f28b08403f706f5a44...595ffb8f291fc4a9bef3201a28b7c0379a41cdee) <sub>(2024-09-08 to 2024-12-29)</sub>
 - Updated input [`fugitive-nvim`](https://github.com/tpope/vim-fugitive): [`fcb4db52` ➡️ `174230d6`](https://github.com/tpope/vim-fugitive/compare/fcb4db52e7f65b95705aa58f0f2df1312c1f2df2...174230d6a7f2df94705a7ffd8d5413e27ec10a80) <sub>(2024-12-15 to 2024-12-29)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/neovim-src`](https://github.com/neovim/neovim): [`17383870` ➡️ `487c48ec`](https://github.com/neovim/neovim/compare/17383870dd3b7f04eddd48ed929cc25c7e102277...487c48ec8689b865bad04fdb87b61f5ada25da97) <sub>(2024-12-12 to 2024-12-25)</sub>
 - Updated input [`neovim-nightly-overlay`](https://github.com/nix-community/neovim-nightly-overlay): [`d3963249` ➡️ `54dd5a7c`](https://github.com/nix-community/neovim-nightly-overlay/compare/d3963249e534e247041862b8162fb738c8604d3a...54dd5a7c0384fdcd11830e52f9896e457f189cb6) <sub>(2024-12-20 to 2025-01-03)</sub>
 - Updated input [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig): [`040001d8` ➡️ `a8ef5e6e`](https://github.com/neovim/nvim-lspconfig/compare/040001d85e9190a904d0e35ef5774633e14d8475...a8ef5e6e497b3ebeaaf35b939c07c211563b2e05) <sub>(2024-12-19 to 2025-01-03)</sub>
 - Updated input [`rustacean-nvim/pre-commit-hooks`](https://github.com/cachix/pre-commit-hooks.nix): [`c2b3567b` ➡️ `f0f0dc49`](https://github.com/cachix/pre-commit-hooks.nix/compare/c2b3567b03baf0999a1dd14f7e7ab34b46297d68...f0f0dc4920a903c3e08f5bdb9246bb572fcae498) <sub>(2024-12-14 to 2024-12-21)</sub>
 - Updated input [`rustacean-nvim/nixpkgs`](https://github.com/nixos/nixpkgs): [`5a48e3c2` ➡️ `7cc0bff3`](https://github.com/nixos/nixpkgs/compare/5a48e3c2e435e95103d56590188cfed7b70e108c...7cc0bff31a3a705d3ac4fdceb030a17239412210) <sub>(2024-12-11 to 2024-12-27)</sub>
 - Updated input [`neovim-nightly-overlay/hercules-ci-effects`](https://github.com/hercules-ci/hercules-ci-effects): [`56f8ea8d` ➡️ `f6233b5c`](https://github.com/hercules-ci/hercules-ci-effects/compare/56f8ea8d502c87cf62444bec4ee04512e8ea24ea...f6233b5cfbada692d93a73d6ed35bdbfd0fdb9c4) <sub>(2024-12-04 to 2025-01-01)</sub>
 - Updated input [`rustacean-nvim/neorocks/git-hooks`](https://github.com/cachix/git-hooks.nix): [`d8c02f0f` ➡️ `f0f0dc49`](https://github.com/cachix/git-hooks.nix/compare/d8c02f0ffef0ef39f6063731fc539d8c71eb463a...f0f0dc4920a903c3e08f5bdb9246bb572fcae498) <sub>(2024-12-08 to 2024-12-21)</sub>
 - Updated input [`nixpkgs`](https://github.com/nixos/nixpkgs): [`4989a246` ➡️ `d6973081`](https://github.com/nixos/nixpkgs/compare/4989a246d7a390a859852baddb1013f825435cee...d6973081434f88088e5321f83ebafe9a1167c367) <sub>(2024-12-17 to 2025-01-02)</sub>
 - Removed input `neovim-nightly-overlay/git-hooks/nixpkgs-stable`.
 - Updated input [`neovim-nightly-overlay/git-hooks`](https://github.com/cachix/git-hooks.nix): [`0ddd26d0` ➡️ `a5a96138`](https://github.com/cachix/git-hooks.nix/compare/0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d...a5a961387e75ae44cc20f0a57ae463da5e959656) <sub>(2024-12-17 to 2025-01-03)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/treefmt-nix`](https://github.com/numtide/treefmt-nix): [`0ce9d149` ➡️ `9e09d30a`](https://github.com/numtide/treefmt-nix/compare/0ce9d149d99bc383d1f2d85f31f6ebd146e46085...9e09d30a644c57257715902efbb3adc56c79cf28) <sub>(2024-12-09 to 2024-12-25)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/nixpkgs`](https://github.com/NixOS/nixpkgs): [`bc27f0fd` ➡️ `de186421`](https://github.com/NixOS/nixpkgs/compare/bc27f0fde01ce4e1bfec1ab122d72b7380278e68...de1864217bfa9b5845f465e771e0ecb48b30e02d) <sub>(2024-12-09 to 2024-12-23)</sub>
 - Updated input [`neovim-nightly-overlay/treefmt-nix`](https://github.com/numtide/treefmt-nix): [`76159fc7` ➡️ `29806aba`](https://github.com/numtide/treefmt-nix/compare/76159fc74eeac0599c3618e3601ac2b980a29263...29806abab803e498df96d82dd6f34b32eb8dd2c8) <sub>(2024-12-18 to 2025-01-03)</sub>
 - Updated input [`web-devicons-nvim`](https://github.com/nvim-tree/nvim-web-devicons): [`0eb18da5` ➡️ `5740b738`](https://github.com/nvim-tree/nvim-web-devicons/compare/0eb18da56e2ba6ba24de7130a12bcc4e31ad11cb...5740b7382429d20b6ed0bbdb0694185af9507d44) <sub>(2024-12-16 to 2025-01-03)</sub>
 - Updated input [`rustacean-nvim/neorocks/neovim-nightly/git-hooks`](https://github.com/cachix/git-hooks.nix): [`d8c02f0f` ➡️ `f0f0dc49`](https://github.com/cachix/git-hooks.nix/compare/d8c02f0ffef0ef39f6063731fc539d8c71eb463a...f0f0dc4920a903c3e08f5bdb9246bb572fcae498) <sub>(2024-12-08 to 2024-12-21)</sub>
 - Updated input [`home-manager`](https://github.com/nix-community/home-manager): [`1395379a` ➡️ `ef64efdb`](https://github.com/nix-community/home-manager/compare/1395379a7a36e40f2a76e7b9936cc52950baa1be...ef64efdbaca99f9960f75efab991e4c49e79a5f1) <sub>(2024-12-19 to 2025-01-03)</sub>
 - Updated input [`neovim-nightly-overlay/neovim-src`](https://github.com/neovim/neovim): [`8ef41f59` ➡️ `c26951b1`](https://github.com/neovim/neovim/compare/8ef41f590224dfeea2e51d9fec150e363fd72ee0...c26951b1d6d4d7ff8fe431e8bfb16744ff56af1c) <sub>(2024-12-19 to 2025-01-03)</sub>
 - Updated input [`neovim-nightly-overlay/flake-parts`](https://github.com/hercules-ci/flake-parts): [`205b12d8` ➡️ `f2f7418c`](https://github.com/hercules-ci/flake-parts/compare/205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9...f2f7418ce0ab4a5309a4596161d154cfc877af66) <sub>(2024-12-04 to 2025-01-01)</sub>